### PR TITLE
Plain-English abstracts for all four programs

### DIFF
--- a/programs/co-emergence/README.md
+++ b/programs/co-emergence/README.md
@@ -2,6 +2,20 @@
 
 **Status:** Draft
 
+## In plain English
+
+Why does time exist, and why does quantum mechanics run on imaginary numbers?
+This program studies a model where the universe is a single, static,
+four-dimensional block — no built-in clock — and asks what structures it
+*must* contain to be consistent with itself. The central finding so far: in a
+small, exactly solvable model, self-consistency with a time-like (Lorentzian)
+geometry forces the wavefunction to develop complex phases — the raw
+ingredient of quantum interference — while a space-like (Riemannian) geometry
+stays purely classical. Pieces of this are rigorously proven (for small
+subsystems); much of the rest rests on extensive numerical evidence. The
+headline thesis — that mass, time, geometry, and quantum mechanics emerge
+together as a package — remains a conjecture, and is labeled as one.
+
 Mass, Lorentzian signature, local time, and local Hilbert space are four aspects of one structure. None exists without the others. They co-emerge as the unique cross-level self-consistent configuration of a four-dimensional block manifold with no evolution parameter, no background structure, and no fundamental Hilbert space.
 
 ## Paper structure

--- a/programs/fixed-point-existence/README.md
+++ b/programs/fixed-point-existence/README.md
@@ -4,6 +4,23 @@ The semiclassical Einstein equation admits self-consistent solutions at three le
 
 **Status:** Pre-submission draft
 
+## In plain English
+
+Einstein's equations say matter tells spacetime how to curve. Quantum
+mechanics says matter is fuzzy — it has no single definite arrangement.
+"Semiclassical gravity" is the proposal that spacetime curves in response to
+the *average* of that fuzziness, with no need to quantize gravity itself.
+Critics have long suspected this picture is not even self-consistent. This
+paper shows that it is: there exist geometries that exactly reproduce
+themselves — the curvature sourced by quantum matter living on the geometry
+is that same geometry. The result is rigorous near ordinary classical
+spacetimes when particles have mass, exact in a known cosmological example
+(Starobinsky), and conditional in the most general case (one assumption
+remains open). Massless particles such as light are not yet covered. None of
+this says nature actually works this way — only that the framework is
+internally coherent, with its breakdown scale (the Planck scale) derived
+rather than assumed.
+
 ## Results
 
 1. **Exact (Starobinsky, 1980).** The trace anomaly on FRW spacetime yields an exact de Sitter fixed point. **(Rigorous)**

--- a/programs/gaussian-gravitational-decoherence/README.md
+++ b/programs/gaussian-gravitational-decoherence/README.md
@@ -4,6 +4,20 @@ The Einstein-Langevin equation predicts that gravitational decoherence of a rigi
 
 **Status:** Pre-submission draft
 
+## In plain English
+
+Put a small but massive object in two places at once — a quantum
+superposition — and gravity itself may destroy the superposition. Penrose and
+Diósi famously estimated how fast; experiments are inching toward testing it.
+This paper sharpens the prediction: the superposition should not decay
+exponentially (steadily, like radioactivity) but as a Gaussian — slowly at
+first, then all at once. The timescale agrees with the Penrose–Diósi estimate
+to within about 13%, but the *shape* of the decay differs, and it depends on
+the material: rigid crystals decay Gaussian, soft materials drift back toward
+exponential. Shape and material-dependence are things an experiment can
+check, distinguishing this account from its rivals. The prediction is derived
+at draft rigor and has not been tested by any experiment.
+
 ## Results
 
 1. The decoherence timescale is tau_coh = (4sqrt(2)/5) hbar/E_Delta ~ 1.13 tau_DP, determined by the same gravitational self-energy as the Diosi-Penrose prediction.

--- a/programs/signature-change-boundary/README.md
+++ b/programs/signature-change-boundary/README.md
@@ -2,6 +2,21 @@
 
 **Status:** Early note / musings
 
+## In plain English
+
+Spacetime has a built-in difference between time and space (its "signature").
+Some approaches to quantum cosmology imagine regions where that distinction
+switches off — geometry with no time direction at all — which raises the
+question: is the border between a timeless region and a normal one a tear, a
+wall, or something traversable? This program studies the simplest such border
+on a fixed, hand-prescribed background and finds it surprisingly tame:
+geometry, particle paths, and waves all either cross it or terminate on it in
+a finite, controlled way, with a precise asymmetry — paths through time end
+at the boundary, paths through space cross unharmed. These are early notes,
+not a paper; the core calculations are rigorous for the fixed background, one
+section is a sketch, and nothing here claims such borders actually occur in
+nature — only that they are not mathematically catastrophic.
+
 A fixed background whose metric changes signature across a degenerate hypersurface $\Sigma$ supports a Lorentzian region adjacent to a Euclidean one, and the crossing of $\Sigma$ by worldlines and fields is benign rather than singular. This program asks a narrow, foundational question: **can a fixed Euclidean background produce a Lorentzian region, and can worldlines cross the boundary between them?**
 
 ## Scope


### PR DESCRIPTION
Adds an "In plain English" section to each program README, rigor-faithful by construction (conjectures stay conjectures in translation). Maintenance rules for worker/reviewer/governor follow in a separate protected-path PR. No .tex changes — paper gates no-op; quorum-exempt (experimenter-supervised docs).