### PR TITLE
Foreground the methodology: agent-workflow doc, case studies, quality-gate hooks, README reframe

### DIFF
--- a/.claude/commands/restructure-paper.md
+++ b/.claude/commands/restructure-paper.md
@@ -15,7 +15,7 @@ Run these in parallel:
 1. **Full paper**: Read `programs/$ARGUMENTS/index.tex`
 2. **Program README**: Read `programs/$ARGUMENTS/README.md`
 3. **Explorations**: List `programs/$ARGUMENTS/explorations/` to see what research has been done
-4. **Framework**: Read `FRAMEWORK.md` for axiom/assumption context
+4. **Conventions**: Read `AGENTS.md` for repository conventions, and the paper's own axiom/assumptions section for framework context
 
 ## Step 2: Analyze the structure
 

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -6,7 +6,7 @@ arguments:
     required: false
 ---
 
-You are orchestrating a two-pass dialectical review of a pull request for the paper "Gravity as Constraint." The first pass finds problems (adversarial critic). The second pass challenges those findings (steelman defender). The calibrated verdict table is the deliverable — not either pass alone.
+You are orchestrating a two-pass dialectical review of a pull request for one of the project's physics papers (under `programs/`). The first pass finds problems (adversarial critic). The second pass challenges those findings (steelman defender). The calibrated verdict table is the deliverable — not either pass alone.
 
 ## Step 1: Resolve the PR
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/require-clean-sources.sh",
+            "timeout": 30,
+            "statusMessage": "Checking for uncommitted source changes..."
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/require-clean-sources.sh",
+            "timeout": 30,
+            "statusMessage": "Verifying work is committed before completion..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,43 +1,64 @@
 # Self-Consistency as Physical Law
 
