### PR TITLE
Semantic claim-support gate (LLM-as-evaluator, advisory)

### DIFF
--- a/.claude/tests/citation-claim-support/test.md
+++ b/.claude/tests/citation-claim-support/test.md
@@ -1,0 +1,38 @@
+---
+name: citation-claim-support
+tools: ["WebFetch", "WebSearch"]
+assertions:
+  - "starobinsky: the cited Starobinsky 1980 paper supports that the trace anomaly of conformal/quantum fields on an FRW background admits an exact de Sitter solution of the semiclassical Einstein equation (a self-consistent inflationary fixed point)"
+  - "parker_simon: the cited Parker-Simon paper supports the use of order reduction to recast the higher-derivative semiclassical Einstein equation as a second-order (order-reduced) equation"
+  - "meda_pinamonti_siemssen: the cited Meda-Pinamonti-Siemssen paper supports existence/uniqueness (a contraction-type argument) for solutions of the semiclassical Einstein equation on cosmological/FLRW spacetimes"
+  - "meda_pinamonti_stability: the cited Meda-Pinamonti 'Linear stability' paper supports that, for a massive quantum field, linear perturbations of the semiclassical solution decay polynomially in time"
+  - "oppenheim: the cited Oppenheim paper supports the position that classical gravity coupled to quantum matter (a postquantum / semiclassical-as-fundamental theory) is a serious candidate rather than only an approximation"
+---
+
+Semantic claim-support check for the load-bearing citations in
+`programs/fixed-point-existence/index.tex`. The deterministic `verify-citations`
+CI gate already confirms these references *exist*; this test checks the harder,
+non-mechanical question METHODOLOGY.md assigns to human/agent review: does each
+cited source actually *support the specific claim* it is attached to?
+
+This is a **semantic smoke test**, not a proof check. Judge each assertion only
+on whether the cited work's own abstract/results back the claim the paper makes
+with it — not on whether the physics is ultimately correct.
+
+For each assertion (keyed by its `\bibitem` key):
+
+1. Read `programs/fixed-point-existence/index.tex` and locate where the key is
+   `\cite`d, to confirm the exact claim the paper attributes to it. The
+   bibliography entry (author, title, journal, year) is in the
+   `thebibliography` block near the end of the file.
+2. Use `WebSearch` to find the cited work by its author, title, and year, then
+   `WebFetch` its abstract page (arXiv, the journal/DOI page, or an
+   authoritative index) to read what it actually claims.
+3. Judge PASS only if the source's own stated results support the specific claim
+   the paper makes. If the source is about a clearly different result, or you
+   cannot locate an authoritative description of it, judge FAIL with the reason.
+   Quote the supporting sentence from the source as evidence.
+
+Be strict: a source that is merely *topically related* but does not state the
+specific claim is a FAIL. Cite the title/venue you actually located as evidence,
+so a reader can tell you found the right paper and not a namesake.

--- a/.github/workflows/semantic-review.yml
+++ b/.github/workflows/semantic-review.yml
@@ -1,0 +1,57 @@
+name: semantic-review
+
+# Advisory semantic tier of the verification stack (see docs/agent-workflow.md):
+# an isolated LLM evaluator judges questions that aren't mechanically decidable —
+# here, whether load-bearing citations actually support the claims they're
+# attached to. Existence is already gated deterministically by verify-citations;
+# this is the harder claim-support question. It is ADVISORY (continue-on-error):
+# an LLM verdict never blocks a merge, but its findings surface in the run.
+#
+# Uses the claude-tests headless runner (LLM-as-evaluator) from the sibling repo.
+# Requires the repo secret CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`);
+# without it the suite is skipped so the workflow stays green.
+
+on:
+  pull_request:
+    paths: ["programs/**/*.tex", ".claude/tests/**"]
+  workflow_dispatch:
+
+jobs:
+  claim-support:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Check out this repo
+        uses: actions/checkout@v4
+
+      - name: Check out claude-tests (LLM-as-evaluator runner)
+        uses: actions/checkout@v4
+        with:
+          repository: willregelmann/claude-tests
+          ref: main # needs the arbitrary-headless-tools change (claude-tests#4)
+          path: .claude-tests-runner
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run semantic claim-support evaluation
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not set — skipping semantic review."
+            exit 0
+          fi
+          python3 .claude-tests-runner/bin/run-tests.py citation-claim-support \
+            --junit semantic-results.xml --model sonnet
+
+      - name: Upload results
+        if: always() && hashFiles('semantic-results.xml') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: semantic-results
+          path: semantic-results.xml

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -111,6 +111,25 @@ rigor into *demonstrated* rigor:
 | `tests` | The co-emergence numerical toy model and scaling tests pass (Python 3.10 / 3.12). |
 | `build-papers` | Every paper compiles with `pdflatex`. |
 | `verify-citations` | Every `\bibitem` resolves against Crossref/arXiv; the build fails on any unresolved reference. See [`tools/verify_citations.py`](../tools/verify_citations.py). |
