### PR TITLE
Portfolio prep: README, CI, Dependabot, repo hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-papers.yml
+++ b/.github/workflows/build-papers.yml
@@ -1,0 +1,27 @@
+name: build-papers
+
+on:
+  push:
+    branches: [main]
+    paths: ["programs/**/*.tex"]
+  pull_request:
+    paths: ["programs/**/*.tex"]
+
+jobs:
+  pdflatex:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        program:
+          - co-emergence
+          - fixed-point-existence
+          - gaussian-gravitational-decoherence
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compile ${{ matrix.program }}
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: index.tex
+          working_directory: programs/${{ matrix.program }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run test suite
+        run: pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,6 @@ programs/                          — Each program has its own directory
   <program-name>/
     index.tex                      — The paper
     explorations/                  — Research investigations for this program
-FRAMEWORK.md                       — Axioms, requirements, and hidden-assumption warnings
 METHODOLOGY.md                     — Research-as-code workflow (read before contributing)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,2 @@
 @AGENTS.md
-@FRAMEWORK.md
 @METHODOLOGY.md

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -27,7 +27,7 @@ Adversarial review has two distinct modes with different mandates. The human rev
 
 **Stress testing mode.** The adversarial agent actively tries to break the result. This means: constructing explicit counterexamples; identifying edge cases where the stated conditions are met but the conclusion fails; finding alternative interpretations of the same mathematics that lead to different conclusions; checking every limiting case against known results from a different direction. Stress testing is the appropriate mode for any result that would be used as a lemma in subsequent work or that makes a new physical prediction.
 
-In stress testing mode, the adversarial agent must explicitly attempt to find violations of the FRAMEWORK.md hidden-assumption warnings: Can time evolution be made to sneak back in? Is there a smuggled background structure? Is there a preferred observer or foliation hidden in the setup? A stress test that does not check these is incomplete.
+In stress testing mode, the adversarial agent must explicitly attempt to find violations of the framework's hidden-assumption warnings: Can time evolution be made to sneak back in? Is there a smuggled background structure? Is there a preferred observer or foliation hidden in the setup? A stress test that does not check these is incomplete.
 
 An agent must never claim a result is proven when it has only been sketched. PRs should clearly label work as one of:
 
@@ -95,7 +95,7 @@ The canonical pattern for a research debate:
 
 ### Shared context
 
-Claude Code agent teams automatically load the project's CLAUDE.md and everything it @-includes — AGENTS.md, FRAMEWORK.md, and METHODOLOGY.md. This means every teammate already has the framework axioms, the hidden-assumption warnings, the rigor standards, and these role descriptions without any additional setup. The spawn prompt provides task-specific parameters; the shared project context is inherited automatically.
+Claude Code agent teams automatically load the project's CLAUDE.md and everything it @-includes — AGENTS.md and METHODOLOGY.md. This means every teammate already has the hidden-assumption warnings, the rigor standards, and these role descriptions without any additional setup. The spawn prompt provides task-specific parameters; the shared project context is inherited automatically.
 
 ### Team size and task sizing
 
@@ -121,11 +121,11 @@ These roles recur across Explorations. When spawning teammates, reference the ro
 
 **Position agent.** Develops the strongest possible version of one assigned position. Works without seeing other positions. Proposes a specific mathematical structure, labels all claims Rigorous/Sketch/Conjecture, and honestly identifies where the position is underspecified. Does not hedge toward a middle ground — the point is genuine commitment to one direction so the synthesis has something to push against.
 
-**Synthesis agent.** Reads all position files after positions are complete. Runs two passes: (1) adversarial critique — for each position, find every hidden assumption, every appeal to existing structure rather than derivation, every violation of FRAMEWORK.md warnings; (2) defense assessment — for each criticism, determine whether it is a fatal flaw or a solvable gap. Then identifies structural convergence across positions and states what the surviving elements imply. Must explicitly check each FRAMEWORK.md hidden-assumption warning against each position.
+**Synthesis agent.** Reads all position files after positions are complete. Runs two passes: (1) adversarial critique — for each position, find every hidden assumption, every appeal to existing structure rather than derivation, every violation of the hidden-assumption warnings; (2) defense assessment — for each criticism, determine whether it is a fatal flaw or a solvable gap. Then identifies structural convergence across positions and states what the surviving elements imply. Must explicitly check each hidden-assumption warning against each position.
 
 **Drafter.** Writes LaTeX given a complete research summary and style reference. Does not conduct research or verify citations — those arrive as inputs. Matches the style of existing papers in the repo exactly. Labels all results with rigor levels. Attempts to compile the output and fixes errors.
 
-**Verifier.** Checks a derivation or PR for mathematical correctness (verification mode) or actively attempts to construct failure cases (stress testing mode). The human reviewer specifies which mode. In stress testing mode, must attempt to find violations of each FRAMEWORK.md hidden-assumption warning.
+**Verifier.** Checks a derivation or PR for mathematical correctness (verification mode) or actively attempts to construct failure cases (stress testing mode). The human reviewer specifies which mode. In stress testing mode, must attempt to find violations of each hidden-assumption warning.
 
 ### Quality gates via hooks
 
@@ -150,7 +150,7 @@ programs/<program-name>/explorations/YYYY-MM-DD-short-title.md
 They are committed directly to the main branch by the human author, not via a feature branch. An Exploration can produce:
 
 - **New issues**, if it identifies specific open problems worth pursuing.
-- **A PR modifying FRAMEWORK.md or METHODOLOGY.md**, if it changes the framework or process.
+- **A PR modifying METHODOLOGY.md**, if it changes the process.
 - **No further action**, if the result is purely negative — that is a valid outcome, and the Exploration is its own record.
 
 An Exploration does not produce a contribution to the paper directly. If it generates new mathematics, that mathematics must be developed in a subsequent issue-and-PR cycle with proper self-checks and adversarial review. The Exploration establishes direction; the PR establishes results.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,57 @@
-# Gravity as Constraint: Self-Consistency as Physical Law
+# Self-Consistency as Physical Law
 
-This is an experiment in **research-as-code**: treating a theoretical physics project the way software teams treat a codebase. The paper is the source, open problems are GitHub issues, and contributions — including from AI agents — arrive as pull requests subject to review. The goal is to explore what happens when research is conducted with version control, structured review, and agent collaboration from the start.
+[![tests](https://github.com/willregelmann/self-consistency/actions/workflows/tests.yml/badge.svg)](https://github.com/willregelmann/self-consistency/actions/workflows/tests.yml)
+[![build-papers](https://github.com/willregelmann/self-consistency/actions/workflows/build-papers.yml/badge.svg)](https://github.com/willregelmann/self-consistency/actions/workflows/build-papers.yml)
+[![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](LICENSE)
+
+This is an experiment in **research-as-code**: treating a theoretical physics project the way software teams treat a codebase. The papers are the source, open problems are GitHub issues, and contributions — including from AI agents — arrive as pull requests subject to review. The goal is to explore what happens when research is conducted with version control, structured review, and human–agent collaboration from the start.
 
 ---
 
-We propose that physical law is what self-consistency looks like: the universe is the fixed point of a constraint requiring that geometry and the quantum fields it hosts mutually determine each other. Gravity is not an independent degree of freedom to be quantized but a constraint---the demand that the block spacetime be self-consistent.
+We propose that physical law is what self-consistency looks like: the universe is the fixed point of a constraint requiring that geometry and the quantum fields it hosts mutually determine each other. Gravity is not an independent degree of freedom to be quantized but a constraint — the demand that the block spacetime be self-consistent.
 
-## Key Results
+## Programs
 
-**Fixed-point existence proofs.** Self-consistent solutions to the semiclassical Einstein equation exist: exactly in cosmology via the trace anomaly, perturbatively near any classical solution via Banach contraction with constant $\kappa \sim (m/M_P)^2 \ll 1$, and conditionally in the general case via the Schauder theorem. The Planck scale emerges as the natural validity boundary where $\kappa \to 1$.
+The work is organized into independent **programs**, each a self-contained paper under `programs/<name>/index.tex` with its own `README.md` describing status and results.
 
-**Gravitational decoherence rate.** The stochastic extension of the self-consistency equation yields a decoherence rate
+| Program | What it establishes | Status |
+|---------|--------------------|--------|
+| [`fixed-point-existence`](programs/fixed-point-existence/) | Self-consistent solutions to the semiclassical Einstein equation exist — exactly (Starobinsky trace anomaly), perturbatively (Banach contraction, $\kappa \sim (m/M_P)^2$), and conditionally (Schauder). The Planck scale emerges as the validity boundary. | Pre-submission draft |
+| [`gaussian-gravitational-decoherence`](programs/gaussian-gravitational-decoherence/) | The Einstein–Langevin equation predicts a **Gaussian** (not exponential) decoherence profile, with $\tau_{\text{coh}} \sim 1.13\,\tau_{\text{DP}}$, as a consequence of the semiclassical equation rather than an added postulate. | Pre-submission draft |
+| [`co-emergence`](programs/co-emergence/) | Mass, Lorentzian signature, local time, and local Hilbert space co-emerge as the unique cross-level self-consistent configuration. The Lorentzian self-consistency map produces phase structure (and an entropy excess) absent in the Riemannian case, confirmed by a finite toy model through N=16. | Draft |
 
-$$\Gamma_{\text{sc}} \sim \frac{G^2 m^4}{\hbar^2 c \, d}$$
+## Building
 
-suppressed by $(m/M_P)^2$ relative to the Diosi-Penrose prediction. We show that the Diosi-Penrose timescale *does not follow* from semiclassical self-consistency and requires postulates beyond the Einstein equation.
+Each paper compiles independently:
 
-**BMV entanglement.** The framework predicts null results for BMV entanglement at the quantum gravity rate. Observation of entanglement at the quantum gravity rate would falsify the framework.
+```bash
+pdflatex programs/<program-name>/index.tex
+```
+
+The bibliography is self-contained via `\begin{thebibliography}`, so no `bibtex` step is needed.
+
+## Numerical results
+
+The `co-emergence` program is backed by a numerical toy model and scaling studies in `programs/co-emergence/tests/`:
+
+```bash
+pip install numpy scipy
+pytest programs/co-emergence/tests/
+```
 
 ## Falsifiability
 
 - Observation of BMV entanglement at the quantum gravity rate refutes the framework.
-- Observation of gravitational decoherence at the Diosi-Penrose rate refutes the framework.
+- Observation of gravitational decoherence at the Diosi–Penrose rate refutes the framework.
 - The sharpest known limitation is black hole evaporation past the Page time, where topology change becomes essential.
-
-## Building
-
-```bash
-pdflatex gravity-as-constraint.tex
-bibtex gravity-as-constraint
-pdflatex gravity-as-constraint.tex
-pdflatex gravity-as-constraint.tex
-```
-
-(The bibliography is self-contained via `thebibliography`, so the `bibtex` step can be skipped.)
 
 ## Methodology
 
-This project is developed collaboratively between a human author and AI agents. Agents contribute by claiming GitHub issues, working on branches, and submitting PRs for human review. All derivations must pass self-checks (dimensional analysis, limiting cases, consistency, order-of-magnitude sanity) before submission, and adversarial review by a second agent can be requested. Citations in the paper must be verified to exist; exploratory references in discussions must be flagged as unverified. See [`METHODOLOGY.md`](METHODOLOGY.md) for the full workflow.
+This project is developed collaboratively between a human author and AI agents. Agents claim GitHub issues, work on branches, and submit PRs for human review. All derivations must pass self-checks (dimensional analysis, limiting cases, consistency, order-of-magnitude sanity) before submission, and adversarial review by a second agent can be requested. Citations in the papers must be verified to exist; exploratory references in discussions must be flagged as unverified. See [`METHODOLOGY.md`](METHODOLOGY.md) for the full workflow and [`AGENTS.md`](AGENTS.md) for repository conventions.
+
+## License
+
+Released under [CC0 1.0 Universal](LICENSE) (public domain dedication).
 
 ## Authors
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+# Collect only test_*.py. Several scripts in the tests/ directories are
+# standalone exploration runners (e.g. pw_unitarity_test.py) that happen to
+# match pytest's default *_test.py pattern but contain no test functions.
+testpaths = programs/co-emergence/tests
+python_files = test_*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Numerical dependencies for the co-emergence toy model and its test suite.
+numpy>=1.24
+scipy>=1.10
+pytest>=7.0
+
+# Used by the standalone exploration/plotting scripts in programs/*/tests/
+# (not required to run the pytest suite).
+matplotlib>=3.7


### PR DESCRIPTION
Infrastructure-only pass to make the repo portfolio-ready. **No paper content changes.**

## What changed

### README
- Rewritten for the current multi-program structure (`co-emergence`, `fixed-point-existence`, `gaussian-gravitational-decoherence`), each a paper under `programs/<name>/index.tex`.
- Fixed stale build instructions: the old README referenced a nonexistent `gravity-as-constraint.tex` and an unnecessary `bibtex` step.
- Added a programs table, a numerical-results section, and tests/build/license badges.

### FRAMEWORK.md cleanup
`FRAMEWORK.md` does not exist in the repo but was referenced by `CLAUDE.md` (`@FRAMEWORK.md` include — a broken include), `AGENTS.md`, and `METHODOLOGY.md`. Removed the dangling pointers; reworded METHODOLOGY to reference the inline hidden-assumption warnings (already stated at METHODOLOGY.md). *If you'd prefer to reconstruct FRAMEWORK.md instead, that's a content task we can do separately.*

### Tests / CI
- `pytest.ini` restricts collection to `test_*.py`. Several standalone exploration scripts (e.g. `pw_unitarity_test.py`) match pytest's default `*_test.py` pattern but contain no tests and use absolute imports, breaking a bare `pytest` run. Full suite now: **59 passed**.
- `requirements.txt` (numpy, scipy, pytest, matplotlib).
- `.github/workflows/tests.yml` — pytest on Python 3.10 and 3.12.
- `.github/workflows/build-papers.yml` — `pdflatex` compile of each program (matrix).
- `.github/dependabot.yml` — weekly pip + github-actions updates.

## Done outside this PR (already live on GitHub)
- **Repo description + topics** set via `gh`.
- **Release tags re-tagged** `v1.0–v1.2` → `v0.1–v0.3` (same commits) to match METHODOLOGY's scheme where `v1.0` is reserved for arXiv submission.
- **LICENSE** left as CC0-1.0 per your decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)