### PR TITLE
Migrate autonomy routines to GitHub Actions (fix the identity defect)

### DIFF
--- a/.github/workflows/autonomy-governor.yml
+++ b/.github/workflows/autonomy-governor.yml
@@ -1,0 +1,19 @@
+name: autonomy-governor
+
+# Scheduled caller for the governor routine (automation/routines/governor.md).
+# Cadence: monthly, 1st at 09:00 UTC. The reusable runner gates on
+# AUTONOMY_ENABLED and guards the machine-account identity. workflow_dispatch
+# is provided for manual testing of a single role.
+
+on:
+  schedule:
+    - cron: "0 9 1 * *"
+  workflow_dispatch:
+
+jobs:
+  governor:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: governor
+      model: claude-opus-4-8
+    secrets: inherit

--- a/.github/workflows/autonomy-identity-probe.yml
+++ b/.github/workflows/autonomy-identity-probe.yml
@@ -1,0 +1,51 @@
+name: autonomy-identity-probe
+
+# Pre-flight identity check for the autonomous fleet. Run manually
+#   gh workflow run autonomy-identity-probe.yml
+# AFTER setting the AUTONOMY_BOT_PAT secret and BEFORE flipping AUTONOMY_ENABLED
+# to true. Confirms the machine-account PAT authenticates as the login recorded
+# in the AUTONOMY_BOT variable, and that it is write-not-admin — the two checks
+# whose absence let the claude.ai deployment run as the experimenter (admin) and
+# silently void the gate stack (EXPERIMENT.md, 2026-06-05/06-09).
+#
+# This workflow is NOT gated by AUTONOMY_ENABLED and runs no Claude session — it
+# is a cheap auth assertion, intended to be green before the fleet is enabled.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.AUTONOMY_BOT_PAT }}
+      AUTONOMY_BOT: ${{ vars.AUTONOMY_BOT }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Verify the machine-account identity and permission level
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::AUTONOMY_BOT_PAT secret not set — nothing to verify."; exit 1
+          fi
+          if [ -z "${AUTONOMY_BOT:-}" ]; then
+            echo "::error::AUTONOMY_BOT variable not set — cannot determine the expected login."; exit 1
+          fi
+
+          LOGIN=$(gh api user --jq .login)
+          echo "AUTONOMY_BOT_PAT authenticates as: ${LOGIN}"
+          echo "Expected (AUTONOMY_BOT variable):  ${AUTONOMY_BOT}"
+          if [ "${LOGIN}" != "${AUTONOMY_BOT}" ]; then
+            echo "::error::Identity mismatch — PAT is '${LOGIN}', expected '${AUTONOMY_BOT}'. Do NOT enable the fleet."
+            exit 1
+          fi
+
+          # Authority boundary: the machine account must be write, NOT admin.
+          ADMIN=$(gh api "repos/${REPO}" --jq '.permissions.admin')
+          echo "repo admin permission for this token: ${ADMIN}"
+          if [ "${ADMIN}" = "true" ]; then
+            echo "::error::Token has ADMIN on the repo. The authority-boundary model (AUTONOMY.md) requires write-not-admin — an admin token can bypass branch protection and self-approve. Fix the machine account's role before enabling."
+            exit 1
+          fi
+
+          echo "::notice::Identity OK: ${LOGIN} (write-not-admin). Safe to enable AUTONOMY_ENABLED."

--- a/.github/workflows/autonomy-librarian.yml
+++ b/.github/workflows/autonomy-librarian.yml
@@ -1,0 +1,19 @@
+name: autonomy-librarian
+
+# Scheduled caller for the librarian routine (automation/routines/librarian.md).
+# Cadence: weekly, Tuesday 03:00 UTC. The reusable runner gates on
+# AUTONOMY_ENABLED and guards the machine-account identity. workflow_dispatch
+# is provided for manual testing of a single role.
+
+on:
+  schedule:
+    - cron: "0 3 * * 2"
+  workflow_dispatch:
+
+jobs:
+  librarian:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: librarian
+      model: claude-sonnet-4-6
+    secrets: inherit

--- a/.github/workflows/autonomy-red-team.yml
+++ b/.github/workflows/autonomy-red-team.yml
@@ -1,0 +1,21 @@
+name: autonomy-red-team
+
+# Scheduled caller for the red-team routine (automation/routines/red-team.md).
+# Cadence: every 3 days at 08:00 UTC. NOTE the cron `0 8 */3 * *` is
+# day-of-month based, so the interval compresses at month boundaries (e.g. the
+# 31st -> the 1st). Harmless; preserved from the pre-registered cadence. The
+# reusable runner gates on AUTONOMY_ENABLED and guards the machine-account
+# identity. workflow_dispatch is provided for manual testing of a single role.
+
+on:
+  schedule:
+    - cron: "0 8 */3 * *"
+  workflow_dispatch:
+
+jobs:
+  red-team:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: red-team
+      model: claude-opus-4-8
+    secrets: inherit

--- a/.github/workflows/autonomy-responder.yml
+++ b/.github/workflows/autonomy-responder.yml
@@ -1,0 +1,20 @@
+name: autonomy-responder
+
+# Scheduled caller for the responder routine (automation/routines/responder.md).
+# Cadence: daily 04:00 UTC (runs before reviewer 05:00 and worker 06:00 so
+# fixes land, get re-reviewed, then new work starts against an up-to-date
+# queue). The reusable runner gates on AUTONOMY_ENABLED and guards the
+# machine-account identity. workflow_dispatch is provided for manual testing.
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  responder:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: responder
+      model: claude-sonnet-4-6
+    secrets: inherit

--- a/.github/workflows/autonomy-reviewer.yml
+++ b/.github/workflows/autonomy-reviewer.yml
@@ -1,0 +1,19 @@
+name: autonomy-reviewer
+
+# Scheduled caller for the reviewer routine (automation/routines/reviewer.md).
+# Cadence: twice daily, 05:00 and 17:00 UTC (the adversarial quorum). The
+# reusable runner gates on AUTONOMY_ENABLED and guards the machine-account
+# identity. workflow_dispatch is provided for manual testing of a single role.
+
+on:
+  schedule:
+    - cron: "0 5,17 * * *"
+  workflow_dispatch:
+
+jobs:
+  reviewer:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: reviewer
+      model: claude-opus-4-8
+    secrets: inherit

--- a/.github/workflows/autonomy-routine.yml
+++ b/.github/workflows/autonomy-routine.yml
@@ -1,0 +1,100 @@
+name: autonomy-routine
+
+# Reusable runner for the seven autonomous routines (AUTONOMY.md). Each role's
+# scheduled caller (autonomy-<role>.yml) invokes this with its role + model.
+# Behavior lives in automation/routines/<role>.md; this file only establishes
+# the machine-account identity and runs a headless Claude Code session on the
+# role's pointer prompt.
+#
+# WHY THIS EXISTS: the original deployment ran the routines as claude.ai
+# scheduled remote agents, which authenticate GitHub with the *account's*
+# global connector — i.e. the experimenter's admin login. That voided every
+# authority boundary in AUTONOMY.md (write-not-admin, no self-verdict, no
+# protected-path self-approval). A GitHub Actions runner authenticates with a
+# credential we control (AUTONOMY_BOT_PAT), restoring the machine-account
+# identity by construction. See EXPERIMENT.md log (2026-06-09).
+#
+# IDENTITY: every git/gh operation authenticates as the machine account via
+# AUTONOMY_BOT_PAT, NOT the default GITHUB_TOKEN (whose actor is
+# github-actions[bot] — neither the machine account nor the experimenter, and
+# whose PRs would not trigger the required-check workflows). checkout runs with
+# persist-credentials:false so the default token's git credential cannot shadow
+# the PAT. A hard identity guard refuses to run the routine if the effective
+# login is not the AUTONOMY_BOT variable value — the exact check whose absence
+# caused the 2026-06-05 incident.
+#
+# KILL SWITCH: the job is gated on the repo variable AUTONOMY_ENABLED == 'true'.
+# Unset or any other value => every routine run skips. Flip that one variable to
+# start or stop the whole fleet; individual roles can also be disabled in the
+# Actions tab.
+
+on:
+  workflow_call:
+    inputs:
+      role:
+        description: Routine role; must match automation/routines/<role>.md
+        required: true
+        type: string
+      model:
+        description: Full Claude model ID to run this routine on
+        required: true
+        type: string
+
+jobs:
+  run:
+    name: ${{ inputs.role }}
+    if: ${{ vars.AUTONOMY_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.AUTONOMY_BOT_PAT }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ROLE: ${{ inputs.role }}
+      MODEL: ${{ inputs.model }}
+      AUTONOMY_BOT: ${{ vars.AUTONOMY_BOT }}
+    steps:
+      - name: Preflight — required secrets and variables present
+        run: |
+          set -euo pipefail
+          missing=
+          [ -z "${GH_TOKEN:-}" ] && missing="$missing AUTONOMY_BOT_PAT(secret)"
+          [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && missing="$missing CLAUDE_CODE_OAUTH_TOKEN(secret)"
+          [ -z "${AUTONOMY_BOT:-}" ] && missing="$missing AUTONOMY_BOT(var)"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required configuration:$missing — cannot run the ${ROLE} routine."
+            exit 1
+          fi
+
+      - name: Check out repo (do not persist the default-token credential)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure git/gh as the machine account, and GUARD the identity
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          git config --global user.name "${AUTONOMY_BOT}"
+          git config --global user.email "${AUTONOMY_BOT}@users.noreply.github.com"
+          ACTUAL=$(gh api user --jq .login)
+          echo "Effective GitHub identity: ${ACTUAL} (expected: ${AUTONOMY_BOT})"
+          if [ "${ACTUAL}" != "${AUTONOMY_BOT}" ]; then
+            echo "::error::Routine would run as '${ACTUAL}', not the machine account '${AUTONOMY_BOT}'."
+            echo "::error::Refusing to act. This is the identity guard the claude.ai deployment lacked (2026-06-05 incident)."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run the ${{ inputs.role }} routine
+        run: |
+          set -euo pipefail
+          PROMPT="You are the ${ROLE} routine of the self-consistency autonomous research experiment. Read AUTONOMY.md at the repository root first, then read automation/routines/${ROLE}.md and execute it exactly. If automation/routines/${ROLE}.md does not exist on this branch, the experiment infrastructure has not landed yet — exit immediately without taking any action."
+          claude -p "$PROMPT" \
+            --model "$MODEL" \
+            --permission-mode bypassPermissions

--- a/.github/workflows/autonomy-scout.yml
+++ b/.github/workflows/autonomy-scout.yml
@@ -1,0 +1,19 @@
+name: autonomy-scout
+
+# Scheduled caller for the scout routine (automation/routines/scout.md).
+# Cadence: weekly, Monday 03:00 UTC. The reusable runner gates on
+# AUTONOMY_ENABLED and guards the machine-account identity. workflow_dispatch
+# is provided for manual testing of a single role.
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  scout:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: scout
+      model: claude-sonnet-4-6
+    secrets: inherit

--- a/.github/workflows/autonomy-worker.yml
+++ b/.github/workflows/autonomy-worker.yml
@@ -1,0 +1,19 @@
+name: autonomy-worker
+
+# Scheduled caller for the worker routine (automation/routines/worker.md).
+# Cadence mirrors the pre-registered cadence: daily 06:00 UTC. The reusable
+# runner gates on AUTONOMY_ENABLED and guards the machine-account identity.
+# workflow_dispatch is provided for manual testing of a single role.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  worker:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: worker
+      model: claude-opus-4-8
+    secrets: inherit

--- a/EXPERIMENT.md
+++ b/EXPERIMENT.md
@@ -1,11 +1,14 @@
 # EXPERIMENT.md — Pre-registration of the Autonomous Research Experiment
 
-**Status:** Halted ~3h after first enablement (2026-06-05). The live identity
-check on the first routine run found routines authenticating as the
-experimenter's admin login rather than the machine account; all seven routines
-were disabled (kill switch step 1 — see log). Restart pending the auth fix;
-the start date will be re-recorded at restart. This file is a protected path;
-agents do not edit it.
+**Status:** Halted since first enablement (2026-06-05). Root cause confirmed
+2026-06-09: the claude.ai scheduled-agent runner authenticates GitHub with the
+account's global connector (the experimenter's admin login), and that connector
+cannot be repointed to the machine account per-routine — so the runner itself,
+not a setting, was the defect. The fleet is being **migrated to GitHub Actions
+scheduled workflows**, which authenticate with a credential we control
+(`AUTONOMY_BOT_PAT`); restart is gated on a green `autonomy-identity-probe` and
+on flipping `AUTONOMY_ENABLED`. The start date will be re-recorded at restart.
+This file is a protected path; agents do not edit it.
 
 ## Hypothesis
 
@@ -127,3 +130,4 @@ terminal artifact, regardless of outcome.
 | 2026-06-05 | Branch protection `strict` (require up-to-date branches) disabled: with SHA-bound experimenter approvals and concurrent auto-merges, strict mode livelocks protected-path PRs (approve → behind → update → approval stale). Pre-registered as a tuning knob; required checks unaffected |
 | 2026-06-05 | **Experiment started.** Start date recorded and all seven routines enabled by the experimenter from the CLI (experimenter-authored PR, admin-merged per the documented protected-path procedure). Scout fired once manually post-enablement to seed the issue queue ahead of its Monday cadence |
 | 2026-06-05 | **Halted at T+3h (kill switch step 1).** The manually-fired scout run doubled as the live identity check: its issues (#65, #66) were authored by the experimenter's login (`willregelmann`, admin) instead of the machine account (`will-physagent`) — the cloud environment's GitHub credential is the experimenter's, so every authority boundary that holds "by construction" (write-not-admin, no branch-protection bypass, experimenter/agent distinction) was void. All seven routines disabled via API within minutes; no PRs were opened and nothing merged under the wrong identity. Scout-filed issues kept — experimenter-authored `agent-ready` issues are valid per the label table. Remediation before restart: (1) rotate the bot PAT (also closing the earlier transcript-exposure note), (2) set the rotated PAT as the cloud environment's GitHub credential so routine runs operate as `will-physagent`, (3) re-fire one routine and verify its effective login on a created artifact, (4) re-enable all seven and re-record the start date. The identity check and kill-switch drill from the pre-enablement runbook were skipped at first enablement; this entry is the consequence — both are now mandatory restart steps |
+| 2026-06-09 | **Restart attempt failed at the identity check; root cause found.** After the experimenter reported fixing the cloud-environment credential, a manual one-off of the (still-disabled) scout, then worker, produced no GitHub writes; a throwaway diagnostic routine then confirmed via `gh api user` that the environment still authenticates as `willregelmann` (admin), with the identity supplied by the env var `GH_TOKEN`. Diagnosis: the claude.ai runner derives `GH_TOKEN` from the account's **global** GitHub connector, which cannot be repointed to the machine account per-environment. Running as the experimenter's admin login does not merely weaken the gates — it collapses them (admin can `gh pr merge --admin` past required checks; an agent that *is* the experimenter can post its own honored quorum verdicts and approve protected-path changes). Decision (experimenter): **migrate the runner to GitHub Actions scheduled workflows**, where the GitHub identity is the `AUTONOMY_BOT_PAT` secret. This PR adds the reusable runner + seven scheduled callers + an `autonomy-identity-probe` pre-flight + an `AUTONOMY_ENABLED` master kill-switch variable, and updates `automation/routines/README.md`. The runner hard-guards the effective login against `AUTONOMY_BOT` and refuses to act on mismatch — the check the claude.ai deployment structurally could not perform. Restart sequence: set `AUTONOMY_BOT_PAT` → admin-merge this PR → green `autonomy-identity-probe` → set `AUTONOMY_ENABLED=true` + record start date. The seven claude.ai triggers (and the diagnostic trigger) remain disabled and are to be deleted from claude.ai/code/routines |

--- a/automation/routines/README.md
+++ b/automation/routines/README.md
@@ -17,9 +17,17 @@ Register each routine with this pointer prompt (replace `<role>`):
 > taking any action.
 
 Source: this repository, branch `main`. Git identity / GitHub auth: the
-machine account recorded in the repo variable `AUTONOMY_BOT`. Create routines
-**disabled**; enable only after the Phase D verification checklist passes (see
-the bootstrap PR).
+machine account recorded in the repo variable `AUTONOMY_BOT`, supplied to the
+runner as the `AUTONOMY_BOT_PAT` secret (see "Deployed instances" below).
+
+> **Runner note (2026-06-09).** The routines were originally registered as
+> claude.ai scheduled remote agents. That runner authenticates GitHub with the
+> account's *global* connector — i.e. the experimenter's admin login — which
+> voided the machine-account identity the whole authority model depends on
+> (EXPERIMENT.md log). The routines now run as **GitHub Actions scheduled
+> workflows** instead, which authenticate with a credential we control
+> (`AUTONOMY_BOT_PAT`). The pointer prompt above is unchanged — it is what the
+> reusable workflow feeds to a headless Claude Code session.
 
 ## Registry
 
@@ -37,44 +45,73 @@ Cadence rationale: responder (04:00) runs before reviewer (05:00) runs before
 worker (06:00) — fixes land, get re-reviewed, then new work starts against an
 up-to-date queue.
 
-## Deployed instances (registered 2026-06-05)
+## Deployed instances (GitHub Actions, 2026-06-09)
 
-The routines are deployed as claude.ai scheduled remote agents, managed at
-<https://claude.ai/code/routines>. This table is the record of the live
-deployment; if it drifts from what is actually registered, this file is wrong —
-fix the file. Disabling these routines is **step 1 of the kill switch**
-(`EXPERIMENT.md`).
+The routines run as **GitHub Actions scheduled workflows** in this repository.
+Each role has a thin scheduled caller (`.github/workflows/autonomy-<role>.yml`)
+that invokes the reusable runner (`.github/workflows/autonomy-routine.yml`) with
+its role and model. This table is the record of the live deployment; if it
+drifts from the workflow files, this file is wrong — fix it.
 
-| Routine | Trigger ID | Cron (UTC) | Model |
-|---------|-----------|------------|-------|
-| autonomy-worker | `trig_012ZLL1t2j7peNzGAadXymML` | `0 6 * * *` | claude-opus-4-8 |
-| autonomy-reviewer | `trig_013PE7Dp6EFji5d9NefgAx4X` | `0 5,17 * * *` | claude-opus-4-8 |
-| autonomy-responder | `trig_01PC2vVYcWUQ7qJQsb4Gf8MV` | `0 4 * * *` | claude-sonnet-4-6 |
-| autonomy-red-team | `trig_01DFgXG9eZ37bPLVgtSGLq7x` | `0 8 */3 * *` | claude-opus-4-8 |
-| autonomy-scout | `trig_013qHNtEy8nxjKdw8nfmiYFT` | `0 3 * * 1` | claude-sonnet-4-6 |
-| autonomy-librarian | `trig_01F12Zj6gbcru4XycQRfg4Dq` | `0 3 * * 2` | claude-sonnet-4-6 |
-| autonomy-governor | `trig_01FEAuqs6FbCKC6TEgCDhYPP` | `0 9 1 * *` | claude-opus-4-8 |
+| Routine | Workflow file | Cron (UTC) | Model |
+|---------|---------------|------------|-------|
+| worker | `autonomy-worker.yml` | `0 6 * * *` | claude-opus-4-8 |
+| reviewer | `autonomy-reviewer.yml` | `0 5,17 * * *` | claude-opus-4-8 |
+| responder | `autonomy-responder.yml` | `0 4 * * *` | claude-sonnet-4-6 |
+| red-team | `autonomy-red-team.yml` | `0 8 */3 * *` | claude-opus-4-8 |
+| scout | `autonomy-scout.yml` | `0 3 * * 1` | claude-sonnet-4-6 |
+| librarian | `autonomy-librarian.yml` | `0 3 * * 2` | claude-sonnet-4-6 |
+| governor | `autonomy-governor.yml` | `0 9 1 * *` | claude-opus-4-8 |
 
-Shared deployment configuration (all seven):
+Shared deployment configuration (all seven, in the reusable runner):
 
-- **Environment:** Anthropic cloud (`env_011CTQhm6jdCKJ3Tu9TnXTLe`); each run
-  is a fully isolated remote session with a fresh checkout of this repo @ `main`.
-- **Prompt:** the pointer template above, verbatim — behavior lives in the
-  version-controlled `<role>.md` files, never in the registration.
-- **Allowed tools:** `Bash, Read, Write, Edit, Glob, Grep, Task, WebSearch, WebFetch`.
-- **MCP connections:** explicitly cleared (least privilege — no external
-  connectors).
-- **Created disabled**; enabled only after the Phase D gate verification in
-  `EXPERIMENT.md` passed, with the experiment start date recorded there.
-- **Identity:** runs authenticate to GitHub with the environment's credential.
-  `quorum-gate` honors verdict markers only from the login in the
-  `AUTONOMY_BOT` repo variable (`will-physagent`) or the experimenter — if a
-  routine's effective login differs, fix the routine's auth or the variable,
-  in that order of preference.
+- **Runner:** `ubuntu-latest`; each run is a fresh checkout of this repo, a
+  global `npm install -g @anthropic-ai/claude-code`, and one headless
+  `claude -p "<pointer prompt>"` session. Stateless — every run reconstructs
+  from GitHub, which suits ephemeral CI.
+- **Prompt:** the pointer template above, built verbatim by the runner —
+  behavior lives in the version-controlled `<role>.md` files, never in the
+  workflow.
+- **Model:** pinned full IDs (above), passed as `claude --model <id>`.
+- **Permissions:** `--permission-mode bypassPermissions` (no human is present
+  to approve tool calls in CI). The full Claude Code toolset is available; the
+  reusable runner does not pass an `--allowedTools` allow-list.
+- **Claude auth:** the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (shared with the
+  `semantic-review` gate).
+- **GitHub identity:** the `AUTONOMY_BOT_PAT` repo secret (the machine
+  account's PAT, `public_repo` scope, deliberately NO `workflow` scope). The
+  runner uses it for every git/gh operation — NOT the default `GITHUB_TOKEN`,
+  whose actor `github-actions[bot]` is neither the machine account nor the
+  experimenter and whose PRs would not trigger the required checks. `checkout`
+  runs with `persist-credentials: false` so the default token cannot shadow the
+  PAT. A hard identity guard in the runner refuses to act unless the effective
+  login equals `AUTONOMY_BOT` — the check whose absence caused the 2026-06-05
+  incident.
+
+### Kill switch
+
+Step 1 of the kill switch is the repo variable **`AUTONOMY_ENABLED`**: the
+reusable runner skips every routine unless it is exactly `true`. Set it to
+`false` (or unset it) to halt the whole fleet in one action; individual roles
+can also be disabled from the Actions tab. (The full kill switch — budget, PAT
+revocation — is in `EXPERIMENT.md`.)
+
+### Enablement runbook
+
+1. Set the `AUTONOMY_BOT_PAT` secret to the machine account's PAT.
+2. Merge these workflows to `main` (scheduled/dispatch workflows only run from
+   the default branch). Protected-path PR → experimenter admin-merge.
+3. Run `gh workflow run autonomy-identity-probe.yml` and confirm it is green
+   (authenticates as `AUTONOMY_BOT`, write-not-admin).
+4. Set `AUTONOMY_ENABLED=true` and record the start date in `EXPERIMENT.md`.
 
 Note on red-team cadence: `0 8 */3 * *` is day-of-month based, so the
 interval compresses at month boundaries (e.g. the 31st → the 1st). Harmless;
 recorded so nobody "fixes" it into a bug report.
+
+Note on scheduled-workflow caveats: Actions cron can be delayed under load, and
+scheduled workflows auto-disable after 60 days of no repository activity (a
+non-issue during an active run).
 
 ## Shared conventions
 


### PR DESCRIPTION
## Why

The autonomous experiment has been halted since first enablement (2026-06-05). Root cause, confirmed 2026-06-09: the **claude.ai scheduled-agent runner authenticates GitHub via the account's global connector** — the experimenter's admin login — and that connector cannot be repointed to the machine account per-routine. Every routine ran as `willregelmann` (admin), which doesn't just weaken the gate stack, it **collapses** it:

- admin can `gh pr merge --admin` past every required check;
- an agent that *is* the experimenter can post its own `quorum:verdict accept` markers (the gate honors experimenter markers) and approve its own protected-path changes (`constitution-guard`).

Diagnosis was via a throwaway diagnostic routine running `gh api user` → `willregelmann`, identity supplied by the env var `GH_TOKEN` from the global connector. Full detail in the EXPERIMENT.md log entry in this PR.

## What

Move the seven routines off claude.ai onto **GitHub Actions scheduled workflows**, where the GitHub identity is the `AUTONOMY_BOT_PAT` secret we control.

- **`autonomy-routine.yml`** — reusable runner. Authenticates as the machine account via `AUTONOMY_BOT_PAT` (never the default `GITHUB_TOKEN`); `checkout` with `persist-credentials: false`; **a hard identity guard that refuses to act unless the effective login equals the `AUTONOMY_BOT` variable** — the check the claude.ai runner structurally could not perform. Runs one headless `claude -p` session on the role pointer prompt, model pinned, full toolset under `--permission-mode bypassPermissions`.
- **`autonomy-<role>.yml` (×7)** — thin scheduled callers preserving the pre-registered cadences and per-role models; `workflow_dispatch` for manual testing.
- **`autonomy-identity-probe.yml`** — manual pre-flight asserting the PAT authenticates as the machine account **and** is write-not-admin. Green before enabling.
- **`AUTONOMY_ENABLED`** repo variable — master kill switch; the runner skips every routine unless it is `true`. Staged at `false`.
- Docs: `automation/routines/README.md` deployment section rewritten for the Actions runner + enablement runbook; `EXPERIMENT.md` status and log updated.

## Design notes / deviations

- **No `--bare`** — it would skip `CLAUDE.md` (the routines rely on the auto-loaded AUTONOMY/METHODOLOGY/AGENTS context) and ignore `CLAUDE_CODE_OAUTH_TOKEN` (our auth).
- **No `--allowedTools` allow-list** — the subagent tool name (`Task` vs `Agent`) was uncertain and the team-spawning routines need it; `bypassPermissions` gives the full toolset with nothing to prompt. (The claude.ai deployment's 9-tool list is the only config not carried over verbatim.)
- **`AUTONOMY_BOT_PAT` keeps `public_repo`, no `workflow` scope** — the routines run *inside* workflows but never *edit* them, so the no-`workflow`-scope constraint still holds. Consistent with `metrics.yml`, which already uses this PAT.
- Caveats noted in the doc: Actions cron jitter; scheduled workflows auto-disable after 60 days of repo inactivity.

## Merge path

Touches `.github/` and protected docs (`automation/`, `EXPERIMENT.md`) → `constitution-guard` will be pending. Per AUTONOMY.md, gate-workflow changes are experimenter-authored and **admin-merged** (`gh pr merge --admin`); GitHub forbids self-approval. No `agent-pr` label (experimenter-supervised).

## Restart sequence (after merge)

1. Set the `AUTONOMY_BOT_PAT` secret to the machine account's PAT (rotate per the incident note).
2. `gh pr merge --admin` this PR (scheduled workflows only run from `main`).
3. `gh workflow run autonomy-identity-probe.yml` → confirm green (`will-physagent`, write-not-admin).
4. `gh variable set AUTONOMY_ENABLED --body true` and record the start date in `EXPERIMENT.md` (+ set the budget ceiling, still blank).
5. Delete the seven disabled claude.ai triggers and the `autonomy-identity-probe` diagnostic trigger from claude.ai/code/routines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)