+| `semantic-review` | *Advisory.* An isolated LLM evaluator judges questions that aren't mechanically decidable — e.g. whether load-bearing citations actually **support** their claims (`.claude/tests/citation-claim-support/`). |
+
+### Three tiers of verification
+
+The CI gates form a deliberate hierarchy from cheap-and-certain to
+judgment-and-advisory:
+
+| Tier | Question | Mechanism | Blocking? |
+|------|----------|-----------|-----------|
+| **Deterministic** | Does it compile / run / resolve? | `tests`, `build-papers`, `verify-citations` | yes |
+| **Semantic** | Does it overclaim / mis-cite / skip a self-check? | `semantic-review` — LLM-as-evaluator ([claude-tests](https://github.com/willregelmann/claude-tests)) | no (advisory) |
+| **Formal** | Is the proof actually valid? | Lean formalization (planned, issue #45) | yes, where formalized |
+
+The semantic tier is run by an **isolated evaluator with no implementation
+context** — the same anti-anchoring principle as the adversarial-review debate,
+but standing and repeatable. It is deliberately *advisory*: an LLM verdict
+flags an overclaim or a dubious citation for human attention, but never
+certifies mathematical truth — that stays with the deterministic and formal
+tiers, because an LLM judge can itself err.
 
 ## Citation discipline
 


### PR DESCRIPTION
Adds the **semantic tier** of the verification stack — an isolated LLM evaluator judging the question `verify_citations.py` deliberately won't: do load-bearing citations actually *support* the claims they're attached to? Uses your **claude-tests** framework as the engine.

**Depends on [claude-tests#4](https://github.com/willregelmann/claude-tests/pull/4)** (arbitrary headless tools — lets the evaluator have `WebFetch`/`WebSearch`).

## What's here
- **`.claude/tests/citation-claim-support/test.md`** — checks 5 load-bearing citations in `fixed-point-existence` (Starobinsky, Parker–Simon, Meda–Pinamonti–Siemssen, Meda–Pinamonti linear-stability, Oppenheim) against their specific claims. The evaluator locates each source via `WebSearch`, reads it via `WebFetch`, and judges support with a quoted evidence line. Scoped to 5 to keep a run bounded; expand once it earns its keep.
- **`.github/workflows/semantic-review.yml`** — clones the sibling claude-tests runner, runs the test headless, **advisory** (`continue-on-error`: an LLM verdict never blocks a merge), gated on the `CLAUDE_CODE_OAUTH_TOKEN` secret (skips cleanly if unset).
- **`docs/agent-workflow.md`** — documents the three-tier stack: deterministic (blocks) → semantic (advisory) → formal (Lean, #45).

## Design notes
- **Advisory by design.** The LLM judge flags overclaims/mis-citations for attention; it never certifies mathematical truth. That stays with the deterministic gates and (eventually) Lean — because the judge can itself err.
- **Isolation.** The evaluator gets no implementation context — same anti-anchoring principle as the adversarial-review debate, but standing and repeatable.

## Self-checks / status
- Test parses with the runner and resolves tools to `Read, Grep, Glob, WebFetch, WebSearch`. ✅
- **Not yet run end-to-end** — that needs the `CLAUDE_CODE_OAUTH_TOKEN` secret (which I can't set) and runs first in CI. The structural wiring is validated; the live verdict will appear on the first tokened run.

## Activation (maintainer)
1. Merge claude-tests#4.
2. Set the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (`claude setup-token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)