+### Research-as-code: running a theoretical-physics program with AI agents as contributors
+
 [![tests](https://github.com/willregelmann/self-consistency/actions/workflows/tests.yml/badge.svg)](https://github.com/willregelmann/self-consistency/actions/workflows/tests.yml)
 [![build-papers](https://github.com/willregelmann/self-consistency/actions/workflows/build-papers.yml/badge.svg)](https://github.com/willregelmann/self-consistency/actions/workflows/build-papers.yml)
 [![verify-citations](https://github.com/willregelmann/self-consistency/actions/workflows/verify-citations.yml/badge.svg)](https://github.com/willregelmann/self-consistency/actions/workflows/verify-citations.yml)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](LICENSE)
 
-This is an experiment in **research-as-code**: treating a theoretical physics project the way software teams treat a codebase. The papers are the source, open problems are GitHub issues, and contributions — including from AI agents — arrive as pull requests subject to review. The goal is to explore what happens when research is conducted with version control, structured review, and human–agent collaboration from the start.
+**This repository is primarily an experiment in a methodology**: how to run a
+rigorous research program with AI agents as contributors and a human as
+reviewer. The paper is the source, open problems are GitHub issues, and
+contributions — including from AI agents — arrive as pull requests subject to
+review, self-checks, adversarial critique, rigor labels, and machine
+verification.
 
----
+Theoretical physics (quantum gravity, via a self-consistency framework) is the
+**testbed** — chosen because it is unforgiving: a hard formal domain where
+sloppy or hallucinated AI output becomes obvious. The research is real and is
+described below, but the artifact worth studying is the *process*.
 
-We propose that physical law is what self-consistency looks like: the universe is the fixed point of a constraint requiring that geometry and the quantum fields it hosts mutually determine each other. Gravity is not an independent degree of freedom to be quantized but a constraint — the demand that the block spacetime be self-consistent.
+## What this demonstrates
 
-## Programs
+The agent-engineering machinery is documented in **[`docs/agent-workflow.md`](docs/agent-workflow.md)** — roles, the contribution lifecycle, agent-team debates, custom tooling, and guardrails. Highlights:
 
-The work is organized into independent **programs**, each a self-contained paper under `programs/<name>/index.tex` with its own `README.md` describing status and results.
+- **Agent-as-contributor, human-as-reviewer.** Agents work on branches and open PRs; only the human merges. ([`METHODOLOGY.md`](METHODOLOGY.md))
+- **Custom agent tooling** in [`.claude/`](.claude/commands/): `/work-issue`, `/review-pr` (two-pass dialectical review), `/restructure-paper`, plus `TeammateIdle`/`TaskCompleted` quality-gate hooks.
+- **Agent-team debates** that develop competing positions in parallel to fight anchoring, then adjudicate by synthesis — recorded as dated Explorations.
+- **Verifiable output over attested output.** Three CI gates: tests pass, every paper compiles, and **every citation resolves against Crossref/arXiv** ([`tools/verify_citations.py`](tools/verify_citations.py)).
+- **Honest failure.** Rigor labels are demoted when wrong, negative results are recorded, and the citation gate has already caught a real mis-citation. See the **[case studies](docs/case-studies.md)** — the receipts.
+
+## The research (testbed)
+
+We propose that physical law is what self-consistency looks like: the universe
+is the fixed point of a constraint requiring that geometry and the quantum
+fields it hosts mutually determine each other. Gravity is not an independent
+degree of freedom to be quantized but a constraint — the demand that the block
+spacetime be self-consistent.
+
+The work is organized into independent **programs**, each a self-contained paper
+under `programs/<name>/index.tex` with its own `README.md`:
 
 | Program | What it establishes | Status |
 |---------|--------------------|--------|
 | [`fixed-point-existence`](programs/fixed-point-existence/) | Self-consistent solutions to the semiclassical Einstein equation exist — exactly (Starobinsky trace anomaly), perturbatively (Banach contraction, $\kappa \sim (m/M_P)^2$), and conditionally (Schauder). The Planck scale emerges as the validity boundary. | Pre-submission draft |
 | [`gaussian-gravitational-decoherence`](programs/gaussian-gravitational-decoherence/) | The Einstein–Langevin equation predicts a **Gaussian** (not exponential) decoherence profile, with $\tau_{\text{coh}} \sim 1.13\,\tau_{\text{DP}}$, as a consequence of the semiclassical equation rather than an added postulate. | Pre-submission draft |
-| [`co-emergence`](programs/co-emergence/) | Mass, Lorentzian signature, local time, and local Hilbert space co-emerge as the unique cross-level self-consistent configuration. The Lorentzian self-consistency map produces phase structure (and an entropy excess) absent in the Riemannian case, confirmed by a finite toy model through N=16. | Draft |
+| [`co-emergence`](programs/co-emergence/) | Mass, Lorentzian signature, local time, and local Hilbert space co-emerge as the unique cross-level self-consistent configuration, with phase structure (and an entropy excess) confirmed by a finite toy model through N=16. | Draft |
 
 ## Building
 
-Each paper compiles independently:
+Each paper compiles independently; the bibliography is self-contained via `\begin{thebibliography}`, so no `bibtex` step is needed:
 
 ```bash
 pdflatex programs/<program-name>/index.tex
 ```
 
-The bibliography is self-contained via `\begin{thebibliography}`, so no `bibtex` step is needed.
-
-## Numerical results
-
-The `co-emergence` program is backed by a numerical toy model and scaling studies in `programs/co-emergence/tests/`:
+The `co-emergence` numerics are backed by a test suite:
 
 ```bash
-pip install numpy scipy
-pytest programs/co-emergence/tests/
+pip install -r requirements.txt
+pytest
 ```
 
 ## Falsifiability
@@ -45,10 +66,6 @@ pytest programs/co-emergence/tests/
 - Observation of BMV entanglement at the quantum gravity rate refutes the framework.
 - Observation of gravitational decoherence at the Diosi–Penrose rate refutes the framework.
 - The sharpest known limitation is black hole evaporation past the Page time, where topology change becomes essential.
-
-## Methodology
-
-This project is developed collaboratively between a human author and AI agents. Agents claim GitHub issues, work on branches, and submit PRs for human review. All derivations must pass self-checks (dimensional analysis, limiting cases, consistency, order-of-magnitude sanity) before submission, and adversarial review by a second agent can be requested. Citations in the papers must be verified to exist; exploratory references in discussions must be flagged as unverified. See [`METHODOLOGY.md`](METHODOLOGY.md) for the full workflow and [`AGENTS.md`](AGENTS.md) for repository conventions.
 
 ## License
 

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,122 @@
+# The Agent Workflow
+
+This project is an experiment in **research-as-code**: a theoretical-physics
+program run the way a software team runs a codebase, with AI agents as
+first-class contributors. This document is the map of the machinery — the
+roles, the lifecycle, the tooling, and the guardrails that keep agent-produced
+research honest.
+
+The physics (see the [programs](../programs/)) is the *testbed*. The
+methodology is the *product*. The full normative spec lives in
+[`METHODOLOGY.md`](../METHODOLOGY.md); this is the operational tour.
+
+---
+
+## The core model
+
+**Agent-as-contributor, human-as-reviewer.** Agents claim issues, work on
+branches, and open PRs. The human author reviews and merges. **Agents have no
+merge authority** — every change to the papers passes through human review.
+This mirrors the 2025–2026 consensus that autonomous science still needs a
+human in the loop for conceptual judgment, while letting agents do the heavy
+lifting of derivation, search, and drafting.
+
+## The contribution lifecycle
+
+```
+issue ──▶ branch ──▶ commits ──▶ self-check ──▶ PR ──▶ [adversarial review] ──▶ human merge
+```
+
+1. **Claim an issue.** Every PR targets a specific issue; speculative work
+   proposes an issue first.
+2. **Branch** as `program/issue-N-description` (or `tooling/…` for
+   repo-wide infrastructure).
+3. **Commit in coherent steps** — messages say what was *derived*, not "update".
+4. **Self-check** before the PR: dimensional analysis, limiting cases,
+   consistency, order-of-magnitude sanity — documented in the PR description.
+5. **Adversarial review** (optional, human-requested) — see below.
+6. **Human merges.**
+
+## Rigor labels and the rigor lifecycle
+
+Every result is labelled **Rigorous**, **Sketch**, or **Conjecture**, and the
+label is *not permanent*. Results are promoted (Conjecture→Sketch→Rigorous) and
+**demoted** (→Demoted / Conjecture→Withdrawn) as understanding changes. Each
+transition is its own PR. Demotion is treated as normal maintenance, not
+failure — a silently-wrong result is worse than an honestly-labelled sketch.
+See [case studies](case-studies.md) for real promotions and demotions.
+
+## Adversarial review
+
+After self-checks, a second agent can be dispatched to critique a derivation,
+in one of two modes:
+
+- **Verification** — check every step: does the algebra follow, are cited
+  results used as cited, are there sign/factor errors? Baseline for any
+  Sketch→Rigorous promotion.
+- **Stress testing** — actively try to *break* the result: counterexamples,
+  edge cases, alternative interpretations, and explicit checks that no hidden
+  time-evolution, background structure, or preferred foliation has snuck in.
+
+## Agent teams and the debate pattern
+
+For genuinely open questions, the project uses **agent teams** rather than a
+single agent, specifically to fight anchoring. Multiple **position agents**
+develop the strongest version of competing approaches *in parallel, without
+seeing each other's reasoning*; a **synthesis agent** then runs adversarial
+critique across all positions and reports what survives.
+
+> **Worked example — the mass-gap debate.** Two position agents independently
+> developed competing mechanisms for self-consistent mass generation
+> ([`position-starobinsky-mass.md`](../programs/co-emergence/explorations/position-starobinsky-mass.md),
+> [`position-measure-mass.md`](../programs/co-emergence/explorations/position-measure-mass.md)),
+> and a synthesis pass
+> ([`2026-03-03-mass-gap-synthesis.md`](../programs/co-emergence/explorations/2026-03-03-mass-gap-synthesis.md))
+> adjudicated — killing one mechanism as background-dependent, keeping the
+> trace-anomaly mechanism, and surfacing the codependence insight that
+> reshaped the program. The losing position is kept in the record, not deleted.
+
+The output of a debate is an **Exploration** — a dated artifact committed to
+the program's `explorations/` directory. Explorations shape direction; they do
+not edit the paper directly. (A known limitation, tracked for improvement:
+position agents drawn from the same base model partially correlate, so genuine
+independence benefits from varying the model/temperature across positions.)
+
+## Custom tooling (`.claude/commands/`)
+
+Three project-specific slash commands encode the workflow:
+
+| Command | What it does |
+|---------|--------------|
+| [`/work-issue`](../.claude/commands/work-issue.md) | Picks an issue (ranked by dependencies/impact) and sets up the contribution workflow. |
+| [`/review-pr`](../.claude/commands/review-pr.md) | Runs the two-pass dialectical review (adversarial critic, then steelman defender) and emits a calibrated verdict table. |
+| [`/restructure-paper`](../.claude/commands/restructure-paper.md) | Plans a paper reorganization — the intellectual analogue of a refactor. |
+
+## Quality gates (hooks)
+
+[`.claude/settings.json`](../.claude/settings.json) wires the `TeammateIdle`
+and `TaskCompleted` hook events to
+[`scripts/hooks/require-clean-sources.sh`](../scripts/hooks/require-clean-sources.sh),
+which blocks a teammate from going idle or a task from completing while tracked
+source files (papers, tooling, tests) have uncommitted changes. It fails open
+on any internal error, so it can never wedge the workflow.
+
+## CI gates
+
+Every PR is checked by GitHub Actions — the guardrails that turn *attested*
+rigor into *demonstrated* rigor:
+
+| Workflow | Gate |
+|----------|------|
+| `tests` | The co-emergence numerical toy model and scaling tests pass (Python 3.10 / 3.12). |
+| `build-papers` | Every paper compiles with `pdflatex`. |
+| `verify-citations` | Every `\bibitem` resolves against Crossref/arXiv; the build fails on any unresolved reference. See [`tools/verify_citations.py`](../tools/verify_citations.py). |
+
+## Citation discipline
+
+Two tiers. **Paper-grade** references (anything in `thebibliography`) must be
+verified to exist *and* to support the claim. **Exploratory** references in
+issues/PRs may be unverified but must be flagged as such, and never committed to
+a `.tex` file. Existence is now mechanically enforced by the `verify-citations`
+gate; claim-support remains a human/agent responsibility. The gate has already
+caught a real error — see [case studies](case-studies.md).

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -1,0 +1,73 @@
+# Case Studies: The Methodology Working
+
+The point of [the workflow](agent-workflow.md) is not that agents produce
+research — it's that the guardrails catch the failure modes agents are prone
+to. These are receipts: concrete moments where adversarial review, honest
+negative-result reporting, rigor demotion, or a CI gate did its job. Each is a
+real artifact in the git history, not a claim.
+
+---
+
+## 1. Adversarial review downgraded a result (Rigorous → Sketch)
+
+**Artifact:** commit [`04c05fa`](https://github.com/willregelmann/self-consistency/commit/04c05fa) — *"Address adversarial review: downgrade Prop 3, fix Banach language, qualify Hilbert derivation claim."*
+
+A proposition in the co-emergence paper ("Lorentzian conditioning produces
+quantum coherences") was labelled **Rigorous**. Adversarial review found that
+its genericity condition was unverified for physically natural fields and that
+the proof leaned on a fixed-point form only established in the toy model. The
+result was demoted **Rigorous → Sketch**, the Banach-vs-Hilbert language was
+corrected, and an overclaim that "Hilbert space is derived" was softened to
+"not introduced as a separate axiom," with the open question stated explicitly.
+
+*Why it matters:* the single most important competence for agent-driven
+research is not over-claiming. Here the process caught and walked back an
+overclaim before it could propagate.
+
+## 2. Negative results are recorded, not buried
+
+**Artifacts:**
+[`ebd01bb`](https://github.com/willregelmann/self-consistency/commit/ebd01bb) —
+*"PW conditioning is not approximately unitary (negative result)"*;
+[`b0abc7f`](https://github.com/willregelmann/self-consistency/commit/b0abc7f) —
+*"B1 and C1 signature explorations (both negative results)."*
+
+A natural conjecture — that Page–Wootters conditioning yields approximately
+unitary time evolution — was investigated and **failed**. Likewise, two
+attempts to derive Lorentzian signature from lower-level self-consistency were
+negative. All three are committed Explorations, kept as permanent records so
+future agents don't re-walk closed paths.
+
+*Why it matters:* a system rewarded for producing positive results will
+hallucinate them. This program treats a documented negative result as a
+first-class output that narrows the search space.
+
+## 3. Rigor demotion as routine maintenance
+
+The general-rank von Neumann entropy-excess claim was demoted after a
+counterexample was found (3×3 density matrices with extreme entries), while the
+all-rank **purity-decrease** result and the rank-2 entropy result survived and
+remain Rigorous. The paper now states precisely where the result holds and
+where it doesn't.
+
+*Why it matters:* rigor labels track the truth as it's currently understood,
+and are revised in public rather than quietly left stale.
+
+## 4. The citation gate caught a real mis-citation
+
+**Artifact:** PR [#46](https://github.com/willregelmann/self-consistency/pull/46) (`verify-citations`).
+
+On its *first run*, the automated citation gate flagged an unresolved
+reference in the `fixed-point-existence` paper. Investigation showed the
+`gottschalk_siemssen` entry had stapled the wrong authors and title onto a
+**correct arXiv ID** (2201.10288). That ID is actually Meda & Pinamonti,
+*"Linear stability of semiclassical theories of gravity"* (Ann. Henri Poincaré
+24, 1211, 2023) — which turned out to be the *correct* source for the cited
+claim (massive fields give polynomially decaying perturbations). The citation
+was corrected and verified paper-grade: author, title, journal/year, **and**
+claim-support.
+
+*Why it matters:* hallucinated and mis-attributed citations are the headline
+trust problem for AI-assisted research (in 2025, fabricated citations survived
+human peer review at major venues). A mechanical existence gate caught a real
+instance here that human reading had missed.

--- a/scripts/hooks/require-clean-sources.sh
+++ b/scripts/hooks/require-clean-sources.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Quality gate for the research-as-code workflow.
+#
+# Wired to the TeammateIdle and TaskCompleted hook events (see
+# .claude/settings.json). It blocks a teammate from going idle, or a task from
+# being marked complete, while there are uncommitted changes to tracked source
+# files (papers, tooling, tests). METHODOLOGY.md asks that work happen in
+# coherent commits; this enforces that a unit of work isn't "finished" with the
+# derivation left unsaved in the working tree.
+#
+# Exit 0  -> allow (clean, or not applicable)
+# Exit 2  -> block, with guidance on stderr
+# Any other exit code is treated as a non-blocking error by Claude Code, so this
+# script fails OPEN: internal errors never wedge the workflow.
+
+set -u
+
+# Claude Code passes hook context as JSON on stdin; we don't need it (we use the
+# project dir env var), but consume it so the writer doesn't see a broken pipe.
+cat >/dev/null 2>&1 || true
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$root" 2>/dev/null || exit 0
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Staged, unstaged, or untracked changes to tracked-source paths.
+changed="$(
+  git status --porcelain --untracked-files=all 2>/dev/null \
+    | sed 's/^...//' \
+    | grep -E '^(programs/.*\.tex$|tools/.*$|programs/.*/tests/.*\.py$)' \
+    || true
+)"
+
+if [ -n "$changed" ]; then
+  {
+    echo "Blocked: uncommitted changes to tracked source files —"
+    echo "$changed" | sed 's/^/  /'
+    echo
+    echo "Commit the work (one coherent step per commit, per METHODOLOGY.md)"
+    echo "before going idle or marking this task complete."
+  } >&2
+  exit 2
+fi
+
+exit 0


### PR DESCRIPTION
Supersedes #47 (auto-closed when #46's base branch was deleted on merge). Rebased onto `main`; contains only the docs/hooks/README changes.

Makes the agent-engineering story legible — the repo's primary artifact is the *process*, not the physics.

## What's here
- **`docs/agent-workflow.md`** — operational tour: roles, contribution lifecycle, rigor lifecycle, adversarial review, the agent-team **debate pattern** (mass-gap debate as worked example), custom slash commands, quality-gate hooks, CI gates.
- **`docs/case-studies.md`** — receipts the guardrails work: adversarial review downgrade (`04c05fa`), recorded negative results (`ebd01bb`, `b0abc7f`), rigor demotion, and the citation gate catching a real mis-citation (#46).
- **Quality-gate hooks** — `.claude/settings.json` wires `TeammateIdle`/`TaskCompleted` (verified real) to `scripts/hooks/require-clean-sources.sh`; blocks idle/completion while tracked sources are uncommitted, **fails open** on error. Tested both paths.
- **README reframe** — methodology-first; physics as testbed; "What this demonstrates" section.
- **Stale-reference fixes** in the slash commands (`FRAMEWORK.md`, "Gravity as Constraint").

🤖 Generated with [Claude Code](https://claude.com/claude-code)