### PR TITLE
Post-verification fixes: claim-support paper-congruence + routine deployment docs

### DIFF
--- a/.claude/tests/citation-claim-support/test.md
+++ b/.claude/tests/citation-claim-support/test.md
@@ -2,37 +2,53 @@
 name: citation-claim-support
 tools: ["WebFetch", "WebSearch"]
 assertions:
-  - "starobinsky: the cited Starobinsky 1980 paper supports that the trace anomaly of conformal/quantum fields on an FRW background admits an exact de Sitter solution of the semiclassical Einstein equation (a self-consistent inflationary fixed point)"
-  - "parker_simon: the cited Parker-Simon paper supports the use of order reduction to recast the higher-derivative semiclassical Einstein equation as a second-order (order-reduced) equation"
-  - "meda_pinamonti_siemssen: the cited Meda-Pinamonti-Siemssen paper supports existence/uniqueness (a contraction-type argument) for solutions of the semiclassical Einstein equation on cosmological/FLRW spacetimes"
-  - "meda_pinamonti_stability: the cited Meda-Pinamonti 'Linear stability' paper supports that, for a massive quantum field, linear perturbations of the semiclassical solution decay polynomially in time"
-  - "oppenheim: the cited Oppenheim paper supports the position that classical gravity coupled to quantum matter (a postquantum / semiclassical-as-fundamental theory) is a serious candidate rather than only an approximation"
+  - "starobinsky: the paper's own text at every \\cite{starobinsky} site is consistent with — and supported by — what the cited Starobinsky 1980 paper establishes: that the trace anomaly of conformal/quantum fields on an FRW background admits an exact de Sitter solution of the semiclassical Einstein equation (a self-consistent inflationary fixed point)"
+  - "parker_simon: the paper's own text at every \\cite{parker_simon} site is consistent with — and supported by — what the cited Parker-Simon paper establishes: the use of order reduction to recast the higher-derivative semiclassical Einstein equation as a second-order (order-reduced) equation"
+  - "meda_pinamonti_siemssen: the paper's own text at every \\cite{meda_pinamonti_siemssen} site is consistent with — and supported by — what the cited Meda-Pinamonti-Siemssen paper establishes: existence/uniqueness (a contraction-type argument) for solutions of the semiclassical Einstein equation on cosmological/FLRW spacetimes"
+  - "meda_pinamonti_stability: the paper's own text at every \\cite{meda_pinamonti_stability} site is consistent with — and supported by — what the cited Meda-Pinamonti 'Linear stability' paper establishes: that, for a massive quantum field, linear perturbations of the semiclassical solution decay polynomially in time"
+  - "oppenheim: the paper's own text at every \\cite{oppenheim} site is consistent with — and supported by — what the cited Oppenheim paper establishes: the position that classical gravity coupled to quantum matter (a postquantum / semiclassical-as-fundamental theory) is a serious candidate rather than only an approximation"
 ---
 
 Semantic claim-support check for the load-bearing citations in
 `programs/fixed-point-existence/index.tex`. The deterministic `verify-citations`
 CI gate already confirms these references *exist*; this test checks the harder,
 non-mechanical question METHODOLOGY.md assigns to human/agent review: does each
-cited source actually *support the specific claim* it is attached to?
+cited source actually *support the claim the paper currently attaches to it*?
 
-This is a **semantic smoke test**, not a proof check. Judge each assertion only
-on whether the cited work's own abstract/results back the claim the paper makes
-with it — not on whether the physics is ultimately correct.
+**The paper is the thing under test, not the assertion list.** Each assertion
+has two parts: a `\bibitem` key, and a reference description of what the cited
+source actually establishes. The description is ground truth about the SOURCE;
+it says nothing about what the paper currently claims — the paper's text may
+have drifted or been edited to misattribute. Judging an assertion true because
+the description matches the source, without checking the paper's own words, is
+the known failure mode of this test (it let a deliberately inverted claim pass
+during gate verification on 2026-06-05). Do not repeat it.
+
+This is a **semantic smoke test**, not a proof check. Judge only on whether the
+cited work's own abstract/results back the claim the paper makes — not on
+whether the physics is ultimately correct.
 
 For each assertion (keyed by its `\bibitem` key):
 
-1. Read `programs/fixed-point-existence/index.tex` and locate where the key is
-   `\cite`d, to confirm the exact claim the paper attributes to it. The
-   bibliography entry (author, title, journal, year) is in the
-   `thebibliography` block near the end of the file.
-2. Use `WebSearch` to find the cited work by its author, title, and year, then
-   `WebFetch` its abstract page (arXiv, the journal/DOI page, or an
-   authoritative index) to read what it actually claims.
-3. Judge PASS only if the source's own stated results support the specific claim
-   the paper makes. If the source is about a clearly different result, or you
-   cannot locate an authoritative description of it, judge FAIL with the reason.
-   Quote the supporting sentence from the source as evidence.
+1. Read `programs/fixed-point-existence/index.tex` and locate EVERY site where
+   the key is `\cite`d. Extract, verbatim, the claim the paper's surrounding
+   text attributes to the source at each site. Record these extracted claims —
+   they are the object being judged.
+2. Compare each extracted claim against the assertion's reference description
+   of the source. If the paper attributes to the source a materially different
+   result — and especially if it attributes the OPPOSITE position (e.g. citing
+   a paper that develops a theory as having refuted it) — judge **FAIL**
+   immediately, quoting the divergent paper text. Do not proceed to step 3 to
+   "rescue" the assertion.
+3. Use `WebSearch` to find the cited work by author, title, and year, then
+   `WebFetch` its abstract page (arXiv, journal/DOI page, or an authoritative
+   index). Judge PASS only if the source's own stated results support the
+   extracted paper claims from step 1. Quote the supporting sentence from the
+   source as evidence.
 
