### PR TITLE
constitution-guard: status-pattern fix for the approval livelock

### DIFF
--- a/.github/workflows/constitution-guard.yml
+++ b/.github/workflows/constitution-guard.yml
@@ -3,9 +3,24 @@ name: constitution-guard
 # Constitutional tier of the merge-gate stack (AUTONOMY.md): passes trivially
 # unless the PR touches a protected path, in which case it requires an
 # approving review from the experimenter (@willregelmann) on the CURRENT head
-# SHA. Always-run (no paths filter) so the required context can never be
-# missing. Re-runs when a review is submitted so a late approval unblocks the
-# PR without a push.
+# SHA.
+#
+# Like quorum-gate, the required context `constitution-guard` is a COMMIT
+# STATUS posted by this workflow — the job is deliberately named differently.
+# The original job-as-check design had a livelock: the fail-at-open run and
+# the pass-on-approval run live in different check suites, and the merge box
+# honored the stale failure (observed on PR #58, 2026-06-05). Statuses are
+# latest-wins per context, so a late approval cleanly supersedes.
+#
+# States: success (no protected paths, or approved at head SHA) / pending
+# (protected paths touched, awaiting experimenter approval). There is no
+# failure state — an unapproved constitutional change is "waiting", not
+# "broken".
+#
+# NOTE: changes to THIS file (or any gate workflow) cannot be authored by the
+# machine account (its PAT deliberately lacks the workflow scope) and cannot
+# be self-approved by the experimenter — gate amendments are experimenter-
+# authored and admin-merged (see AUTONOMY.md, Amendment procedure).
 
 on:
   pull_request:
@@ -14,15 +29,16 @@ on:
     types: [submitted, dismissed]
 
 permissions:
+  statuses: write
   contents: read
   pull-requests: read
 
 jobs:
-  guard:
-    name: constitution-guard
+  evaluate:
+    name: constitution-guard-eval
     runs-on: ubuntu-latest
     steps:
-      - name: Check protected paths and experimenter approval
+      - name: Evaluate protected paths and experimenter approval
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -31,23 +47,29 @@ jobs:
           EXPERIMENTER: willregelmann
         run: |
           set -euo pipefail
+
+          post() {
+            gh api "repos/$REPO/statuses/$HEAD_SHA" \
+              -f context=constitution-guard -f state="$1" -f description="$2" >/dev/null
+            echo "constitution-guard on $HEAD_SHA -> $1 ($2)"
+          }
+
           FILES=$(gh api "repos/$REPO/pulls/$PR/files" --paginate | jq -r '.[].filename')
           echo "Changed files:"
           echo "$FILES"
           PROTECTED='^(METHODOLOGY\.md|AUTONOMY\.md|EXPERIMENT\.md|CLAUDE\.md|AGENTS\.md|\.github/|tools/|\.claude/|scripts/|automation/)'
           if ! echo "$FILES" | grep -qE "$PROTECTED"; then
-            echo "No protected paths touched — pass."
+            post success "No protected paths touched."
             exit 0
           fi
-          echo "Protected paths touched. Requiring approving review from @$EXPERIMENTER on $HEAD_SHA."
+
           # The approval must be bound to the current head SHA: an approval
           # followed by additional commits is stale and does not count.
           APPROVED=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
             | jq -r --arg u "$EXPERIMENTER" --arg sha "$HEAD_SHA" \
               '[ .[] | select(.user.login == $u and .state == "APPROVED" and .commit_id == $sha) ] | length')
           if [ "$APPROVED" -ge 1 ]; then
-            echo "Experimenter approval present for the current head SHA — pass."
+            post success "Protected paths approved by @$EXPERIMENTER at $HEAD_SHA."
           else
-            echo "::error::This PR modifies constitutionally protected paths (AUTONOMY.md) and requires an approving review from @$EXPERIMENTER on the current head commit."
-            exit 1
+            post pending "Protected paths touched; awaiting approving review from @$EXPERIMENTER on the current head commit."
           fi

--- a/AUTONOMY.md
+++ b/AUTONOMY.md
@@ -167,3 +167,12 @@ routine definitions require a PR carrying the experimenter's approving review
 change motivated in the PR description — but must expect them to wait for human
 review. The experiment's kill switch and budget are documented in
 `EXPERIMENT.md` and are outside any agent's authority.
+
+**Gate-workflow amendments** (files under `.github/workflows/`) are a special
+case with no agent path at all: the machine account's PAT deliberately lacks
+the `workflow` scope, so agents cannot author them, and GitHub forbids the
+experimenter approving their own PR. Gate changes are therefore
+experimenter-authored and merged with an explicit admin override
+(`gh pr merge --admin`), each one recorded in the `EXPERIMENT.md` log. This is
+the designed emergency path, not a loophole: it is available only to the one
+identity that already holds the kill switch.


### PR DESCRIPTION
Rewrites constitution-guard to post the required context as a per-SHA commit status (the quorum-gate pattern) instead of relying on the job's check run. Root cause and incident on PR #58: fail-at-open and pass-on-approval runs sit in different check suites; the merge box honors the stale failure, so every constitutional amendment needed manual run-poking. Also: "awaiting approval" is now `pending` rather than `failure`, and AUTONOMY.md documents the gate-amendment procedure (experimenter-authored, admin-merged) that this PR itself must use — the bot cannot author workflow changes (no workflow scope) and the experimenter cannot self-approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)