### PR TITLE
[gate-test 1a] broken .tex must be blocked by pdflatex

### DIFF
--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -530,4 +530,5 @@ self-consistent semiclassical gravity (2026). Companion paper.
 
 \end{thebibliography}
 
+\undefinedmacrogatetest
 \end{document}


### PR DESCRIPTION
Deliberate undefined macro. EXPECTED: pdflatex (gaussian-gravitational-decoherence) FAILS, merge blocked. Will be closed after observation. Part of Phase D verification (EXPERIMENT.md).