-Be strict: a source that is merely *topically related* but does not state the
-specific claim is a FAIL. Cite the title/venue you actually located as evidence,
-so a reader can tell you found the right paper and not a namesake.
+Be strict, in both directions: a source that is merely *topically related* but
+does not state the paper's specific claim is a FAIL; a paper claim that
+diverges from what the source establishes is a FAIL even though the reference
+description remains true of the source. Cite the title/venue you actually
+located as evidence, so a reader can tell you found the right paper and not a
+namesake.

--- a/automation/routines/README.md
+++ b/automation/routines/README.md
@@ -10,8 +10,11 @@ these files**, which are version-controlled and constitutionally protected.
 Register each routine with this pointer prompt (replace `<role>`):
 
 > You are the `<role>` routine of the self-consistency autonomous research
-> experiment. Read `automation/routines/<role>.md` in this repository and
-> execute it exactly. Read `AUTONOMY.md` first.
+> experiment. Read AUTONOMY.md at the repository root first, then read
+> `automation/routines/<role>.md` and execute it exactly. If
+> `automation/routines/<role>.md` does not exist on this branch, the
+> experiment infrastructure has not landed yet — exit immediately without
+> taking any action.
 
 Source: this repository, branch `main`. Git identity / GitHub auth: the
 machine account recorded in the repo variable `AUTONOMY_BOT`. Create routines
@@ -33,6 +36,45 @@ the bootstrap PR).
 Cadence rationale: responder (04:00) runs before reviewer (05:00) runs before
 worker (06:00) — fixes land, get re-reviewed, then new work starts against an
 up-to-date queue.
+
+## Deployed instances (registered 2026-06-05)
+
+The routines are deployed as claude.ai scheduled remote agents, managed at
+<https://claude.ai/code/routines>. This table is the record of the live
+deployment; if it drifts from what is actually registered, this file is wrong —
+fix the file. Disabling these routines is **step 1 of the kill switch**
+(`EXPERIMENT.md`).
+
+| Routine | Trigger ID | Cron (UTC) | Model |
+|---------|-----------|------------|-------|
+| autonomy-worker | `trig_012ZLL1t2j7peNzGAadXymML` | `0 6 * * *` | claude-opus-4-8 |
+| autonomy-reviewer | `trig_013PE7Dp6EFji5d9NefgAx4X` | `0 5,17 * * *` | claude-opus-4-8 |
+| autonomy-responder | `trig_01PC2vVYcWUQ7qJQsb4Gf8MV` | `0 4 * * *` | claude-sonnet-4-6 |
+| autonomy-red-team | `trig_01DFgXG9eZ37bPLVgtSGLq7x` | `0 8 */3 * *` | claude-opus-4-8 |
+| autonomy-scout | `trig_013qHNtEy8nxjKdw8nfmiYFT` | `0 3 * * 1` | claude-sonnet-4-6 |
+| autonomy-librarian | `trig_01F12Zj6gbcru4XycQRfg4Dq` | `0 3 * * 2` | claude-sonnet-4-6 |
+| autonomy-governor | `trig_01FEAuqs6FbCKC6TEgCDhYPP` | `0 9 1 * *` | claude-opus-4-8 |
+
+Shared deployment configuration (all seven):
+
+- **Environment:** Anthropic cloud (`env_011CTQhm6jdCKJ3Tu9TnXTLe`); each run
+  is a fully isolated remote session with a fresh checkout of this repo @ `main`.
+- **Prompt:** the pointer template above, verbatim — behavior lives in the
+  version-controlled `<role>.md` files, never in the registration.
+- **Allowed tools:** `Bash, Read, Write, Edit, Glob, Grep, Task, WebSearch, WebFetch`.
+- **MCP connections:** explicitly cleared (least privilege — no external
+  connectors).
+- **Created disabled**; enabled only after the Phase D gate verification in
+  `EXPERIMENT.md` passed, with the experiment start date recorded there.
+- **Identity:** runs authenticate to GitHub with the environment's credential.
+  `quorum-gate` honors verdict markers only from the login in the
+  `AUTONOMY_BOT` repo variable (`will-physagent`) or the experimenter — if a
+  routine's effective login differs, fix the routine's auth or the variable,
+  in that order of preference.
+
+Note on red-team cadence: `0 8 */3 * *` is day-of-month based, so the
+interval compresses at month boundaries (e.g. the 31st → the 1st). Harmless;
+recorded so nobody "fixes" it into a bug report.
 
 ## Shared conventions
 


### PR DESCRIPTION
## Summary

Two fixes from Phase D gate verification (EXPERIMENT.md):

1. **claim-support false negative (gate test 3).** PR #56 deliberately inverted the paper's Oppenheim claim; the gate passed 5/5 because assertions were judged against sources, not against the paper. Assertions now bind to the paper's own text at each cite site, and the protocol fails on paper-vs-description divergence before web verification.
2. **Deployment documentation.** The repo now records the live routine registrations (trigger IDs, crons, models, session config, identity caveat) per research-as-code — the deployment itself is documented, not just the intent.

## Protected paths

Touches `.claude/` and `automation/` — requires the experimenter's approving review (constitution-guard). This PR is authored by the machine account precisely so that approval is possible; it doubles as gate test 7's approve path.

## Verification plan

After merge: re-run semantic-review on PR #56 — it must now FAIL on the inverted claim. The fix PR itself runs claim-support against the unmodified paper and must PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)