### PR TITLE
[gate-test 3] misattributed claim must be blocked by claim-support

### DIFF
--- a/programs/fixed-point-existence/index.tex
+++ b/programs/fixed-point-existence/index.tex
@@ -58,8 +58,9 @@ G_{\mu\nu}[g] = 8\pi G\,\langle\Psi|\hat{T}_{\mu\nu}[g]|\Psi\rangle
 is not a dynamical equation in the usual sense. It is a fixed-point condition: we seek the
 geometry $g_{\mu\nu}$ such that the quantum state it hosts, evolving on it, sources exactly
 that geometry. The position that eq.~\eqref{eq:sce} may be fundamental (rather than an
-approximation to quantized gravity) dates to M\o ller (1962) and Rosenfeld (1963) and has
-been developed by Oppenheim~\cite{oppenheim}. Whether this position is internally
+approximation to quantized gravity) dates to M\o ller (1962) and Rosenfeld (1963), though
+Oppenheim~\cite{oppenheim} has since proven that gravity must necessarily be quantized at
+the Planck scale, ruling such semiclassical theories out. Whether this position is internally
 consistent depends on whether fixed points exist.
 
 This paper establishes existence at three levels of generality, with explicit


### PR DESCRIPTION
Deliberately inverts what the cited Oppenheim paper argues (the .tex now claims it proves gravity must be quantized; the source develops the opposite postquantum/classical-gravity position). EXPECTED: claim-support FAILS — first real LLM evaluation with the OAuth token set. pdflatex and verify should PASS (text-only change, bibliography untouched). Will be closed after observation. Part of Phase D verification.