### PR TITLE
Record experiment start: 2026-06-09 (GitHub Actions runner)

### DIFF
--- a/EXPERIMENT.md
+++ b/EXPERIMENT.md
@@ -1,14 +1,11 @@
 # EXPERIMENT.md — Pre-registration of the Autonomous Research Experiment
 
-**Status:** Halted since first enablement (2026-06-05). Root cause confirmed
-2026-06-09: the claude.ai scheduled-agent runner authenticates GitHub with the
-account's global connector (the experimenter's admin login), and that connector
-cannot be repointed to the machine account per-routine — so the runner itself,
-not a setting, was the defect. The fleet is being **migrated to GitHub Actions
-scheduled workflows**, which authenticate with a credential we control
-(`AUTONOMY_BOT_PAT`); restart is gated on a green `autonomy-identity-probe` and
-on flipping `AUTONOMY_ENABLED`. The start date will be re-recorded at restart.
-This file is a protected path; agents do not edit it.
+**Status:** Running. Started 2026-06-09 on the GitHub Actions runner, after the
+first enablement (2026-06-05, claude.ai runner) was halted at T+3h for the
+identity defect and the fleet was migrated (see log). Go-live preconditions
+met: `autonomy-identity-probe` green (routines authenticate as `will-physagent`,
+write-not-admin) and `AUTONOMY_ENABLED` flipped to `true`. This file is a
+protected path; agents do not edit it.
 
 ## Hypothesis
 
@@ -29,8 +26,8 @@ audit. The experiment is designed so these two outcomes are distinguishable.
 | Parameter | Value |
 |---|---|
 | Duration | **90 days** from start date |
-| Start date | _first enablement 2026-06-05 halted at T+3h (see log); to be re-recorded at restart_ |
-| End date | start + 90 days |
+| Start date | **2026-06-09** (fresh clock; the 2026-06-05 enablement was halted at T+3h before any research ran) |
+| End date | **2026-09-07** (start + 90 days) |
 | Worker cadence / model | daily / opus |
 | Reviewer cadence / model | every 12h / opus |
 | Responder cadence / model | daily / sonnet |
@@ -131,3 +128,4 @@ terminal artifact, regardless of outcome.
 | 2026-06-05 | **Experiment started.** Start date recorded and all seven routines enabled by the experimenter from the CLI (experimenter-authored PR, admin-merged per the documented protected-path procedure). Scout fired once manually post-enablement to seed the issue queue ahead of its Monday cadence |
 | 2026-06-05 | **Halted at T+3h (kill switch step 1).** The manually-fired scout run doubled as the live identity check: its issues (#65, #66) were authored by the experimenter's login (`willregelmann`, admin) instead of the machine account (`will-physagent`) — the cloud environment's GitHub credential is the experimenter's, so every authority boundary that holds "by construction" (write-not-admin, no branch-protection bypass, experimenter/agent distinction) was void. All seven routines disabled via API within minutes; no PRs were opened and nothing merged under the wrong identity. Scout-filed issues kept — experimenter-authored `agent-ready` issues are valid per the label table. Remediation before restart: (1) rotate the bot PAT (also closing the earlier transcript-exposure note), (2) set the rotated PAT as the cloud environment's GitHub credential so routine runs operate as `will-physagent`, (3) re-fire one routine and verify its effective login on a created artifact, (4) re-enable all seven and re-record the start date. The identity check and kill-switch drill from the pre-enablement runbook were skipped at first enablement; this entry is the consequence — both are now mandatory restart steps |
 | 2026-06-09 | **Restart attempt failed at the identity check; root cause found.** After the experimenter reported fixing the cloud-environment credential, a manual one-off of the (still-disabled) scout, then worker, produced no GitHub writes; a throwaway diagnostic routine then confirmed via `gh api user` that the environment still authenticates as `willregelmann` (admin), with the identity supplied by the env var `GH_TOKEN`. Diagnosis: the claude.ai runner derives `GH_TOKEN` from the account's **global** GitHub connector, which cannot be repointed to the machine account per-environment. Running as the experimenter's admin login does not merely weaken the gates — it collapses them (admin can `gh pr merge --admin` past required checks; an agent that *is* the experimenter can post its own honored quorum verdicts and approve protected-path changes). Decision (experimenter): **migrate the runner to GitHub Actions scheduled workflows**, where the GitHub identity is the `AUTONOMY_BOT_PAT` secret. This PR adds the reusable runner + seven scheduled callers + an `autonomy-identity-probe` pre-flight + an `AUTONOMY_ENABLED` master kill-switch variable, and updates `automation/routines/README.md`. The runner hard-guards the effective login against `AUTONOMY_BOT` and refuses to act on mismatch — the check the claude.ai deployment structurally could not perform. Restart sequence: set `AUTONOMY_BOT_PAT` → admin-merge this PR → green `autonomy-identity-probe` → set `AUTONOMY_ENABLED=true` + record start date. The seven claude.ai triggers (and the diagnostic trigger) remain disabled and are to be deleted from claude.ai/code/routines |
+| 2026-06-09 | **Experiment started (run 2) on the GitHub Actions runner.** Migration PR (#68) admin-merged. `autonomy-identity-probe` run came back green — `AUTONOMY_BOT_PAT` authenticates as `will-physagent` with repo admin = false (write-not-admin), the two boundary conditions the claude.ai runner violated. `AUTONOMY_ENABLED` flipped to `true` at 20:12 UTC; first scheduled fire is the responder at 04:00 UTC 2026-06-10. Clock runs fresh from 2026-06-09 (the 2026-06-05 enablement is not counted — it was halted at T+3h before any research merged). Cleanup outstanding: delete the seven disabled claude.ai triggers and the `autonomy-identity-probe` diagnostic trigger from claude.ai/code/routines (the remote-trigger API cannot delete them) |


### PR DESCRIPTION
Records the launch in the pre-registration: Status → Running, start **2026-06-09**, end **2026-09-07** (fresh 90-day clock — the 2026-06-05 enablement was halted at T+3h before any research merged), and a log entry capturing the green `autonomy-identity-probe` (`will-physagent`, write-not-admin) and the `AUTONOMY_ENABLED=true` flip.

Protected path (EXPERIMENT.md), experimenter-authored → admin-merged; no `agent-pr` label.

Budget ceiling row deliberately left unchanged in this PR — a follow-up sets the USD/week figure once provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)