### PR TITLE
Demotion: correct false equality condition in the entropy-excess lemma

### DIFF
--- a/programs/co-emergence/index.tex
+++ b/programs/co-emergence/index.tex
@@ -312,7 +312,9 @@ is $|\psi^*_\sigma|$, with the same $|\psi^*_\sigma|$ in both cases.
 Phase-stripping recovers the Riemannian state by construction, so the
 entropy excess is entirely a phase effect.
 Lemma~\ref{lem:entropy_excess} proves that this excess is guaranteed
-for any non-uniform magnitude profile.
+for any \emph{non-separable} magnitude profile (one whose reshaped
+magnitude matrix has rank $\geq 2$); a non-uniform but separable
+(rank-one) profile produces no excess at all.
 
 The distinction matters: a na\"ive diagnostic that checks only whether
 the reduced density matrix has large imaginary off-diagonal elements
@@ -352,7 +354,15 @@ equivalently $S_2(\theta) \geq S_2(0)$ where $S_2 = -\log
 \item[(b)] \textbf{(Rank 2.)} The von Neumann entropy increases:
 $S(\theta) \geq S(0)$.
 \end{enumerate}
-In both cases, equality holds if and only if all $m_{ij}$ are equal.
+In both cases, equality holds if and only if the magnitude matrix is
+\emph{phase-degenerate}: for every column pair $(j,k)$ the difference
+$\log m_{ik} - \log m_{ij}$ is independent of $i$ modulo $2\pi/\theta$.
+For non-resonant $\theta$ this is equivalent to $\log m_{ij}$ being
+additively separable, $\log m_{ij} = a_i + b_j$---i.e.\ the magnitude
+matrix $m$ has rank one. All $m_{ij}$ equal is the special case
+$a_i = b_j = \mathrm{const}$; it is sufficient for equality but
+\emph{not} necessary (any rank-one $m$ with non-constant $a_i$ or $b_j$,
+or a $\theta$ tuned to a $2\pi$-resonance, also gives equality).
 \end{lemma}
 
 \begin{proof}
@@ -401,8 +411,17 @@ gives $|\rho(\theta)_{jk}| \leq \sum_i m_{ij}\, m_{ik} =
 \]
 Equality requires $|\rho(\theta)_{jk}| = \rho(0)_{jk}$ for all
 $j \neq k$, which forces each triangle inequality in Fact~3 to be
-tight---all phases $\theta(\log m_{ik} - \log m_{ij})$ must be equal
-across $i$ for each pair $(j,k)$, hence all $m_{ij}$ equal.
+tight. Since the summands $m_{ij} m_{ik} > 0$, their phases
+$\theta(\log m_{ik} - \log m_{ij})$ must coincide across $i$ (modulo
+$2\pi$) for each pair $(j,k)$. For non-resonant $\theta$ this means
+$\log m_{ik} - \log m_{ij}$ is independent of $i$, i.e.\ $\log m_{ij} =
+a_i + b_j$ is separable and $m$ has rank one. This is strictly weaker
+than ``all $m_{ij}$ equal'': any rank-one positive matrix saturates the
+bound---its Gram matrix has a single nonzero eigenvalue, so the purity
+is identically $1$ for every $\theta$---so the converse of the
+all-equal characterization fails. (At resonant $\theta$, further
+non-separable equality cases arise when all phase differences are
+multiples of $2\pi$.)
 
 \textbf{Part (b):} When $\min(d_{\mathrm{sub}}, d_{\mathrm{env}}) =
 2$, there are at most two nonzero singular values $\sigma_1 \geq
@@ -439,16 +458,26 @@ The toy model entries $m_\sigma = e^{-R_\sigma}$ fall in this regime.
 In the toy model, the Lorentzian fixed point
 $\psi^*_\sigma \propto \exp((-1 + i\theta)\, R_\sigma)$ has magnitude
 $|\psi^*_\sigma| \propto e^{-R_\sigma}$ and phase $\theta R_\sigma$,
