### PR TITLE
Abstract maintenance contract for the plain-English READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,11 @@ Read `METHODOLOGY.md` before contributing. It defines:
 - Accented names use LaTeX commands (e.g., `Di\'osi`, `M\o ller`)
 - Date format: Month YYYY
 - Authors: Will Regelmann, Claude (Anthropic)
+- Each program README maintains an `## In plain English` abstract for
+  non-physicist readers: every sentence traceable to a labeled result, no
+  claim stated above its rigor label, conjectures called conjectures in plain
+  English too. Updated in the same PR as any headline rigor change; the
+  governor freshness-sweeps monthly.
 
 ## Before starting work
 

--- a/EXPERIMENT.md
+++ b/EXPERIMENT.md
@@ -120,3 +120,5 @@ terminal artifact, regardless of outcome.
 | Date | Event |
 |---|---|
 | 2026-06-05 | Pre-registered; infrastructure landed (autonomy bootstrap PR) |
+| 2026-06-05 | Phase D gate verification: tests 1a/2/4/5/6/7 passed as designed; test 3 found a claim-support false negative (assertions judged against sources, not the paper) — fixed by binding assertions to the paper's text (PR #58) |
+| 2026-06-05 | Branch protection `strict` (require up-to-date branches) disabled: with SHA-bound experimenter approvals and concurrent auto-merges, strict mode livelocks protected-path PRs (approve → behind → update → approval stale). Pre-registered as a tuning knob; required checks unaffected |

--- a/automation/routines/governor.md
+++ b/automation/routines/governor.md
@@ -49,6 +49,10 @@ In the SAME PR as the exploration:
 - Edit `programs/*/OBJECTIVES.md`: reprioritize, mark milestones Done (with the
   merging PR), add milestones the debate justified, mark killed directions
   **Killed** with one line of why (never delete the row).
+- Freshness-sweep each program README's "In plain English" abstract against
+  the current results; corrections ride this governance PR (convention in
+  AGENTS.md: every sentence traceable to a labeled result, no claim above its
+  label's confidence).
 - Labels: `agent-pr` + `governance`. PR description must @-mention the
   experimenter (`@willregelmann`) — a non-blocking notification, not an
   approval request.

--- a/automation/routines/reviewer.md
+++ b/automation/routines/reviewer.md
@@ -31,6 +31,10 @@ Discipline specific to the autonomous setting:
   exhaustively.
 - Check rigor labels against the actual argument. Mislabeled rigor is an
   automatic **revise**, minimum.
+- If the PR touches a README "In plain English" abstract — or changes a
+  headline result's rigor without updating it — check abstract↔paper
+  congruence. Plain-English overclaiming, or a stale abstract contradicting
+  the paper's new state, is a **revise** at minimum.
 
 Map the synthesis recommendation to a verdict:
 

--- a/automation/routines/worker.md
+++ b/automation/routines/worker.md
@@ -71,6 +71,10 @@ review mode.
 - If the PR promotes any result Sketch → Rigorous, also label
   `promotion-rigorous`.
 - If it demotes or withdraws, also label `demotion` / `withdrawn`.
+- If the PR changes the rigor status of a headline result (promotion,
+  demotion, withdrawal), update the program README's "In plain English"
+  abstract in the same PR. The abstract must never claim higher confidence
+  than the paper's labels (convention in AGENTS.md).
 - Enable auto-merge: `gh pr merge <N> --auto --squash`. Do not merge any other
   way. The gate stack decides from here.
 


### PR DESCRIPTION
Companion to #59: assigns ownership of the In-plain-English abstracts so they cannot silently drift from the papers' rigor labels. Worker: update with any headline rigor change (same PR). Reviewer: overclaim or staleness = revise. Governor: monthly freshness sweep. Convention added to AGENTS.md. Touches protected paths — requires experimenter approval (constitution-guard).