-which is exactly the structure $m^{1+i\theta}$ of
-Lemma~\ref{lem:entropy_excess} with $m_\sigma = e^{-R_\sigma}$. The
+which is the structure $m^{1+i\theta}$ of
+Lemma~\ref{lem:entropy_excess} with $m_\sigma = e^{-R_\sigma}$ and
+$\theta \to -\theta$ (since $\theta R_\sigma = -\theta \log m_\sigma$);
+the substitution is immaterial because $\rho(-\theta) = \rho(\theta)^*$,
+so all singular values, and hence all entropies, are unchanged. The
 Riemannian fixed point has $\theta = 0$, giving the same magnitudes
 but no phases.
 
 Lemma~\ref{lem:entropy_excess}(a) rigorously guarantees that the
 Lorentzian state has lower purity (higher R\'enyi-2 entropy) than the
-Riemannian state for all bipartitions, whenever the curvature values
-$R_\sigma$ are not all equal---i.e., whenever the external field $h$
-is non-uniform. For the von Neumann entropy: the toy model entries
+Riemannian state for any bipartition whose reshaped magnitude matrix
+$m_\sigma = e^{-R_\sigma}$ is non-separable (rank $\geq 2$). A
+bipartition across which $R_\sigma$ is additively separable yields a
+rank-one magnitude matrix and hence \emph{no} excess; non-uniformity of
+$h$ alone is therefore not sufficient. In the toy model the cross-level
+couplings in $R_\sigma = h_\sigma + \sum_j \alpha_j M_j(\sigma_j) +
+\beta |\psi_\sigma|^2$ generically render $m_\sigma$ non-separable, so
+the excess does occur, but the guarantee is conditional on
+non-separability rather than on mere non-uniformity. For the von
+Neumann entropy: the toy model entries
 $m_\sigma = e^{-R_\sigma}$ with $h \sim \mathrm{Uniform}[0.5, 1.5]$
 have moderate heterogeneity (entry ratio $\lesssim 3$), placing them
 well within the regime where $S(\theta) \geq S(0)$ holds


### PR DESCRIPTION
## What this is

A **red-team demotion/correction** (routine: `automation/routines/red-team.md`; Red-team log #75). A stress test of the (Rigorous) phase-induced entropy-excess lemma (`lem:entropy_excess`, `programs/co-emergence/index.tex`) found a genuine error in a merged Rigorous result. Filling the precise characterization is tracked in #76.

## The gap found

The lemma states: *"In both cases, equality holds if and only if all `m_ij` are equal."* The proof closes with *"...all phases must be equal across `i`, **hence all `m_ij` equal**."*

**This is false.** Tight contraction of every Gram off-diagonal forces `θ(log m_ik − log m_ij)` to be constant in `i` — i.e. `log m_ij = a_i + b_j` **separable**, equivalently the magnitude matrix has **rank one** — which is strictly weaker than all-entries-equal. The "hence all `m_ij` equal" step is a non-sequitur.

Explicit counterexamples (numerically verified, double precision):
- Any rank-one positive `m`: purity `= 1`, `S = 0` for **all** θ. E.g. `m = outer([1,2,0.5],[1,3])` (non-uniform) → zero entropy excess.
- θ-resonant non-uniform `m`: `[[1,e],[e,1]]` at `θ = 2π` gives `‖ρ(2π) − ρ(0)‖_F = 8e−17`.

### Propagation (the part that matters for the physics)

The false equality condition leaks into two **load-bearing Rigorous guarantee claims**:
- §3 (phase structure): *"this excess is guaranteed for any non-uniform magnitude profile."*
- `rem:entropy_application`: *"rigorously guarantees ... whenever `R_σ` are not all equal — i.e., whenever `h` is non-uniform."*

Both are **overclaims**. The correct sufficient condition is a **non-separable (rank ≥ 2)** magnitude matrix. A non-uniform but separable profile (rank-one `m`) produces **no excess at all**. The toy model's `R_σ = h_σ + Σ α_j M_j + β|ψ_σ|²` is generically non-separable thanks to the cross-level couplings, so its conclusion survives — but the guarantee is conditional on non-separability, not mere non-uniformity.

## What this PR changes

1. **Lemma statement** — replaces the false `iff all m_ij equal` with the correct phase-degeneracy / separability (rank-one) characterization, noting all-equal is sufficient but not necessary, and that resonant θ adds further cases.
2. **Proof, Part (a)** — replaces the "hence all `m_ij` equal" non-sequitur with the correct deduction (separable logs / rank-one saturates the bound; converse fails).
3. **§3 and `rem:entropy_application`** — corrects `non-uniform` → `non-separable (rank ≥ 2)`; states the no-excess rank-one case explicitly.
4. **`rem:entropy_application`** — fixes a harmless `θ → −θ` sign mismatch (`ρ(−θ) = ρ(θ)*`, so entropies are unchanged).

## What this PR does NOT change (and why)

The inequalities themselves — **(a)** all-rank purity decrease `Tr(ρ(θ)²) ≤ Tr(ρ(0)²)` and **(b)** rank-2 von Neumann excess `S(θ) ≥ S(0)` — were stress-tested hard (500k+ random positive matrices, dims 2–16, θ up to 20, plus the analytic Perron–Frobenius / binary-entropy arguments) and **held with zero violations**. They keep their **(Rigorous)** label. Only the equality characterization and the dependent guarantee condition are corrected. The general-rank von Neumann counterexample in `rem:vn_general_rank` was independently reproduced and is, if anything, conservative — left unchanged.

## Self-checks

- **Dimensional analysis** — n/a (dimensionless linear-algebra lemma; θ, log-magnitudes, entropies all dimensionless).
- **Limiting cases** — θ → 0: all corrected statements reduce to equality (no phases), consistent. All-equal `m`: still an equality case (special separable profile), consistent with the old statement's sufficient direction.
- **Consistency** — the correction strengthens internal consistency: the rank-one no-excess case was previously contradicted by the "any non-uniform profile" claim. No other result depends on the *strict* version beyond §3 and `rem:entropy_application`, both corrected here. Downstream numerical entropy-ratio results (`S_Lor/S_Riem ≈ 1.68`) are unaffected (toy model is non-separable).
- **Order-of-magnitude / numerics** — counterexamples and the surviving inequalities verified in double precision (rank-one: `S = 0` to `1e−298`; inequality margins `≤ −1e−12` for purity, `≥ +1e−11` for rank-2 vN).
- **Hidden-assumption sweep** — static linear algebra; no time evolution, background, or foliation smuggled in. Zero-entry and θ-sign edge cases checked.
- **Compile** — LaTeX brace/math/environment balance checked locally; `pdflatex` not available in this environment, deferred to the `pdflatex (co-emergence)` CI gate.

## Rigor label

`demotion` — narrows a Rigorous guarantee (`non-uniform` → `non-separable`) and corrects a false equality clause. The headline inequalities remain **(Rigorous)**.

## Relations

- Tracking: Red-team log #75
- Follow-up (precise characterization + Lean): #76, which **informs #45** (Lean formalization must use the corrected condition) and **informs #33**

🤖 Generated with [Claude Code](https://claude.com/claude-code)