### PR TITLE
Restore self-consistency-hierarchy explorations into co-emergence

### DIFF
--- a/programs/co-emergence/README.md
+++ b/programs/co-emergence/README.md
@@ -32,7 +32,7 @@ The paper leads with proved results, then develops the interpretive framework:
 
 - **`fixed-point-existence`** — Companion paper. Provides the Level 2 anchor: Banach contraction for massive fields (Rigorous), Starobinsky exact solution for conformal matter (Rigorous), Schauder existence (conditional). Results are cited, not re-derived.
 
-- **`self-consistency-hierarchy`** (DEPRECATED) — Previous version of this paper. The hierarchy framework originated there; the co-emergence thesis emerged from its explorations (B1, C1, signature-mass debate, mass gap debate). The explorations in that program are the research record for this one.
+- **`self-consistency-hierarchy`** (removed 2026-03, commit 782414f) — Previous version of this paper; the program directory no longer exists. The hierarchy framework originated there, and the co-emergence thesis emerged from its explorations (B1, C1, signature-mass debate, mass gap debate). Those explorations were restored from git history into this program's `explorations/` directory (2026-06), where they remain the research record for the results table below.
 
 ## Key results
 

--- a/programs/co-emergence/explorations/2026-03-02-B1-signature-from-massive-fields.md
+++ b/programs/co-emergence/explorations/2026-03-02-B1-signature-from-massive-fields.md
@@ -1,0 +1,40 @@
+# B1: Lorentzian Signature from Massive Field Content
+
+**Date:** 2026-03-02
+**Issue:** #6
+**Type:** Research exploration
+**Outcome:** Negative result — Level 2 self-consistency does not distinguish metric signatures
+
+---
+
+## Question
+
+Does the self-consistency fixed point of the SCE *require* Lorentzian signature when the field content includes massive fields? Specifically, does the Banach contraction fail on a Riemannian manifold?
+
+## Finding
+
+**No.** The Banach contraction argument carries over to Riemannian manifolds with the same scaling $\kappa \sim (m/M_P)^2 \ll 1$. Every ingredient in the proof has a Riemannian analogue that is mathematically simpler:
+
+- Hyperbolic field equation → elliptic (all eigenvalues positive, unique vacuum)
+- Hadamard state selection → automatic (no ambiguity)
+- Global hyperbolicity + Cauchy surface → compact manifold (no causal structure needed)
+- Hadamard parametrix → Seeley-DeWitt expansion (same structure)
+
+The renormalization toolkit on Riemannian manifolds is well-established (Vassilevich 2003, Birrell-Davies 1982). The trace anomaly has the same form. The mass gap controls non-local kernel decay identically. The SCE has self-consistent solutions on both Lorentzian and Riemannian manifolds.
+
+## Implication for the Gate Decision
+
+B1 is negative. Level 2 self-consistency does not distinguish signatures. Signature must be derived at Level 0 (topology) or via a mechanism outside the current hierarchy.
+
+This does not kill the program — it narrows the search. Per the research plan gate decision, the program survives if C1 succeeds (intersection form → signature bridge).
+
+## Ancillary Finding: Wheeler's Biconformal Gauging
+
+James T. Wheeler (Utah State) has shown rigorously that gauging SO(4,2) on Euclidean space produces Lorentzian signature on submanifolds (arXiv:1808.07083, 0811.0112). The mechanism: quotient the conformal group by the Weyl subgroup, identify orthogonal Lagrangian submanifolds, and these automatically acquire Lorentzian metric. This is a geometric theorem, not a physical argument. It offers a potential alternative mechanism for signature emergence that may connect to the topological level. [UNVERIFIED — Wheeler references need paper-grade verification before citation in .tex files.]
+
+## References (exploratory, unverified unless noted)
+
+- Vassilevich (2003), "Heat kernel expansion: user's manual," Physics Reports 388, 279. [unverified]
+- Birrell & Davies (1982), "Quantum Fields in Curved Space," Cambridge. [unverified]
+- Wheeler (2018), arXiv:1808.07083. [unverified]
+- Wheeler (2008), arXiv:0811.0112, "The existence of time." [unverified]

--- a/programs/co-emergence/explorations/2026-03-02-C1-signature-bridge.md
+++ b/programs/co-emergence/explorations/2026-03-02-C1-signature-bridge.md
@@ -1,0 +1,84 @@
+# C1: Intersection Form to Metric Signature Bridge
+
+**Date:** 2026-03-02
+**Type:** Research exploration
+**Outcome:** Negative result — the intersection form does not determine metric signature. Moreover, a fundamental topological obstruction prevents the manifolds where intersection forms are most powerful from admitting Lorentzian metrics at all.
+
+---
+
+## Question
+
+Does an indefinite intersection form with signature $(1, b_2^-)$ on a smooth 4-manifold imply that compatible metrics must be Lorentzian? Can the Hirzebruch signature theorem $\sigma(\mathcal{M}) = \frac{1}{3}p_1(\mathcal{M})$ connect the intersection form to metric signature via Pontryagin classes?
+
+## Finding
+
+**No, and worse than expected.** There is not merely an absence of a theorem — there is an active obstruction.
+
+### The Euler characteristic obstruction
+
+A closed manifold $M^n$ admits a Lorentzian metric if and only if it admits a nowhere-vanishing vector field, which (by the Poincaré-Hopf theorem) holds if and only if $\chi(M) = 0$ (Geroch 1968, Steenrod 1951).
+
+For a closed simply-connected 4-manifold with intersection form $Q$ of rank $b_2$:
+$$\chi(M) = 2 + b_2$$
+since $b_0 = b_4 = 1$, $b_1 = b_3 = 0$ (by simple connectivity and Poincaré duality).
+
+Therefore $\chi(M) \geq 2$ for any closed simply-connected 4-manifold, and $\chi \geq 3$ whenever $Q$ is nontrivial ($b_2 \geq 1$).
+
+**Consequence:** No closed simply-connected 4-manifold with a nontrivial intersection form admits a Lorentzian metric.
+
+### Why this is devastating
+
+The hierarchy paper's Level 0 relies on Freedman's classification (1982) and Donaldson's constraints (1983), which apply to closed simply-connected 4-manifolds. These are exactly the manifolds where:
+
+- The intersection form classifies the homeomorphism type (Freedman)
+- The intersection form constrains which smooth structures exist (Donaldson)
+- Uncountably many exotic smooth structures live (Taubes 1987)
+
+But these are also exactly the manifolds that **cannot be Lorentzian**. The machinery that makes the topological level powerful is incompatible with the metric-level requirement.
+
+### Escape routes investigated
+
+**1. Non-compact manifolds (exotic $\mathbb{R}^4$'s).** These have $\chi = 1$ (or can be arranged to have $\chi = 0$), so they can be Lorentzian. But $H_2(\mathbb{R}^4) = 0$, so the intersection form is trivial. The intersection form machinery simply does not apply.
+
+**2. Manifolds with boundary.** Can have $\chi = 0$ and nontrivial $H_2$. But:
+- Freedman's classification does not apply directly
+- The intersection form is no longer unimodular (Poincaré duality fails for manifolds with boundary)
+- Exotic smooth structure classification is much less developed
+
+**3. Non-simply-connected manifolds.** Can have $\chi = 0$ with nontrivial topology (e.g., $T^4$ has $\chi = 0$). But:
+- Freedman's classification requires $\pi_1 = 0$
+- The intersection form does not classify the manifold
+- The exotic smooth structure landscape is harder to characterize
+
+**4. Pontryagin class / Hirzebruch route.** The Hirzebruch signature theorem $\sigma = \frac{1}{3}p_1$ connects the intersection form signature to a characteristic class of the tangent bundle. But characteristic classes are topological invariants — they cannot distinguish Riemannian from Lorentzian metrics on the same manifold. The tangent bundle $TM$ has the same Pontryagin classes regardless of the signature of the fiber metric.
+
+### What the intersection form signature actually means
+
+The intersection form signature $\sigma = b_2^+ - b_2^-$ is a topological invariant counting the difference between positive and negative eigenvalues of $Q$ on $H_2(M; \mathbb{Z})$. It constrains which smooth structures exist (Donaldson: a definite form on a smooth manifold must be diagonal). But it says nothing about the metric on the tangent spaces. The word "signature" is a coincidence of terminology, not a mathematical connection.
+
+## Implication for the Gate Decision
+
+C1 is negative. Combined with B1 (also negative), the Phase 2 gate decision is **outcome 3**: the hierarchy cannot derive Lorentzian signature from its current structure. Per the research plan:
+
+> "Both fail: The hierarchy cannot derive Lorentzian signature. The paper must retreat to 'signature assumed' and flag this as the primary open problem. Level 0 is substantially revised."
+
+## Possible Directions Forward
+
+1. **Accept signature as an additional axiom.** Add "the manifold admits a Lorentzian metric" to Level 0. This is honest but weakens the topological program — the signature would not be derived from topology.
+
+2. **Shift to non-compact or bounded manifolds.** Abandon the closed simply-connected setting. Work with manifolds with boundary or non-compact manifolds where Lorentzian metrics exist. This sacrifices the Freedman classification and most of the intersection form machinery. It may require entirely different topological tools.
+
+3. **Wheeler's biconformal gauging.** (From B1 ancillary finding.) Wheeler showed that gauging SO(4,2) on Euclidean space produces Lorentzian signature on submanifolds. This is a conformal-geometric mechanism, not a topological one. It would need to be integrated with the hierarchy at a different level. [UNVERIFIED — needs paper-grade verification.]
+
+4. **Cobordism / manifolds-with-corners approach.** Instead of a single closed 4-manifold, the physical spacetime could be a cobordism between 3-manifolds. Cobordisms naturally have $\chi = 0$ possible (e.g., a cylinder $\Sigma \times [0,1]$ has $\chi = 0$ when $\chi(\Sigma) = 0$). The exotic smooth structure program extends to cobordisms in interesting ways.
+
+5. **Reformulate Level 0 entirely.** The intersection form may not be the right topological invariant for constraining the hierarchy. Other candidates: surgery-theoretic invariants, homotopy type, fundamental group structure.
+
+## References (exploratory, unverified unless noted)
+
+- Geroch (1968), "Spinor structure of space-times in general relativity, I," J. Math. Phys. 9, 1739. [unverified]
+- Steenrod (1951), "The Topology of Fibre Bundles," Princeton. [unverified]
+- Freedman (1982), J. Differential Geometry 17, 357. [verified — see MEMORY.md]
+- Donaldson (1983), J. Differential Geometry 18, 279. [verified — see MEMORY.md]
+- Taubes (1987), J. Differential Geometry 25, 363. [verified — see MEMORY.md]
+- Hirzebruch (1966), "Topological Methods in Algebraic Geometry," Springer. [unverified]

--- a/programs/co-emergence/explorations/2026-03-02-position2-os-critique.md
+++ b/programs/co-emergence/explorations/2026-03-02-position2-os-critique.md
@@ -1,0 +1,291 @@
+# Position 2: Critique of the OS Reconstruction Path to Signature Emergence
+
+**Date:** 2026-03-02
+**Role:** Position agent (adversarial)
+**Debate:** Signature bridge — can OS reconstruction derive Lorentzian signature?
+
+---
+
+## Summary of the Argument Under Attack
+
+The claim is that Osterwalder-Schrader (OS) reconstruction provides the mechanism by which Lorentzian signature emerges from the self-consistency hierarchy. The chain:
+
+1. Self-consistency constraints determine field content with mass gap
+2. Mass gap implies reflection positivity
+3. Reflection positivity implies OS reconstruction to Lorentzian theory
+4. Lorentzian theory = physical content; Riemannian theory = Euclidean section
+5. Therefore signature is derived, not assumed
+
+I will demonstrate that this chain breaks at multiple points, with at least two failures that are fatal on their own.
+
+---
+
+## A. The Flat-Space Problem
+
+**Verdict: FATAL**
+
+### The OS axioms assume flat Euclidean space
+
+The Osterwalder-Schrader axioms (OS0-OS4) are formulated on flat Euclidean R^d. The five axioms are:
+
+- **OS0 (Analyticity):** Correlation functions are entire analytic
+- **OS1 (Regularity):** Polynomial growth bound on the generating functional
+- **OS2 (Euclidean Invariance):** S is invariant under translations, rotations, reflections of R^d
+- **OS3 (Reflection Positivity):** Positivity under time reflection across a hyperplane in R^d
+- **OS4 (Ergodicity):** Time translation subgroup acts ergodically
+
+The Wightman axioms they reconstruct are formulated on flat Minkowski space. OS2 requires invariance under the full Euclidean group E(d), which is the isometry group of flat Euclidean space. The reconstruction theorem then proves that this invariance analytically continues to Poincare invariance of the Wightman functions on flat Minkowski space.
+
+### The circularity
+
+The self-consistency hierarchy proposes to derive spacetime itself from topological constraints. The metric is not given — it emerges at Level 2 via the semiclassical Einstein equation. Using OS reconstruction requires:
+
+1. A flat Euclidean background on which to define the Schwinger functions
+2. Full Euclidean group invariance (OS2)
+3. A preferred reflection hyperplane (OS3)
+4. Translation invariance to define the time-translation subgroup (OS4)
+
+Every one of these is a background structure. The hierarchy's Axiom 3 states: "No non-geometric entities appear in the fundamental description," and FRAMEWORK.md warns explicitly against "smuggling in a background: any fixed structure that other things are defined 'on top of'." OS reconstruction requires exactly this: a fixed flat background.
+
+### Has OS been generalized to curved spacetime?
+
+Only partially. Jaffe and Ritter (2007) proved reflection positivity results for scalar and Dirac fields on certain curved Riemannian manifolds (Comm. Math. Phys. 270, 545-572). But this generalization requires:
+
+- A **static Killing field** playing the role of Euclidean time
+- The manifold must admit this specific symmetry
+- The reflection is across the fixed-point set of this Killing field
+
+A static Killing field is a very strong assumption. It means the curved spacetime has a preferred "time direction" built into its symmetry group. For the hierarchy, which proposes to derive the time direction from topology, requiring a static Killing field is circular: you need the time direction to define the reflection that is supposed to derive the time direction.
+
+Furthermore, a general solution of the semiclassical Einstein equation at Level 2 has no reason to admit a static Killing field. Cosmological solutions are not static. The Jaffe-Ritter generalization covers only a measure-zero subset of physically relevant spacetimes.
+
+### Why this is fatal
+
+The OS argument claims: "topology determines field content, field content determines reflection positivity, reflection positivity reconstructs Lorentzian theory." But reflection positivity is defined on a flat background (standard OS) or on a static background (Jaffe-Ritter). The hierarchy claims to derive the background. This is circular:
+
+> To derive the background, you need reflection positivity.
+> To define reflection positivity, you need the background.
+
+No known generalization of OS reconstruction removes this dependence on background structure.
+
+**References:**
+- Osterwalder & Schrader (1973), Comm. Math. Phys. 31, 83. [unverified]
+- Osterwalder & Schrader (1975), Comm. Math. Phys. 42, 281. [unverified]
+- Jaffe & Ritter (2007), Comm. Math. Phys. 270, 545. [unverified — found via web search of Jaffe publications; title "Quantum Field Theory on Curved Backgrounds. I."]
+
+---
+
+## B. Reflection Positivity Smuggles in Time
+
+**Verdict: FATAL (independent of A)**
+
+### What reflection positivity requires
+
+Reflection positivity (OS3) is defined with respect to a codimension-1 hyperplane in Euclidean space. Let theta denote reflection across this hyperplane. The axiom states:
+
+For functions f supported on one side of the hyperplane ("the future"), the inner product satisfies: 0 <= <theta(f), f>.
+
+The hyperplane divides Euclidean space into two half-spaces. The direction perpendicular to the hyperplane becomes, after Wick rotation, the time direction. **The choice of hyperplane IS the choice of time direction.**
+
+### The Axiom 2 violation
+
+FRAMEWORK.md states Axiom 2: "The fundamental description contains no evolution parameter. All equations are constraints on the structure of the block, not rules for generating it."
+
+The mechanical test from FRAMEWORK.md: "can this formulation be expressed entirely as a constraint on a four-dimensional block with no preferred slicing?"
+
+Reflection positivity requires:
+1. Choosing a hyperplane (a preferred 3-dimensional slice)
+2. Distinguishing "one side" from "the other side" (a preferred direction)
+3. Defining reflection across this hyperplane (a preferred map)
+
+This is a **preferred foliation** in everything but name. The OS argument claims to derive the timelike direction from reflection positivity. But reflection positivity is defined by choosing a direction and calling it timelike. The derivation is circular.
+
+### Can reflection positivity be formulated without a preferred hyperplane?
+
+Research shows no affirmative answer. The mathematical structure of reflection positivity is inherently tied to a codimension-1 decomposition. Jaffe and Ritter's work on reflection positivity and monotonicity (2007) formulates reflection positivity on manifolds but still requires a specific reflection map with a fixed-point set that plays the role of the temporal boundary.
+
+The very concept of "reflection" requires something to reflect across. That something is a preferred spatial slice. Removing it collapses the entire OS framework.
+
+### The contrast with the hierarchy's aspiration
+
+The hierarchy proposes that the block satisfies all constraints simultaneously with no preferred slicing. OS reconstruction requires choosing a slicing first. These are logically incompatible. The argument does not "derive" the slicing from the consistency constraints — it assumes the slicing to define the constraints.
+
+---
+
+## C. The Mass Gap Is Not Derived
+
+**Verdict: SERIOUS BUT POTENTIALLY SOLVABLE**
+
+### The chain's weakest empirical link
+
+Link 1 of the argument is: "Self-consistency constraints determine field content with mass gap." This is the claim that the topological/smooth structure of the block, via the self-consistency hierarchy, determines the matter content, and that this matter content has a mass gap.
+
+There is no known mathematical mechanism for this.
+
+### The Asselmeyer-Maluga program
+
+The closest existing work is by Asselmeyer-Maluga and collaborators, who have explored connections between exotic smooth structures and matter content since the early 2000s. They claim that exotic smoothness generates source terms in the Einstein-Hilbert action. However:
+
+1. The program is not widely accepted in the mathematical physics community
+2. The claim that exotic smoothness on R^4 generates specific particle content (fermions, gauge fields) relies on identifications that have been challenged — notably, Duston (arXiv:0911.4068) found a negative result showing the assumed connection between geometry and smoothness structure was not as direct as claimed
+3. Even if the Asselmeyer-Maluga program were fully validated, it does not establish a mass gap. It would establish that topology generates matter content, but whether that content has a mass gap is a separate question — one that is equivalent to the Clay Millennium Problem for Yang-Mills theory
+
+### What remains without the mass gap
+
+Without Link 1, the OS argument reduces to:
+
+> IF there is a mass gap, THEN the Euclidean theory satisfies reflection positivity, THEN OS reconstruction gives a Lorentzian theory.
+
+This is a conditional statement. It is not a derivation of signature from topology. The antecedent (mass gap) is:
+- Not derived from the hierarchy
+- Not known to follow from topology
+- Equivalent to one of the hardest unsolved problems in mathematical physics
+
+### Why "potentially solvable"
+
+Unlike attacks A and B, which identify logical circularities, attack C identifies a missing step. It is conceivable that future work could establish a connection between exotic smooth structures and mass gaps. The self-consistency hierarchy is a research program, and identifying required results is legitimate. But the OS argument, as currently stated, treats this link as if it were established or at least plausible, when it is in fact the least understood step in the entire chain.
+
+---
+
+## D. The Conformal Factor Problem
+
+**Verdict: SERIOUS BUT POTENTIALLY SOLVABLE**
+
+### The problem
+
+The Euclidean Einstein-Hilbert action is:
+
+S_E[g] = -(1/16 pi G) integral(R sqrt(g) d^4x)
+
+Under a conformal transformation g -> Omega^2 g, the scalar curvature transforms, and the action becomes unbounded below. Specifically, the kinetic term for the conformal factor has the wrong sign: conformal transformations can make the action arbitrarily negative.
+
+This is the conformal factor problem, identified by Gibbons, Hawking, and Perry (1978). It means:
+
+1. The Euclidean gravitational path integral integral(e^{-S_E[g]} Dg) does not converge
+2. The Euclidean gravitational partition function is not well-defined as a real integral
+3. The Schwinger functions of a gravitational theory on Euclidean space may not satisfy the OS axioms
+
+### Why this matters for the OS argument
+
+OS reconstruction starts from a well-defined Euclidean QFT satisfying OS0-OS4. If the Euclidean gravitational theory does not exist as a well-defined theory (because the path integral diverges), there is nothing to reconstruct from.
+
+The standard GHP prescription rotates the conformal mode contour to the imaginary axis. But:
+- This is an ad hoc fix, not derived from first principles
+- It changes the space of metrics being integrated over
+- It is unclear whether the resulting "Euclidean" theory satisfies reflection positivity after the contour rotation, since the contour rotation itself is signature-dependent
+
+### The self-consistency hierarchy angle
+
+The hierarchy proposes to replace the gravitational path integral with a measure on smooth structures (Level 1). This potentially circumvents the conformal factor problem, since the measure is on Sm(M) rather than on metrics. But the OS argument requires a Euclidean QFT at the metric level (not the smooth-structure level) to define Schwinger functions. So the OS argument operates precisely at the level where the conformal factor problem bites.
+
+### Why "potentially solvable"
+
+The conformal factor problem is a problem for the gravitational path integral in general, not specific to the OS argument. Various proposals exist (GHP contour rotation, Lorentzian path integrals avoiding the Euclidean sector entirely, non-perturbative lattice approaches). If any of these are vindicated, the obstruction lifts. But as of now, the Euclidean gravitational partition function is not rigorously defined, and claiming OS reconstruction applies to gravity assumes a resolution that does not yet exist.
+
+**References:**
+- Gibbons, Hawking, Perry (1978), "Path Integrals and the Indefiniteness of the Gravitational Action," Nucl. Phys. B 138, 141. [unverified]
+
+---
+
+## E. Is the "Mutual Dependence" Genuine or Verbal?
+
+**Verdict: SERIOUS BUT POTENTIALLY SOLVABLE**
+
+### The claim under scrutiny
+
+The OS argument asserts: "Signature is meaningless without mass and mass is meaningless without signature." This is presented as a deep insight about the co-emergence of signature and matter content.
+
+### The Riemannian QFT counter-argument
+
+Consider a quantum field theory on a Riemannian 4-manifold with positive-definite metric. The Laplacian Delta = -nabla^2 has a real, positive spectrum. Add a parameter m^2:
+
+(-Delta + m^2) phi = 0
+
+This equation is perfectly well-defined. The Green's function exists. The QFT is self-consistent. On a compact manifold, the theory has a spectral gap (the smallest eigenvalue of -Delta + m^2 is strictly positive).
+
+The parameter m^2 plays the same mathematical role as it does in Lorentzian QFT: it shifts the spectrum and controls the decay of correlation functions. We don't call it "mass" in the Riemannian context because there is no energy-momentum relation E^2 = p^2 + m^2, but this is a matter of physical interpretation, not mathematical content.
+
+### The crucial test
+
+The Riemannian QFT with parameter m^2 > 0:
+- Has well-defined correlation functions
+- Has a spectral gap
+- Is self-consistent
+- Satisfies the self-consistency hierarchy at Level 2 (as shown in exploration B1: the SCE Banach contraction works equally well on Riemannian manifolds)
+
+So what exactly is "meaningless" about mass without Lorentzian signature? The parameter exists, the theory is consistent, the physics (in the sense of self-consistent constraint satisfaction) works. The claim of mutual dependence appears to conflate:
+
+1. **Mathematical fact:** the parameter m^2 is well-defined regardless of signature
+2. **Physical interpretation:** we call it "mass" only when it appears in a Lorentzian energy-momentum relation
+
+If the "mutual dependence" is about interpretation rather than mathematics, it cannot drive a mathematical derivation of signature. You cannot derive the signature of the metric from the fact that we have different names for m^2 in different signatures.
+
+### The strongest version of the counter
+
+From exploration B1: "The Banach contraction argument carries over to Riemannian manifolds with the same scaling kappa ~ (m/M_P)^2 << 1. Every ingredient in the proof has a Riemannian analogue that is mathematically simpler."
+
+The self-consistency hierarchy, as currently formulated, is equally satisfied by a Riemannian block. The "mutual dependence" between signature and mass does not exist at the mathematical level. Both are well-defined independently.
+
+---
+
+## F. FRAMEWORK.md Hidden Assumptions Check
+
+### F1. Time evolution sneaking back in?
+
+**YES — FATAL.** Reflection positivity requires:
+- A preferred "Euclidean time" direction (the direction perpendicular to the reflection hyperplane)
+- A "time translation" subgroup (OS4: ergodicity of time translations)
+- A distinction between "future" and "past" (one side of the hyperplane vs. the other)
+
+The entire OS framework is built on the concept of Euclidean time. The Wick rotation to Lorentzian time is the punchline. FRAMEWORK.md warns: "Watch for it everywhere. It hides behind innocent language." In the OS argument, it hides behind the language of "reflection" and "positivity," but the mathematical content is: choose a time direction, verify a positivity condition with respect to it, then continue analytically to real time.
+
+This is precisely the kind of hidden temporal structure that Axiom 2 prohibits.
+
+### F2. Smuggled background?
+
+**YES — FATAL.** As detailed in Attack A:
+- The OS axioms require flat Euclidean R^d (OS2: Euclidean invariance)
+- The Jaffe-Ritter generalization requires a static Killing field
+- Both are background structures
+
+The hierarchy claims: "The only thing that should be fixed is the constraint structure itself." The OS argument fixes a background spacetime.
+
+### F3. Taking signature for granted?
+
+**YES — FATAL.** This is the core irony. The OS argument claims to derive signature, but:
+- The starting point is a Euclidean (Riemannian) theory — this assumes positive-definite signature
+- The endpoint is a Lorentzian theory — this assumes (1,3) signature
+- The mechanism (Wick rotation) maps one assumed signature to another
+
+The argument does not derive signature from scratch. It maps one signature to another via an analytic continuation that is defined only when both signatures exist. The question "why Lorentzian rather than Riemannian?" is answered by "because we applied OS reconstruction," but OS reconstruction works precisely because you set up the Euclidean theory in the right way to produce a Lorentzian answer. The setup encodes the answer.
+
+### F4. Taking dimensionality for granted?
+
+**MINOR.** The OS axioms work in any dimension d. This is not a specific failure of the OS argument, though the hierarchy's dimensionality argument (Section 4 of the paper) is independent of OS reconstruction.
+
+### F5. Observer-dependent language?
+
+**NO.** The OS framework is formulated in terms of correlation functions and mathematical axioms, not observers or measurements.
+
+---
+
+## Summary Verdict
+
+| Attack | Verdict | Survivable? |
+|--------|---------|-------------|
+| A. Flat-space / background dependence | FATAL | No — OS requires background the hierarchy claims to derive |
+| B. Reflection positivity = preferred foliation | FATAL | No — directly violates Axiom 2 |
+| C. Mass gap not derived | SERIOUS | Yes — a research gap, not a logical impossibility |
+| D. Conformal factor problem | SERIOUS | Yes — general problem, not specific to OS argument |
+| E. "Mutual dependence" is verbal | SERIOUS | Yes — may be reformulable, but current version is empty |
+| F1. Hidden time | FATAL | No — OS is built on Euclidean time |
+| F2. Smuggled background | FATAL | No — same as A |
+| F3. Signature assumed | FATAL | No — OS maps one signature to another, doesn't derive from nothing |
+
+### The core problem
+
+Attacks A, B, and F1-F3 are all manifestations of the same fundamental issue: **OS reconstruction is a tool for relating two theories that are defined on backgrounds with known signatures. It cannot derive signature from a theory that has no signature.**
+
+The self-consistency hierarchy aspires to derive spacetime structure from topological constraints. OS reconstruction requires spacetime structure as input. These are logically incompatible goals. OS reconstruction might be a useful approximation for understanding how subsystems experience Lorentzian physics within the hierarchy, but it cannot be the mechanism by which the hierarchy produces Lorentzian signature in the first place.
+
+The OS argument, if accepted, would make the hierarchy dependent on exactly the kind of background structure it claims to eliminate. It would be a step backward from the framework's ambitions, not a step forward.

--- a/programs/co-emergence/explorations/2026-03-02-position3-co-emergence.md
+++ b/programs/co-emergence/explorations/2026-03-02-position3-co-emergence.md
@@ -1,0 +1,171 @@
+# Position 3: Signature and Mass as Co-Emergent via Joint Fixed Point
+
+**Date:** 2026-03-02
+**Role:** Position agent (alternative to OS reconstruction)
+**Status:** Complete
+
+---
+
+## Thesis
+
+Metric signature and mass spectrum are not independently specifiable. They co-define each other through a joint fixed-point condition: the metric determines what "mass" means (via the spectral theory of the wave operator), while the mass content determines the metric (via the semiclassical Einstein equation). Lorentzian signature with m > 0 is the unique nontrivial fixed point of this joint system. Riemannian signature admits only the trivial fixed point (no propagating degrees of freedom, no mass spectrum, no physics).
+
+This avoids the Osterwalder-Schrader route entirely. Instead of starting from a Euclidean theory and reconstructing Lorentz structure, we argue that the signature IS the mass content and vice versa: neither exists without the other, and their mutual consistency forces the Lorentzian solution.
+
+---
+
+## The Argument in Three Steps
+
+### Step 1: The signature-dependent wave operator (Sketch)
+
+On a 4-manifold M equipped with a metric g of signature (p, q), the natural wave operator for a scalar field of mass m is:
+
+$$\Box_g \phi + m^2 \phi = 0$$
+
+where $\Box_g = g^{\mu\nu} \nabla_\mu \nabla_\nu$.
+
+The character of this equation depends entirely on signature:
+
+- **Lorentzian (1,3):** The operator $\Box_g + m^2$ is *hyperbolic*. Solutions propagate. The Cauchy problem is well-posed. The dispersion relation $-\omega^2 + k^2 + m^2 = 0$ defines a mass shell — a real, physical constraint separating massive from massless excitations. The mass gap (lowest nonzero eigenvalue) is physically meaningful: it determines a finite correlation length $\xi \sim 1/m$.
+
+- **Riemannian (4,0) or (0,4):** The operator $\Box_g + m^2$ is *elliptic*. There is no propagation, no Cauchy problem, no dispersion relation, no mass shell. The equation $\Delta \phi + m^2 \phi = 0$ is a Helmholtz equation. Solutions are either exponentially decaying or oscillatory depending on boundary conditions, but there is no distinction between "massive" and "massless" excitations that corresponds to physical propagation. The parameter $m$ enters as a coefficient in an eigenvalue problem, not as a physical mass.
+
+**Key point:** The *concept of mass* requires hyperbolicity. Without a timelike direction, there is no dispersion relation, no mass shell, no distinction between propagating and non-propagating modes. Mass is not a property that fields can have on a Riemannian manifold — not in the sense relevant to physics.
+
+This is not an approximation or a limit. It is a categorical distinction: the hyperbolic/elliptic divide changes the mathematical CHARACTER of the solutions, not just their quantitative behavior.
+
+### Step 2: The mass-dependent stress-energy (Sketch)
+
+In the other direction: the stress-energy tensor $T_{\mu\nu}$ depends on the field content, including its mass spectrum. Via the semiclassical Einstein equation:
+
+$$G_{\mu\nu}[g] = 8\pi G \langle T_{\mu\nu}[\phi, g] \rangle_g$$
+
+the metric g is determined by the quantum fields $\phi$ living on it. But the expectation value $\langle T_{\mu\nu} \rangle_g$ depends on:
+
+1. The *state* of the quantum field, which is defined using the spectral decomposition of $\Box_g + m^2$
+2. The *mass* m, which only has physical meaning if g is Lorentzian (Step 1)
+3. The *renormalization*, which requires the Hadamard condition — a condition on the short-distance singularity structure of the two-point function that is formulated differently for hyperbolic vs. elliptic operators
+
+The companion paper (fixed-point-existence.tex) establishes that the map $g \mapsto G^{-1}_{\mu\nu}(8\pi G \langle T_{\mu\nu} \rangle_g)$ has a fixed point under Banach contraction with $\kappa \sim (m/M_P)^2 \ll 1$. But this entire construction assumes Lorentzian signature. The contraction estimate uses the Hadamard parametrix, which is a property of the hyperbolic Green's function.
+
+**Key point:** The fixed-point mechanism of the companion paper does not merely *happen* to use Lorentzian signature. It *requires* it. The contraction estimate breaks down for elliptic operators because the Green's function structure is qualitatively different.
+
+### Step 3: The joint fixed-point equation (Conjecture)
+
+Combine Steps 1 and 2 into a single self-consistency condition. Define the joint state as the pair $(g, \Phi)$ where g is a metric on M (of any signature) and $\Phi$ is the field content (including mass spectrum). The self-consistency map is:
+
+$$\mathcal{F}: (g, \Phi) \mapsto (g', \Phi')$$
+
+where:
+- $g' = \text{SCE}(g, \Phi)$: solve the semiclassical Einstein equation for the metric consistent with the quantum fields $\Phi$ on background $g$
+- $\Phi' = \text{Spec}(g')$: determine the physically meaningful field content (mass spectrum, propagating degrees of freedom) from the spectral theory of the wave operator on $(M, g')$
+
+A self-consistent solution is a fixed point: $\mathcal{F}(g, \Phi) = (g, \Phi)$.
+
+**Conjecture (The Signature Selection Principle):** The joint map $\mathcal{F}$ has exactly two classes of fixed points:
+
+1. **Trivial:** $g$ is Riemannian, $\Phi = \emptyset$ (no propagating fields, no mass spectrum). This is self-consistent because: on a Riemannian manifold, there are no propagating degrees of freedom (Step 1), so $\langle T_{\mu\nu} \rangle = 0$, so the SCE gives $G_{\mu\nu} = 0$, which is satisfied by Ricci-flat Riemannian metrics. The fixed point exists but has no physical content.
+
+2. **Nontrivial:** $g$ is Lorentzian, $\Phi$ has $m > 0$. This is self-consistent because: Lorentzian signature allows propagating massive fields (Step 1), massive fields produce nonzero $\langle T_{\mu\nu} \rangle$ that sources curvature (Step 2), and the companion paper's fixed-point theorem guarantees a self-consistent solution in the Lorentzian sector.
+
+The claim is that there are no OTHER fixed points — no self-consistent solution with Riemannian signature and nontrivial field content, and no self-consistent solution with Lorentzian signature and vanishing field content (the latter would be classical vacuum GR, which does exist but has $\Phi = \emptyset$ and thus no mass, placing it in the trivial class at the quantum level).
+
+---
+
+## Supporting Mathematical Structures
+
+### A. Wigner classification as a consistency check
+
+Wigner (1939) classified particles as irreducible unitary representations of the Poincare group ISO(3,1). The massive representations have little group SO(3), giving spin. The key observation: the Poincare group IS the isometry group of Lorentzian Minkowski space. The Euclidean isometry group ISO(4) has different representation theory — in particular, the little group for a "massive" representation would be SO(3) as well (stabilizer of a point in R^4 with |p|^2 = m^2 is SO(3)), but the representations are NOT unitary in the sense needed for quantum mechanics because there is no distinction between timelike and spacelike momenta. The mass shell is a 3-sphere in momentum space, not a hyperboloid. **(Sketch)**
+
+The Wigner classification is not an independent argument for Lorentzian signature — it assumes Poincare invariance. But it serves as a *consistency check* on the fixed-point picture: if the fixed point produces a Lorentzian metric, then the effective particle content must organize into Poincare representations, and the mass spectrum must sit on hyperboloid mass shells. This is a nontrivial self-consistency condition that the fixed point must satisfy.
+
+### B. Bisognano-Wichmann and modular flow
+
+The Bisognano-Wichmann theorem (1975, 1976) establishes that for a quantum field theory satisfying the Wightman axioms, the Tomita-Takesaki modular automorphism group associated with a wedge region and the vacuum state IS the one-parameter group of Lorentz boosts preserving that wedge.
+
+This means: the algebraic structure of the quantum field theory (the von Neumann algebra of observables in a wedge region, together with the vacuum state) *encodes* the Lorentzian geometry. The boost generator is not put in by hand — it emerges from the modular theory of the algebra.
+
+In the co-emergence picture, this provides the mechanism by which Step 2 works: the quantum fields do not merely "source curvature" via the stress tensor. The algebraic structure of the field theory *contains* the geometric information about the metric signature. The Bisognano-Wichmann theorem makes the field → geometry direction mathematically precise, at least for wedge regions in Minkowski space.
+
+**Limitation (honest):** Bisognano-Wichmann is proven for QFT on Minkowski space. Extending it to curved spacetimes is an open problem (though partial results exist for wedge-like regions in static spacetimes). The theorem cannot be used as-is to derive signature from scratch — it assumes Lorentzian signature to define wedge regions. But it provides evidence that the field content and the signature are algebraically entangled, which is what the co-emergence picture requires. **(Sketch)**
+
+### C. Connes-Rovelli thermal time as a consequence, not a foundation
+
+Connes and Rovelli (1994) proposed the thermal time hypothesis: in a generally covariant quantum theory, physical time flow is determined by the modular automorphism group of the algebra of observables in a given state. This uses Tomita-Takesaki theory to extract a notion of time from the algebraic structure alone.
+
+In the co-emergence framework, the Connes-Rovelli thermal time is a *consequence* of the nontrivial fixed point, not a route to it. Once the joint fixed point selects Lorentzian signature and nontrivial field content, the modular structure of the resulting QFT automatically generates the time flow. The thermal time hypothesis explains why time appears in the effective description — but it does not explain why the signature is Lorentzian in the first place, because it applies equally to any state on a von Neumann algebra (including states on algebras that have nothing to do with spacetime).
+
+**Warning check (Axiom 2):** The thermal time hypothesis introduces a "flow" — a one-parameter automorphism group. This is a time parameter and appears to violate Axiom 2. However, in the co-emergence picture, the modular flow is a property of the effective description at Level 3 of the hierarchy (the density matrix obtained by marginalizing the smooth-structure measure). It is not present in the fundamental description. The flow is emergent, not fundamental. This must be stated carefully: the modular automorphism group is real mathematical structure, but it is structure of the algebra of observables, not of the block itself. **(Sketch)**
+
+### D. Tegmark's anthropic argument recast as a fixed-point selection
+
+Tegmark (1997) argued that only (3+1)-dimensional spacetime supports well-posed PDEs (hyperbolicity), stable atoms, and thus observers. This is usually presented as an anthropic selection argument. In the co-emergence framework, it can be recast:
+
+The hyperbolic/elliptic distinction is not about observers — it is about whether the self-consistency map $\mathcal{F}$ has nontrivial fixed points at all. In non-Lorentzian signatures:
+- (4,0) and (0,4): Elliptic. No propagation. Trivial fixed point only.
+- (2,2): Ultrahyperbolic. Ill-posed Cauchy problem. The SCE map is not well-defined (no unique solution to source). No fixed point.
+- (3,1) and (1,3): Hyperbolic. Well-posed. Nontrivial fixed points exist.
+
+This removes the anthropic reasoning. The signature is not selected because observers require it. It is selected because the self-consistency constraints have nontrivial solutions ONLY for Lorentzian signature. **(Conjecture)**
+
+---
+
+## Where This Position Is Underspecified
+
+1. **The map $\mathcal{F}$ is not rigorously defined.** The "Spec" map (extracting field content from a metric) is schematic. Making it precise requires defining what "physically meaningful field content" means on a generic curved Lorentzian manifold — this is essentially the problem of defining QFT on curved spacetime, which is only solved in special cases.
+
+2. **The claim that Riemannian fixed points are trivial is not proven.** I have argued that elliptic operators don't support propagating degrees of freedom, which is standard. But ruling out ALL nontrivial self-consistent Riemannian configurations requires showing that there is no way to define a nontrivial stress-energy tensor on a Riemannian manifold that is self-consistently sourced. Instantons (finite-action Euclidean solutions) exist and are nontrivial — but they do not propagate and have $\langle T_{\mu\nu} \rangle = 0$ in the vacuum, which supports the claim.
+
+3. **The ultrahyperbolic case (2,2) needs more analysis.** I claimed the Cauchy problem is ill-posed, which is standard (the Asgeirsson mean value theorem prevents localized initial data). But "no fixed point" is stronger than "ill-posed Cauchy problem" and has not been established.
+
+4. **Connection to the self-consistency hierarchy is incomplete.** This position operates at Level 2 (metric level). How the signature selection propagates to Level 0 (topological) and Level 1 (smooth) is not addressed. The C1 exploration found that closed simply-connected 4-manifolds cannot be Lorentzian (Euler characteristic obstruction), which means the topological level must use non-compact or non-simply-connected manifolds — and this position does not resolve that tension.
+
+5. **The companion paper's contraction estimate is used but not extended.** The Banach contraction with $\kappa \sim (m/M_P)^2$ is established for Lorentzian signature. I claimed it "breaks down" for Riemannian signature. This is plausible (the Green's function structure changes qualitatively) but the failure has not been demonstrated by explicit calculation.
+
+---
+
+## FRAMEWORK.md Warning Checks
+
+**Time evolution sneaking in?** The map $\mathcal{F}$ is defined as a self-consistency constraint, not a dynamical evolution. The "iteration" $\mathcal{F}^n(g_0, \Phi_0) \to (g_*, \Phi_*)$ is computational, not physical (per FRAMEWORK.md warning about confusing the map for the territory). The fixed point itself is a four-dimensional constraint with no preferred slicing. However, Step 1 uses the Cauchy problem and well-posedness, which are inherently temporal concepts (they require an initial data surface). This is a tension: the argument for WHY Lorentzian signature is special uses the very temporal structure that Axiom 2 forbids at the fundamental level. Resolution: the Cauchy problem characterizes the EFFECTIVE behavior at Level 2, not the fundamental description. The block satisfies the field equation as a four-dimensional constraint; the well-posedness of the Cauchy problem is a PROPERTY of this constraint (it admits unique solutions given boundary data on a hypersurface), not a PROCEDURE used to generate the solution.
+
+**Smuggled background?** The map $\mathcal{F}$ acts on the space of metrics on a fixed manifold M. This is a background topological structure. In the full hierarchy, M should itself be determined by the constraints (Level 0). This position operates at Level 2 and takes M as given, which is an acknowledged limitation.
+
+**Preferred foliation?** No. The fixed-point equation $\mathcal{F}(g, \Phi) = (g, \Phi)$ is covariant. It does not select a foliation.
+
+**Metric signature taken for granted?** No — this is explicitly what the argument addresses. The signature is not assumed; it is derived as a property of the nontrivial fixed point.
+
+**Dimensionality taken for granted?** Yes. The argument assumes a 4-manifold. This is a limitation shared with the entire hierarchy paper. The framework's explanation for four-dimensionality (unique richness of exotic smooth structures) operates at Level 1, not Level 2.
+
+---
+
+## How This Differs from the OS Position
+
+The Osterwalder-Schrader reconstruction approach starts from a well-defined Euclidean theory and shows that, given certain conditions (reflection positivity, mass gap, regularity), one can analytically continue to a Lorentzian theory. The signature appears through the Wick rotation.
+
+The co-emergence approach does NOT start from a Euclidean theory. It starts from the self-consistency constraint on the PAIR (metric, field content) and shows that the constraint has nontrivial solutions only for Lorentzian signature. No analytic continuation is involved. No Euclidean formulation is needed. The argument is:
+
+1. Define the self-consistency map on the space of ALL metrics (any signature).
+2. Show that the only nontrivial fixed points are Lorentzian.
+3. The Lorentzian signature is a CONSEQUENCE of requiring nontrivial self-consistent physics, not a CONSEQUENCE of analytic continuation from Euclidean space.
+
+The key advantage: no Wick rotation means no assumption about the relationship between Euclidean and Lorentzian formulations. The co-emergence argument is purely within the constraint framework of Axiom 1.
+
+The key disadvantage: the argument is less rigorous. OS reconstruction is a proven theorem (under its assumptions). The co-emergence fixed-point selection is a conjecture supported by plausibility arguments.
+
+---
+
+## Key References
+
+- Wigner, E. P. (1939). "On unitary representations of the inhomogeneous Lorentz group." Ann. Math. 40, 149-204. [Unverified — standard reference, needs paper-grade verification]
+- Bisognano, J. J. and Wichmann, E. H. (1975). "On the duality condition for a Hermitian scalar field." J. Math. Phys. 16, 985. [Unverified — needs verification]
+- Bisognano, J. J. and Wichmann, E. H. (1976). "On the duality condition for quantum fields." J. Math. Phys. 17, 303. [Unverified — needs verification]
+- Connes, A. and Rovelli, C. (1994). "Von Neumann algebra automorphisms and time-thermodynamics relation in generally covariant quantum theories." Class. Quantum Grav. 11, 2899. [Unverified — confirmed to exist via web search, details need verification]
+- Tegmark, M. (1997). "On the dimensionality of spacetime." Class. Quantum Grav. 14, L69. [Unverified — confirmed to exist via web search, details need verification]
+- Haag, R. and Kastler, D. (1964). "An algebraic approach to quantum field theory." J. Math. Phys. 5, 848-861. [Unverified — standard reference]
+
+---
+
+## Summary
+
+The co-emergence position proposes that Lorentzian signature is not derived from topology (the C1 route, which failed), nor reconstructed from Euclidean data (the OS route), but is the unique solution to a joint self-consistency constraint between metric and field content. Mass requires hyperbolicity; hyperbolicity requires Lorentzian signature; massive fields source the metric via the SCE; the metric determines the signature. The circle closes only for Lorentzian signature with m > 0. This is a self-consistency argument in the spirit of Axiom 1, operating at Level 2 of the hierarchy.

--- a/programs/co-emergence/explorations/2026-03-02-research-plan.md
+++ b/programs/co-emergence/explorations/2026-03-02-research-plan.md
@@ -1,0 +1,307 @@
+# Research Plan: Formalizing the Self-Consistency Hierarchy
+
+**Date:** 2026-03-02
+**Branch:** wdw-timeless-block
+**Type:** Planning artifact
+**Outcome:** Phased research plan with dependency graph, deliverables, and kill conditions
+
+---
+
+## Context
+
+The self-consistency hierarchy paper (`src/self-consistency-hierarchy.tex`) proposes a four-level framework for timeless quantum gravity. Nearly all claims are labeled Conjecture. The companion paper (`src/fixed-point-existence.tex`) provides the only rigorous anchor, at Level 2. This plan maps every open problem into a prioritized sequence with dependencies, tractability assessments, and concrete deliverables.
+
+The plan is organized by *dependency and risk*, not by level number. We attack the most tractable problem first (Level 2 completion), then the most dangerous (the signature bridge), then the problems that depend on those results (Levels 1 and 3).
+
+---
+
+## Dependency Graph
+
+```
+                    ┌─────────────────────────────┐
+                    │  A1: H^s operator-norm bound │  (issue #20)
+                    │  Level 2 — Rigorous upgrade  │
+                    └──────────────┬───────────────┘
+                                   │
+                    ┌──────────────▼───────────────┐
+                    │  A2: Uniform stress-energy    │  (see issue table below)
+                    │  bound (A3 extension)         │
+                    │  Level 2 — general case       │
+                    └──────────────┬───────────────┘
+                                   │
+          ┌────────────────────────┼────────────────────────┐
+          │                        │                        │
+┌─────────▼──────────┐  ┌─────────▼──────────┐  ┌─────────▼──────────┐
+│ B1: Lorentzian sig │  │ C1: Signature      │  │                    │
+│ from massive fields│  │ bridge (topology   │  │                    │
+│ Level 2            │  │ → metric)          │  │                    │
+│ (issue #6)         │  │ Level 0 ↔ Level 2  │  │                    │
+│                    │  │ (see issue table below)        │  │                    │
+└─────────┬──────────┘  └─────────┬──────────┘  │                    │
+          │                       │              │                    │
+          └───────────┬───────────┘              │                    │
+                      │                          │                    │
+           ┌──────────▼──────────┐    ┌──────────▼──────────┐        │
+           │ GATE: Is Level 0   │    │ D1: Natural measure  │        │
+           │ viable?            │    │ on Sm(M)             │        │
+           │ (Phase 2 verdict)  │    │ Level 1              │        │
+           └──────────┬─────────┘    │ (see issue table below)          │        │
+                      │              └──────────┬───────────┘        │
+                      │                         │                    │
+                      │              ┌──────────▼───────────┐        │
+                      │              │ D2: Banach contraction│        │
+                      │              │ on smooth-structure   │        │
+                      │              │ measures              │        │
+                      │              │ Level 1 → Level 2    │        │
+                      │              │ (see issue table below)          │        │
+                      │              └──────────┬───────────┘        │
+                      │                         │                    │
+                      └────────────┬────────────┘                    │
+                                   │                                 │
+                        ┌──────────▼──────────┐           ┌──────────▼──────────┐
+                        │ E1: Marginalization │           │ E2: Macroscopic     │
+                        │ conjecture toy model│           │ definiteness        │
+                        │ Level 3             │           │ Level 3             │
+                        │ (see issue table below)         │           │ (issue #4)          │
+                        └─────────────────────┘           └─────────────────────┘
+```
+
+### Dependency summary
+
+| Problem | Depends on | Blocks |
+|---------|-----------|--------|
+| A1: H^s bound | — | A2, B1, C1, D1 (all downstream) |
+| A2: Uniform stress-energy | A1 | D2 (as input to contraction estimate) |
+| B1: Lorentzian from massive fields | A1 (uses Banach machinery) | Gate decision |
+| C1: Signature bridge | — (pure topology/geometry) | Gate decision |
+| D1: Measure on Sm(M) | Gate (Level 0 viable) | D2, E1 |
+| D2: Banach on smooth structures | A2, D1 | E1 |
+| E1: Marginalization toy model | D1 (need measure to marginalize) | E2 |
+| E2: Macroscopic definiteness | E1 | — |
+
+B1 and C1 are independent of each other and can run in parallel. A1 is the only problem with no upstream dependency and the clearest path to completion.
+
+---
+
+## Phase 1: Metric-Level Completion (Level 2)
+
+**Goal:** Promote the perturbative Banach contraction from Sketch to Rigorous.
+**Upstream dependencies:** None.
+**Estimated tractability:** High — the path is documented in issue #20.
+
+### Problem A1: Rigorous H^s operator-norm bound (issue #20)
+
+The perturbative Banach contraction (Section 4 of `fixed-point-existence.tex`) requires:
+
+$$\left\|\frac{\delta\langle\hat{T}_{\mu\nu}\rangle_{\mathrm{ren}}}{\delta g}\right\|_{H^s \to H^{s-2}} < \infty$$
+
+uniformly over the compact set $K_\rho$. The paper has a motivated scaling estimate $\kappa \sim (m/M_P)^2$ but flags it as insufficient for rigorous application of Banach's theorem.
+
+**Concrete path** (from issue #20):
+1. Express $\delta\langle\hat{T}_{\mu\nu}\rangle_{\mathrm{ren}}/\delta g$ as the retarded stress-energy two-point function.
+2. Use the Källén-Lehmann spectral representation (massive case) to bound the kernel — spectral gap above $4m^2$ gives polynomial suppression at high $k$.
+3. Translate momentum-space bound to $H^s \to H^{s-2}$ operator norm.
+4. Confirm uniformity over $K_\rho$ via compactness and continuity from assumption (A2).
+
+**Deliverable:** PR upgrading Section 4 of `fixed-point-existence.tex` from Sketch to Rigorous.
+
+**Rigor target:** Rigorous (this is the point — close the gap).
+
+### Problem A2: Uniform stress-energy bound (A3 extension)
+
+The Schauder argument (Section 5) requires assumption (A3): uniform bound on $\langle\hat{T}_{\mu\nu}\rangle_{\mathrm{ren}}$ over $K_\rho$. This is established for FRW spacetimes (Pinamonti-Siemssen 2015). The general case requires controlling the state-dependent part of the Hadamard renormalization uniformly.
+
+**Deliverable:** New issue documenting the gap. PR extending the bound if tractable, or documenting the obstruction if not.
+
+**Rigor target:** Sketch → Rigorous for FRW; Conjecture → Sketch for general case.
+
+### Kill condition
+
+None — Level 2 problems have well-defined mathematical content and clear paths. Failure here would mean the specific technical approach (Källén-Lehmann, etc.) doesn't work, not that the result is wrong. Alternative approaches exist.
+
+---
+
+## Phase 2: Signature Bridge (Level 0 ↔ Level 2) — Critical Gate
+
+**Goal:** Determine whether Lorentzian signature can be derived rather than assumed.
+**Upstream dependencies:** Soft dependency on Phase 1 (B1 uses Banach machinery).
+**Estimated tractability:** Unknown — this is the most uncertain phase.
+
+This phase runs two independent investigations in parallel. Either one succeeding is sufficient; both failing triggers the kill condition.
+
+### Problem C1: Intersection-form-to-signature bridge (see issue table below)
+
+**The question:** Does an indefinite intersection form with signature $(1,n-1)$ on a smooth 4-manifold imply that compatible metrics must be Lorentzian?
+
+This is a pure mathematics question in 4-manifold topology and Lorentzian geometry. The intersection form is a global invariant on $H_2$; the metric signature is local (tangent bundle). Connecting them requires a theorem that, to our knowledge, does not exist.
+
+**Candidate approach:** An indefinite form with signature $(1,3)$ may be the only form compatible with an oriented smooth 4-manifold admitting a global timelike vector field. The Hirzebruch signature theorem $\sigma(\mathcal{M}) = \frac{1}{3}p_1(\mathcal{M})$ connects intersection form signature to the Pontryagin class, which constrains the tangent bundle. Whether this chain reaches metric signature is open.
+
+**Deliverable:** Exploration documenting the mathematical investigation. If positive: validates the topological approach. If negative: documents what fails and what alternatives exist.
+
+### Problem B1: Lorentzian signature from massive field content (issue #6)
+
+**The question:** Does the self-consistency fixed point of the SCE *require* Lorentzian signature when the field content includes massive fields?
+
+This is independent of Level 0 topology. It asks whether the Banach contraction at Level 2 simply fails on a Riemannian manifold — i.e., whether the metric-level self-consistency itself forces the signature.
+
+**Candidate approach:** On a Riemannian manifold, there are no mass shells, no particle content, no propagating degrees of freedom in the usual sense. The stress-energy expectation value is fundamentally different. The question is whether $\mathcal{F}(g) = g$ has no solution when $g$ is Riemannian and the field content is massive.
+
+**Deliverable:** Exploration or PR contributing to the signature discussion.
+
+### Gate decision
+
+After Phase 2, one of three outcomes:
+
+1. **C1 succeeds:** Level 0 topological framework validated. Proceed with confidence to Phases 3–4.
+2. **C1 fails but B1 succeeds:** Lorentzian signature derived at Level 2, not Level 0. Revise the hierarchy — Level 0 selects the PL manifold but does not determine the signature. The signature enters at the metric level. This weakens the topological program but does not kill it.
+3. **Both fail:** The hierarchy cannot derive Lorentzian signature. The paper must retreat to "signature assumed" and flag this as the primary open problem. Level 0 is substantially revised.
+
+### Kill condition
+
+Both C1 and B1 produce negative results (not just "no progress" — actual counterexamples or no-go arguments). This forces the paper to:
+- Weaken Conjecture 5 (signature emergence) to an explicit open problem without a proposed mechanism.
+- Revise Section 6 to state that signature is assumed, not derived.
+- Evaluate whether the hierarchy adds value over standard approaches if it cannot derive signature.
+
+---
+
+## Phase 3: Level 1 Measure Theory (Smooth Structures)
+
+**Goal:** Define the self-consistency measure $\mu^*$ on $\mathrm{Sm}(\mathcal{M})$.
+**Upstream dependencies:** Phase 2 gate (need Level 0 viable). Phase 1 partial (need Banach results as input to D2).
+**Estimated tractability:** Low to medium — requires substantial original mathematics.
+
+### Problem D1: Natural measure on smooth structures (see issue table below)
+
+**The question:** Define a measure $\mu$ on $\mathrm{Sm}(\mathcal{M})$ that is:
+1. Defined without reference to a metric (avoiding circularity with Level 2).
+2. Compatible with the self-consistency condition $\mathcal{F}(\mu) = \mu$.
+3. Invariant under orientation-preserving diffeomorphisms.
+
+**Candidate approaches:**
+- **Donaldson-Witten invariants** as weights. The Donaldson polynomial invariants $\gamma_d(S)$ assign integers to smooth structures via the moduli space of anti-self-dual connections. These are diffeomorphism invariants defined without a metric (they use a metric in intermediate steps but the result is metric-independent).
+- **Seiberg-Witten invariants** as an alternative weighting. SW invariants are more computationally tractable and provide similar information.
+- **Moduli space volume.** If $\mathrm{Sm}(\mathcal{M})$ can be given a natural topology (it has a partial order via cobordism), a measure might arise from the topology itself.
+
+**Literature survey needed:** Existing constructions of measures on moduli spaces of gauge-equivalent structures, particularly in the context of topological QFTs. This is the most research-intensive sub-problem.
+
+**Deliverable:** Literature survey exploration + new issue. If a candidate measure is identified: paper section or standalone paper.
+
+### Problem D2: Banach contraction on smooth-structure measures (see issue table below)
+
+**The question:** Given a measure on $\mathrm{Sm}(\mathcal{M})$, does the self-consistency map $\mathcal{F}$ on measures have a contraction estimate analogous to $\kappa \sim (m/M_P)^2$ at the metric level?
+
+This extends the companion paper's Level 2 result to Level 1. The contraction would be in a suitable metric on the space of measures (e.g., Wasserstein distance, total variation).
+
+**Depends on:** D1 (need the measure to be defined), A1/A2 (need the metric-level contraction as an ingredient).
+
+**Deliverable:** New issue. Mathematical investigation yielding either a contraction estimate or identification of where the contraction breaks down.
+
+### Kill condition
+
+No natural measure on $\mathrm{Sm}(\mathcal{M})$ can be defined without metric input. The circularity — needing a metric to define the measure that determines the metric — is unresolvable. If this happens:
+- Level 1 collapses to a formal construct (mathematically stated but not computable).
+- The hierarchy loses its claim to replace the path integral measure problem — it has merely relocated the problem from metrics to smooth structures.
+- Evaluate whether the Level 2 fixed-point result alone (companion paper) is sufficient to motivate the framework without a working Level 1.
+
+---
+
+## Phase 4: QM Emergence (Level 3)
+
+**Goal:** Demonstrate that marginalization of the self-consistency measure produces quantum statistics.
+**Upstream dependencies:** Phase 3 (need the measure to marginalize).
+**Estimated tractability:** Medium for toy model; low for full theory.
+
+### Problem E1: Marginalization conjecture — toy model (see issue table below)
+
+**The question:** In a finite-dimensional analogue of the hierarchy, does marginalizing a self-consistent measure over the complement of a subregion produce an effective density matrix?
+
+**Toy model specification:**
+- Replace $\mathrm{Sm}(\mathcal{M})$ with a finite set of discrete "smooth structures" (e.g., simplicial complexes on a fixed triangulation).
+- Define a self-consistency map $\mathcal{F}$ on probability distributions over this finite set.
+- Find the fixed point $\mu^* = \mathcal{F}(\mu^*)$ (guaranteed by Brouwer's theorem in finite dimensions).
+- Marginalize $\mu^*$ to a subregion.
+- Check whether the marginal has the structure of a density matrix: positive, trace-one, with eigenvalues interpretable as probabilities.
+
+This is achievable with existing tools. The toy model does not prove the full conjecture but demonstrates the mechanism in a controlled setting.
+
+**Deliverable:** Paper section or standalone paper presenting the toy model. If it works: proof of concept for Level 3. If it fails: diagnostic of what goes wrong.
+
+### Problem E2: Macroscopic definiteness (issue #4)
+
+**The question:** Does measure concentration in the self-consistent measure produce effective decoherence in subregion marginals?
+
+This requires E1 (the marginalization mechanism) plus understanding of how the global measure concentrates. The argument would parallel the derivation of classical behavior from quantum decoherence, but here the "decoherence" emerges from the measure structure rather than from environment-induced superselection.
+
+**Deliverable:** Extension of E1 analysis to include concentration phenomena. Likely a section of the same paper.
+
+### Kill condition
+
+Even the finite-dimensional toy model fails to produce quantum-like statistics from marginalization. Specifically: the marginal of the self-consistent measure does not approximate a density matrix, or the statistics it produces are classical (commutative) rather than quantum (non-commutative). If this happens:
+- Level 3 needs a different mechanism for QM emergence.
+- The Hilbert-space-is-derived thesis survives (it follows from the argument in Section 2 of the hierarchy paper, independent of the marginalization mechanism), but the specific marginalization proposal fails.
+- Investigate whether Page-Wootters conditioning provides an alternative Level 3 mechanism within the hierarchy.
+
+---
+
+## Cross-Cutting Concerns
+
+### Citation verification backlog
+
+The hierarchy paper has five citations marked `[VERIFY before final draft]`:
+- Freedman (1982): J. Differential Geometry 17, 357
+- Donaldson (1983): J. Differential Geometry 18, 279
+- Taubes (1987): J. Differential Geometry 25, 363
+- Smale (1961): Ann. Math. 74, 391
+- Hirzebruch (1966): Topological Methods in Algebraic Geometry, Springer
+
+These must be verified via web search before any PR promoting the paper beyond DRAFT status. This is a blocking requirement per METHODOLOGY.md citation discipline.
+
+### Consistency check: WdW companion paper
+
+The hierarchy paper references `\cite{wdw_paper}` — the Wheeler-DeWitt diagnostic paper. This paper was written and then deleted from the repository. The reference must either be:
+1. Restored (re-add the paper), or
+2. Removed (integrate the WdW diagnostic into the hierarchy paper itself), or
+3. Converted to an internal note (cite the exploration instead).
+
+This should be resolved before the hierarchy paper leaves DRAFT status.
+
+### Framework axiom stress test
+
+Before any phase produces a PR to the hierarchy paper, the PR should be stress-tested against every FRAMEWORK.md hidden-assumption warning:
+- Does time evolution sneak back in? (The self-consistency map $\mathcal{F}$ is iterative — is the iteration sneaking in temporal structure?)
+- Is metric signature taken for granted? (Phases 2+ directly address this.)
+- Is dimensionality taken for granted? (The paper addresses this in Section 4, but the argument is Sketch.)
+- Is there a smuggled background? (The PL manifold is a fixed input to Level 0.)
+- Is observer-dependent language used? (Level 3 introduces "laboratory" and "subsystem.")
+
+---
+
+## New GitHub Issues to Open
+
+| # | Title | Level | Blocks | Blocked by |
+|---|-------|-------|--------|------------|
+| #21 | Signature bridge: intersection form to metric signature | 0 ↔ 2 | D1 | — |
+| #22 | Natural measure on smooth structures Sm(M) | 1 | D2, E1 | Phase 2 gate |
+| #23 | Marginalization conjecture: finite-dimensional toy model | 3 | E2 | D1 |
+| #24 | Banach contraction on smooth-structure measures | 1 → 2 | E1 | A1, D1 |
+| #25 | Uniform stress-energy bound: extension beyond FRW | 2 | D2 | A1 |
+
+Existing issues that map to this plan:
+- **#20** → A1 (H^s bound)
+- **#6** → B1 (Lorentzian signature from massive fields)
+- **#4** → E2 (macroscopic definiteness)
+
+---
+
+## Summary Timeline
+
+| Phase | Problems | Depends on | Delivers | Risk |
+|-------|----------|-----------|----------|------|
+| 1 | A1, A2 | — | Rigorous Banach contraction | Low |
+| 2 | B1, C1 (parallel) | A1 (soft) | Signature verdict | High — potentially fatal |
+| 3 | D1, D2 | Phase 2 gate, A1/A2 | Level 1 measure | Medium-high |
+| 4 | E1, E2 | D1 | QM emergence toy model | Medium |
+
+The plan is sequential in phases but parallel within phases. Phase 1 is immediate work. Phase 2 is the critical gate — its outcome determines whether the topological program survives. Phases 3 and 4 are contingent on Phase 2 success.

--- a/programs/co-emergence/explorations/2026-03-02-signature-mass-codependence.md
+++ b/programs/co-emergence/explorations/2026-03-02-signature-mass-codependence.md
@@ -1,0 +1,216 @@
+# Exploration: The Signature-Mass Codependence Debate
+
+**Date:** 2026-03-02
+**Type:** Three-position debate with adversarial synthesis
+**Outcome:** Qualified positive — the codependence insight is genuine but neither proposed mechanism survives as formulated. The debate narrows the path forward.
+
+---
+
+## What Was Debated
+
+Three positions were developed independently on whether the mutual dependence between metric signature and mass can force Lorentzian signature within the self-consistency hierarchy:
+
+1. **Position 1 (OS Reconstruction):** Topology determines field content with a mass gap; the mass gap guarantees reflection positivity; OS reconstruction derives a unique Lorentzian QFT. The bridge is: intersection form → smooth structures → field content → mass gap → reflection positivity → Lorentzian signature.
+
+2. **Position 2 (Adversarial Critique):** The OS path is fatally circular. OS reconstruction requires a flat Euclidean background (or at minimum a static Killing field), a preferred reflection hyperplane, and Euclidean time — all of which are background structures the hierarchy claims to derive. Reflection positivity IS a preferred foliation. The "mutual dependence" between mass and signature is verbal, not mathematical, because the parameter m² is well-defined on Riemannian manifolds.
+
+3. **Position 3 (Co-Emergence Fixed Point):** Abandon OS entirely. Define a joint self-consistency map F: (metric, field content) → (metric, field content) over ALL signatures. Argue that the only nontrivial fixed points are Lorentzian with m > 0, because: (a) mass requires hyperbolicity (hyperbolic vs. elliptic wave operator), (b) massive fields source the metric via SCE, (c) the companion paper's contraction estimate requires Lorentzian Green's functions.
+
+---
+
+## Pass 1: Adversarial Critique
+
+### Position 1 (OS Reconstruction)
+
+**Hidden assumptions:**
+
+1. **Flat Euclidean background (smuggled background).** The OS axioms require E(4) invariance (OS2) and a global reflection hyperplane (OS3). This is a fixed background structure. Position 1 acknowledges this and points to Kontsevich-Segal as a generalization, but Kontsevich-Segal remains a proposal, not a theorem. The generalization to curved backgrounds is an open problem of unknown difficulty. **Verdict: Position 2 is correct that this is a serious structural issue.**
+
+2. **Reflection positivity reintroduces a preferred direction (hidden time).** The reflection hyperplane in OS3 defines a codimension-1 split. The direction perpendicular to it becomes time after Wick rotation. Position 1 argues this is a "gauge choice" because all hyperplanes give the same Lorentzian theory. This defense is partially valid — on flat space, Euclidean invariance makes the choice gauge — but the issue is deeper: the EXISTENCE of a reflection-positive structure is the assumption that does the work, and this existence is not derived from topology. **Verdict: The Axiom 2 concern is genuine but overstated by Position 2 (see Pass 2).**
+
+3. **Link 1 (topology → mass gap) has no mechanism.** Position 1 is honest about this and labels it Conjecture. But the overall argument's presentation sometimes reads as if the chain is nearly complete with only this gap remaining, when in fact the gap is enormous — it includes the Yang-Mills mass gap problem. **Verdict: Honestly labeled but the severity is understated.**
+
+4. **The Wightman axioms assume Minkowski space.** Position 1's defense (Minkowski is output, not input) is technically correct for the OS theorem itself: the theorem constructs the Hilbert space and Hamiltonian from Euclidean data. But in the hierarchy context, the question is whether we can get to OS's starting point (well-defined Euclidean Schwinger functions) without already assuming some signature structure. **Verdict: The circularity concern is real at the hierarchy level even if it is resolved within OS itself.**
+
+5. **Confusing coarse-graining levels with logical dependence.** The chain "intersection form → smooth structures → field content → mass gap → reflection positivity → Lorentzian signature" reads as a causal sequence. Position 1 frames these as levels of the hierarchy, but the logical structure of the argument is sequential: each step depends on the previous. This sequential logical dependence is not the same as temporal ordering, but it creates the appearance of a derivation when several links are conjectural. **Verdict: Minor — a presentation issue, not a logical flaw.**
+
+**Rigor level assessment:** Position 1 claims Links 2–4 are Rigorous on flat space. This is accurate — the OS theorem is proven, and the mass gap → reflection positivity implication is established for free fields and constructive QFT models. But the overall argument is no stronger than its weakest link (Link 1, Conjecture), and the flat-space restriction means even the rigorous links do not apply to the hierarchy's setting without significant extension.
+
+### Position 2 (Adversarial Critique)
+
+**Hidden assumptions and overstatements:**
+
+1. **Treating all FRAMEWORK.md warnings as equal.** Position 2 labels five separate concerns "FATAL" (A, B, F1, F2, F3) but acknowledges these are "all manifestations of the same fundamental issue." Calling the same problem fatal five times inflates the severity count without adding content. There is really one structural objection (OS requires background structure the hierarchy claims to derive), presented five ways.
+
+2. **The Riemannian QFT counter-argument (Section E) has a gap.** Position 2 argues that m² is "perfectly well-defined" on a Riemannian manifold. This is mathematically true — the operator Δ + m² exists and has nice properties. But Position 2 conflates the existence of the parameter with the existence of the PHYSICS it describes. On a Riemannian manifold: there is no propagation (no Cauchy problem), no dispersion relation, no mass shell, no scattering. The parameter m² exists as a number in the equation, but it does not define a mass in any physical sense. Position 3's Step 1 makes this distinction precisely: the hyperbolic/elliptic divide is categorical, not quantitative. **Verdict: Position 2's counter-argument is mathematically correct but physically misleading. The codependence thesis survives this attack when reformulated as "physical mass requires hyperbolicity" rather than "the parameter m² requires Lorentzian signature."**
+
+3. **Ignoring the conditional value of the OS argument.** Position 2's conclusion ("OS reconstruction might be a useful approximation... but it cannot be the mechanism") is too strong. Even if OS cannot be the fundamental mechanism, the conditional statement "IF reflection positivity holds THEN Lorentzian signature follows" is a rigorous result that constrains the solution space. It tells us something real about the structure of self-consistent QFTs, even if it cannot serve as the signature bridge itself. **Verdict: The critique is correct about the foundational role but dismissive of the mathematical content.**
+
+4. **The circularity charge is partially valid but partially a category error.** Position 2 says: "To derive the background, you need reflection positivity. To define reflection positivity, you need the background." This is true for the standard OS formulation. But it conflates two different things: (a) the mathematical formulation of reflection positivity (which requires a hyperplane), and (b) the physical content of reflection positivity (which is a positivity condition on correlation functions). It is conceivable that the physical content can be reformulated without the background — this is the direction of Kontsevich-Segal and algebraic QFT approaches. Position 2 treats the formulation as the content. **Verdict: The circularity is real in the current formulation but may not be essential.**
+
+### Position 3 (Co-Emergence Fixed Point)
+
+**Hidden assumptions:**
+
+1. **The manifold M is taken as given (smuggled background).** Position 3 defines the joint map F on "the space of metrics on a fixed manifold M." This is a topological background structure. Position 3 acknowledges this and notes it operates at Level 2, but this is the same structural issue that undermines Position 1. **Verdict: Honest acknowledgment, but not resolved.**
+
+2. **The claim "Riemannian fixed points are trivial" is not proven.** Position 3's argument: on a Riemannian manifold, the wave operator is elliptic, so no propagation, so ⟨T_μν⟩ = 0, so G_μν = 0 (Ricci-flat). But Euclidean QFT exists and has nontrivial expectation values — constructive QFT has built interacting Euclidean theories with nonzero correlation functions. The ⟨T_μν⟩ of a Euclidean field on a Riemannian manifold is not automatically zero. Indeed, the Casimir effect has a Euclidean derivation. **Verdict: This is a gap, not a fatal flaw. The argument needs to distinguish between "no propagating degrees of freedom" (correct) and "no stress-energy" (incorrect). The physical content may be salvageable: Riemannian QFTs have ⟨T_μν⟩ ≠ 0 from vacuum fluctuations, but the self-consistency map may behave differently because the Green's function structure is qualitatively different.**
+
+3. **The Cauchy problem characterization smuggles in time.** Position 3 argues that Lorentzian signature is special because the Cauchy problem is well-posed. But well-posedness of the Cauchy problem is defined in terms of initial data on a spacelike hypersurface evolving forward — this is explicitly temporal language. Position 3 notices this tension and offers a defense: "the well-posedness of the Cauchy problem is a PROPERTY of the constraint, not a PROCEDURE." This defense is partially valid. Hyperbolicity is indeed a property of the PDE that can be stated without reference to time (it is a property of the symbol of the differential operator). But the physical significance attributed to it (propagation, dispersion, mass shell) does rely on temporal interpretation. **Verdict: Tension exists but is less severe than Position 2 claims for OS. The hyperbolicity of the wave operator is a coordinate-independent property of the metric signature. The INTERPRETATION in terms of propagation involves time, but the MATHEMATICAL FACT that the operator character changes categorically with signature does not.**
+
+4. **The ultrahyperbolic case (2,2) is dismissed too quickly.** Position 3 claims no fixed points exist for signature (2,2) because the Cauchy problem is ill-posed. But ill-posedness does not imply nonexistence of self-consistent solutions; it implies non-uniqueness or instability. A self-consistency fixed point could exist for (2,2) but be unstable. Whether instability rules it out depends on the contraction structure of the map F, which has not been analyzed for (2,2). **Verdict: Minor gap — (2,2) is physically excluded by other arguments, but the mathematical claim is not established.**
+
+5. **Dimensionality is assumed.** The argument operates on a 4-manifold throughout. The framework requires deriving dimensionality. Position 3 defers to the hierarchy's Level 1 argument, which is appropriate, but it means the signature argument is conditional on the dimensionality argument. **Verdict: Acknowledged limitation, not a hidden assumption.**
+
+---
+
+## Pass 2: Defense Assessment
+
+### Position 2's "Fatal" verdicts — are they genuinely fatal?
+
+**Attack A/F2 (flat-space/background dependence): Serious but not fatal to the INSIGHT, fatal to the MECHANISM.**
+
+Position 2 is correct that the standard OS formulation requires background structure incompatible with the hierarchy's axioms. This means OS reconstruction CANNOT serve as the fundamental mechanism for the signature bridge. But Position 2's conclusion — that the entire OS direction is a "step backward" — is too strong. The OS theorem tells us something real: there is a precise mathematical relationship between reflection positivity and Lorentzian structure. The fact that this relationship is currently formulated on a background does not mean it has no content. The content might be reformulable; the Kontsevich-Segal program and algebraic QFT are both attempting this.
+
+**Defense assessment: Position 2 kills OS-as-mechanism but not OS-as-evidence.**
+
+**Attack B/F1 (reflection positivity = preferred foliation): Serious but contains a category error.**
+
+Reflection positivity as currently formulated requires a hyperplane, which defines a preferred direction. Position 2 identifies this with a preferred foliation, violating Axiom 2. But there is a subtlety: on flat space with full Euclidean invariance, reflection positivity holds for ALL hyperplanes simultaneously. The choice of hyperplane is not physical — it is a choice of how to EXTRACT the Lorentzian theory from the Euclidean data. This is analogous to choosing coordinates: the physics is independent of the choice.
+
+The deeper question is whether the hierarchy can produce a structure that is reflection-positive with respect to all hyperplanes without first specifying what "hyperplane" means. This is genuinely unclear. But Position 2's equation of "reflection positivity" with "preferred foliation" is too hasty: on a space with sufficient symmetry, reflection positivity is a global constraint, not a foliation choice.
+
+**Defense assessment: The concern is genuine but the "fatal" label is overstated. Reclassify as "serious, requires reformulation."**
+
+**Attack F3 (signature assumed — Euclidean in, Lorentzian out): Partially a misunderstanding.**
+
+Position 2 claims OS "maps one assumed signature to another." This misreads the theorem. The starting point is not "a theory with Euclidean signature" in the physical sense — it is a set of correlation functions satisfying certain axioms (analyticity, symmetry, positivity). These axioms are mathematical conditions on distributions. The OS theorem then PROVES that these conditions are equivalent to the existence of a Lorentzian QFT. The Euclidean signature is not assumed as physics; it is the mathematical framework in which the conditions are stated.
+
+The circularity concern has some force at the hierarchy level (where do the Euclidean correlation functions come from?), but "OS maps one signature to another" mischaracterizes what the theorem does.
+
+**Defense assessment: Reclassify from "fatal" to "requires clarification." The theorem is not circular; the question is whether its starting point is accessible from the hierarchy.**
+
+### Position 2's "Serious" verdicts — are they correctly calibrated?
+
+**Attack C (mass gap not derived): Correctly assessed as serious but solvable.** The conditional form "IF mass gap THEN Lorentzian" is valuable even without proving the antecedent.
+
+**Attack D (conformal factor problem): Correctly assessed as serious but solvable.** The hierarchy's replacement of the metric path integral with a smooth-structure measure may genuinely circumvent this.
+
+**Attack E (mutual dependence is verbal): Partially correct, partially refuted by Position 3.** Position 2 is right that the parameter m² exists on Riemannian manifolds. Position 3 is right that it has qualitatively different physical significance. The resolution: the codependence thesis is about PHYSICAL mass (propagating degrees of freedom on a mass shell), not about the parameter m². Reformulated this way, the thesis survives Position 2's attack.
+
+### Position 3's acknowledged weaknesses — how serious are they?
+
+1. **The map F is not rigorously defined.** This is the most serious issue. Without a precise definition, the "Signature Selection Principle" (Conjecture) cannot be promoted beyond Conjecture. The Spec map is schematic.
+
+2. **Riemannian triviality not proven.** Serious gap, as noted above — Euclidean QFTs have nonzero ⟨T_μν⟩. But the argument can potentially be rescued by showing the Riemannian self-consistency map has different contraction properties.
+
+3. **Connection to Levels 0–1 incomplete.** This is by design — Position 3 operates at Level 2. The signature selection must eventually connect to the topological level, but that is a separate problem.
+
+---
+
+## Structural Convergence
+
+### What all three positions agree on
+
+1. **The parameter m² alone does not select signature.** All positions agree that the number m² can appear in equations on any-signature manifold. The disagreement is about what additional structure is needed to make m² into physical mass.
+
+2. **The signature bridge must involve field content.** Position 1 routes through OS, Position 3 routes through the joint fixed point, but both agree that a direct topological path (intersection form → metric signature) does not exist. The bridge passes through the matter sector.
+
+3. **The flat-space limitation of standard OS is a genuine problem.** Position 1 acknowledges it, Position 2 emphasizes it, Position 3 avoids it by abandoning OS. All agree that the standard OS formulation is insufficient for the hierarchy's setting.
+
+4. **The mass gap question is critical and open.** All positions require m > 0 for the argument to work. None derives it from topology.
+
+### Where Positions 1 and 3 converge
+
+Despite taking very different routes, Positions 1 and 3 identify the same core structure: **the physical content of mass (propagation, dispersion, mass shell) requires a distinction between timelike and spacelike directions, and the existence of massive fields constrains the metric to be Lorentzian.** Position 1 formalizes this via OS reconstruction (Euclidean → Lorentzian). Position 3 formalizes this via the hyperbolic/elliptic dichotomy (self-consistency → Lorentzian). The convergence suggests the underlying insight is robust even if neither specific formalization survives intact.
+
+### What survives the critic's attacks
+
+1. **The hyperbolic/elliptic categorical distinction.** Position 2 does not challenge this. The fact that the wave operator is hyperbolic for Lorentzian signature and elliptic for Riemannian signature, with qualitatively different solution spaces, is a mathematical fact independent of formulation choices. This is the most robust element of the debate.
+
+2. **The conditional: IF mass gap AND self-consistency THEN Lorentzian.** Even Position 2 classifies the mass gap issue as "serious but solvable" rather than fatal. The conditional statement, properly formulated, is not challenged.
+
+3. **The failure of the direct topological route.** All three positions agree (explicitly or implicitly) that intersection form signature does not directly determine metric signature. This negative result is itself valuable.
+
+### What does not survive
+
+1. **OS reconstruction as the signature bridge mechanism.** Position 2 is correct that the background dependence is incompatible with the hierarchy's axioms. OS may play a supporting role (as evidence, or as an approximation valid in the flat-space limit) but cannot be the fundamental mechanism.
+
+2. **The claim that the signature bridge is "essentially solved."** Position 1 sometimes reads this way. It is not. The bridge requires new mathematics — either a background-independent generalization of reflection positivity, or a rigorous version of Position 3's fixed-point argument.
+
+3. **The claim that signature and mass are MUTUALLY meaningless without each other.** Position 2 correctly notes that m² is well-defined on Riemannian manifolds. The corrected version: PHYSICAL mass (propagation on a mass shell) requires Lorentzian signature, and Lorentzian self-consistency requires m > 0 for the contraction estimate. This is weaker than "co-definition" but still substantive.
+
+---
+
+## The Strongest Surviving Argument
+
+Combining the surviving elements from all three positions, the strongest version of the signature-mass connection is:
+
+**Claim (Conjecture).** Among metrics of all possible signatures on a closed 4-manifold, the semiclassical self-consistency map g ↦ G⁻¹(8πG⟨T_μν⟩_g) has nontrivial fixed points only for Lorentzian signature with m > 0.
+
+**Supporting argument (Sketch):**
+
+1. For Riemannian signature (4,0): the wave operator is elliptic. There are no propagating degrees of freedom. The stress-energy from vacuum fluctuations exists but has qualitatively different structure (no dispersion, no mass shell). The self-consistency map may have fixed points (this has not been ruled out rigorously), but they describe a qualitatively different — and physically empty — situation: geometry consistent with vacuum fluctuations but no particles, no scattering, no thermodynamics.
+
+2. For ultrahyperbolic signature (2,2): the wave operator is ultrahyperbolic. The Cauchy problem is ill-posed (by the Asgeirsson mean value theorem, data cannot be localized). The self-consistency map is not well-defined without a unique Green's function. No fixed point is expected, but this has not been proven.
+
+3. For Lorentzian signature (1,3): the wave operator is hyperbolic. Propagating degrees of freedom exist. The mass gap provides a scale that enters the Banach contraction estimate (κ ~ (m/M_P)² ≪ 1). The companion paper proves a fixed point exists. This is the only signature for which the self-consistency machinery is known to produce a nontrivial result.
+
+**Key distinction from Position 1:** No Wick rotation, no Euclidean starting point, no OS reconstruction. The argument stays within the Lorentzian sector throughout.
+
+**Key distinction from Position 3 as written:** More modest claims. The Riemannian case is not claimed to be "trivial" (it may have nontrivial fixed points); rather, the Lorentzian case is the only one known to produce PHYSICAL content. The argument is that Lorentzian signature is selected not because other signatures are impossible but because other signatures are empty.
+
+**Rigor assessment:** The individual ingredients (hyperbolic/elliptic distinction, Banach contraction in the Lorentzian case) are Rigorous or Sketch. The overall claim (uniqueness of nontrivial fixed points to Lorentzian signature) is Conjecture. The gap is: no rigorous analysis of the self-consistency map for non-Lorentzian signatures.
+
+---
+
+## Implications for the Hierarchy Paper
+
+1. **The signature bridge section should be rewritten.** The current framing (intersection form signature → metric signature) should be replaced with the joint fixed-point picture. The bridge passes through field content at Level 2, not directly through topology at Level 0.
+
+2. **OS reconstruction should be cited as supporting evidence, not as the mechanism.** The OS theorem provides rigorous evidence that reflection positivity and Lorentzian structure are intimately connected. This supports the hypothesis but does not constitute the bridge itself due to background dependence.
+
+3. **The "Signature Selection Principle" should be stated as a conjecture.** Specifically: the semiclassical self-consistency map has nontrivial fixed points only for Lorentzian signature. This is a well-defined mathematical conjecture that can be investigated.
+
+4. **The mass gap remains the critical open problem.** Whether topology determines a mass gap, or whether the mass gap should be treated as an additional input to the hierarchy, is the most important unresolved question. The conditional form of the argument is valuable regardless.
+
+5. **The "potentially fatal" assessment of the signature bridge can be softened.** The debate shows that the signature-mass connection is a genuine mathematical phenomenon (not verbal hand-waving), even though no complete derivation exists. The correct assessment is: the signature bridge is a conjecture with a plausible argument structure and a clear research program, not a gap that threatens to collapse the framework.
+
+---
+
+## Answers to the Key Questions
+
+**1. Is the "mutual dependence of mass and signature" a genuine mathematical insight or verbal hand-waving?**
+
+Genuine, but needs precise formulation. The correct statement is: physical mass (propagating degrees of freedom on a mass shell with finite correlation length) requires a hyperbolic wave operator, which requires Lorentzian signature. In the other direction, the companion paper's contraction estimate requires m > 0 for the Lorentzian self-consistency map. The dependence is real but ASYMMETRIC: the parameter m² exists without Lorentzian signature, but its physical content does not. Position 2 is right about the parameter; Positions 1 and 3 are right about the physics.
+
+**2. Does OS reconstruction have any role in this framework, despite the flat-space limitation?**
+
+Yes, but as evidence and as a limiting case, not as the mechanism. The OS theorem proves that reflection positivity and Lorentzian structure are mathematically equivalent (on flat space). This is a rigorous constraint on the structure of self-consistent QFTs. In the hierarchy, it would apply at Level 2 in the flat-space (weak-gravity) limit, providing a consistency check: the effective QFT obtained by marginalizing the smooth-structure measure should satisfy reflection positivity.
+
+**3. Is Position 3's "joint fixed point" approach more compatible with the framework's axioms?**
+
+Yes. Position 3 avoids the background dependence that kills Position 1. The joint fixed-point equation F(g, Φ) = (g, Φ) is a four-dimensional constraint with no preferred slicing, no Wick rotation, and no Euclidean starting point. It operates directly at Level 2 of the hierarchy. The main weakness — that the map F is not rigorously defined — is a research gap, not a conceptual incompatibility.
+
+**4. What is the actual status of the signature problem after this debate?**
+
+The signature bridge is a well-motivated conjecture with a clear argument structure. The direct topological route (intersection form → metric signature) does not work. The OS route provides supporting evidence but cannot serve as the fundamental mechanism. The joint fixed-point route (Position 3, refined) is the most promising path, but requires: (a) rigorous definition of the self-consistency map for general signatures, (b) analysis of the Riemannian case to confirm the absence of nontrivial fixed points, (c) resolution of the mass gap question. Status: Conjecture, with a clear research program to promote to Sketch.
+
+**5. What concrete next steps (if any) survive?**
+
+- **Immediate (for the hierarchy paper):** Rewrite the signature bridge section to present the joint fixed-point conjecture. Cite OS as supporting evidence in the flat-space limit. State the Signature Selection Principle as a named conjecture.
+- **Short-term research:** Analyze the Banach contraction map for Riemannian signature explicitly. Show that the contraction constant κ diverges or the map fails to be well-defined, confirming the absence of nontrivial Riemannian fixed points. This is a concrete calculation that could promote the conjecture to Sketch.
+- **Medium-term research:** Investigate whether the Kontsevich-Segal framework (complex metrics, positivity of the partition function) can replace standard OS reconstruction in a background-independent setting. This is the most promising route to making the OS evidence rigorous in the hierarchy's context.
+- **Long-term:** Connect the Level 2 signature selection to Levels 0–1. Does the intersection form of the PL manifold constrain which signatures the Level 2 fixed point can have? This would close the loop between topology and signature, but through field content rather than directly.
+
+---
+
+## Record of Positions
+
+The three position files are part of this exploration's record:
+
+1. `explorations/position-1-os-reconstruction.md` — OS reconstruction path (advocate)
+2. `explorations/2026-03-02-position2-os-critique.md` — Adversarial critique of OS path
+3. `explorations/2026-03-02-position3-co-emergence.md` — Co-emergence via joint fixed point
+
+All three contain valuable analysis that may be relevant to future work on the signature bridge, even where the synthesis disagrees with their conclusions.

--- a/programs/co-emergence/explorations/2026-03-03-mass-gap-origin.md
+++ b/programs/co-emergence/explorations/2026-03-03-mass-gap-origin.md
@@ -1,0 +1,207 @@
+# Exploration: Mass Gap Origin — Synthesis of Three-Position Debate
+
+**Date:** 2026-03-03
+**Type:** Adversarial synthesis (3 positions)
+**Outcome:** Nuanced negative result. The hierarchy cannot currently derive mass. The strongest surviving claim is conditional: IF mass exists (as input), THEN self-consistency constrains which values are allowed and forces Lorentzian signature. The Asselmeyer-Maluga program provides the only concrete mechanism for generating mass from topology, but it is insufficiently verified to serve as a foundation. The self-consistency selection argument (Position 2) is suggestive but defeated by the CFT counterexample at its strongest level. Mass should be treated as input constrained by self-consistency, not as output derived from it — at the current state of the mathematics.
+
+---
+
+## The Three Positions
+
+**Position 1 (Exotic mass):** The Asselmeyer-Maluga program generates matter fields — including fermions with mass — from exotic smooth structures on R^4. The mechanism: exotic R^4 -> Casson handles -> non-trivial 3-manifold boundaries -> Dirac action boundary terms. Mostow rigidity makes the mass parameters topological invariants.
+
+**Position 2 (Self-consistent mass):** The Banach contraction for the SCE requires m > 0 (the massless case fails). Self-consistency therefore *selects* massive fields. Analogies to QCD chiral symmetry breaking, BCS gap equation, and NJL model support the claim that self-consistent systems generically generate mass gaps.
+
+**Position 3 (Mass as input):** Neither Position 1 nor Position 2 derives mass. CFTs are self-consistent and massless, killing Position 2's strong claim. The Asselmeyer-Maluga program is unverified and speculative, weakening Position 1. The hierarchy should accept mass as input and investigate consequences.
+
+---
+
+## Pass 1: Adversarial Critique
+
+### Critique of Position 1 (Exotic Mass)
+
+**1a. The Dirac operator requires a metric — circularity.** Position 1 claims mass originates at Level 0-1 (before the metric), but the entire mechanism for identifying boundary terms as fermion fields depends on the Dirac operator, which requires a metric and a spin structure. Position 1 acknowledges this (Section 5.4) but calls it a "significant gap." It is worse than a gap — it is a circularity. The mechanism claims topology generates mass, but the mathematical identification of *what* topology generates requires metric-level (Level 2) structure. The co-emergence thesis recognizes this as a feature, not a bug: mass, metric, and signature are co-defined. But this means the Asselmeyer-Maluga mechanism cannot operate purely at Level 0-1. It operates at the Level 0-1-2 *intersection*, which is a weaker claim than Position 1 makes. **Severity: SERIOUS.** Not fatal because the co-emergence framework expects cross-level dependence, but fatal to the claim that mass originates at a single level.
+
+**1b. The fermion identification is ad hoc.** "Hyperbolic knot complements = fermions" and "torus bundles = bosons" is a modeling choice, not a theorem. Thurston geometrization gives eight model geometries; the selection of two for particle identification is not derived from any principle. The three-generations claim (from 3-fold branched covers via Alexander's theorem) is numerology: 3 is a common number in mathematics, and the coincidence with three fermion generations, absent a mechanism linking branched cover sheets to generation quantum numbers, is not evidence. **Severity: SERIOUS.** The identification may be correct but is currently unfalsifiable and underdetermined.
+
+**1c. No independent verification after 20+ years.** Position 3 is right about this. The Asselmeyer-Maluga program has been developed by essentially one research group. The core claims have not been independently reproduced. The publication venues (while including GRG and CQG, which are respectable) do not include the top-tier journals where extraordinary claims face maximum scrutiny. **Severity: SERIOUS (not fatal).** Lack of verification is not disproof. The program could be correct and overlooked. But it means we cannot treat it as established, and the hierarchy paper should not rely on it as though it were.
+
+**1d. The mass gap itself is not proven.** Position 1 is honest about this: the spectral gap of the Dirac operator on hyperbolic 3-manifolds with boundary is conjectured, not established (Section 3.2). Even granting the entire Asselmeyer-Maluga mechanism, the result is fields that *have mass parameters*, not fields that *must be massive*. The mass parameters could in principle be zero. **Severity: SERIOUS.** This is the gap that matters most for the co-emergence thesis.
+
+**1e. Trivial H_2 on R^4.** Position 3's attack (1.2) is correct: exotic R^4 has trivial homology, so the intersection form is empty. The mathematical tools that make dimension 4 special (Donaldson invariants, Seiberg-Witten invariants) do not directly apply. However, this is **not fatal** to Position 1 as Position 3 claims. Position 1 does not use the intersection form. Its mechanism operates through the *smooth structure* (Casson handles, Akbulut corks), not through homology. The trivial H_2 kills intersection-form arguments but does not kill the exotic smoothness mechanism. **Position 3 overstates this attack.**
+
+### Critique of Position 2 (Self-Consistent Mass)
+
+**2a. The CFT counterexample is decisive against the strong claim.** Position 3's attack (2.2) is correct and fatal to Position 2's strongest formulation ("self-consistency requires mass"). Conformal field theories are rigorously self-consistent, massless quantum field theories. They exist. Therefore, self-consistency does not logically require mass. Full stop.
+
+Position 2 partially anticipates this: "these CFTs exist on flat space, not as coupled gravity-matter systems." This defense has some force — a CFT coupled to gravity via the SCE is a different mathematical object than a CFT on flat space. The conformal anomaly means conformal invariance is broken by the gravitational coupling, and the trace anomaly drives the Starobinsky de Sitter solution. But the defense does not fully succeed: a conformally coupled massless scalar ($\xi = 1/6$, $m = 0$) has zero trace anomaly in 4D and IS a legitimate matter content for the SCE. The self-consistency of this system has not been disproven. **Severity: FATAL to "self-consistency requires mass." The strong claim must be abandoned.**
+
+**2b. The Banach failure is about the proof technique, not about nature.** Position 3 is correct (attack 2.1): the failure of the Banach contraction estimate for m = 0 shows the *proof technique* is inadequate, not that the fixed point doesn't exist. The Schauder theorem could still establish existence. Non-perturbative methods could find the fixed point by a different route. The companion paper itself labels the massless case as "open," not "impossible." **Severity: FATAL to "m = 0 is inconsistent." SERIOUS BUT SOLVABLE for the weaker claim (see below).**
+
+**2c. The analogies are structurally informative but not proofs.** Position 2's QCD, BCS, and NJL analogies are well-chosen and demonstrate that self-consistent mass generation from massless starting points is a *generic phenomenon* in physics. This is genuinely important context. But the analogies operate in flat spacetime with known Lagrangians. The SCE operates on curved spacetime with the quantum stress-energy tensor. The mathematical structures (function spaces, nonlinearities, compactness properties) are different. The analogies establish plausibility, not necessity. **Severity: MISUNDERSTANDING if treated as proof; correctly weighted if treated as motivation.**
+
+**2d. The Starobinsky effective mass argument is the strongest surviving element.** Position 2's Section 3 makes a specific, checkable argument: the Starobinsky de Sitter fixed point gives $R = 12H_0^2 \neq 0$, so non-conformally-coupled fields ($\xi \neq 1/6$) acquire an effective mass $m_{\text{eff}}^2 = \xi R = 12\xi H_0^2$. This effective mass then enables the Banach contraction for perturbations around the de Sitter background. The argument is: even if bare mass is zero, the self-consistent de Sitter geometry generates an effective mass for non-conformal fields. **Severity: This survives the CFT attack** because it only applies to fields that are NOT conformally invariant. Conformally coupled fields ($\xi = 1/6$) remain massless, which is consistent with the existence of massless photons. The mechanism selects m > 0 only for fields whose coupling to curvature breaks conformal invariance. This is a weaker but more honest claim.
+
+**2e. Mass is not a dynamical variable in the SCE.** Position 2 acknowledges this weakness (Section, Weakness 1). The SCE is $G_{\mu\nu} = 8\pi G \langle T_{\mu\nu} \rangle$, a fixed-point equation for $g_{\mu\nu}$, not for $m$. Mass enters as an external parameter. The "mass-scale bootstrap" (Section 3) provides $m_{\text{eff}}^2 = m^2 + \xi R$, but this shifts an existing mass — it does not generate one from zero (except via the Starobinsky mechanism for non-conformal coupling). **Severity: SERIOUS.** The position would need a higher-level fixed-point equation that determines $m$ alongside $g$.
+
+### Critique of Position 3 (Mass as Input)
+
+**3a. Several "FATAL" verdicts are overstated.** Position 3 labels six of its ten attacks as "FATAL." This is too aggressive. Specifically:
+
+- Attack 1.2 (trivial H_2) is labeled FATAL to Position 1, but Position 1 does not use the intersection form. The exotic smoothness mechanism operates through Casson handles, not homology. This attack kills a straw man. **Overstated.**
+
+- Attack 1.3 ("the mechanism is vague at the critical step") is labeled FATAL, but Position 1 provides a specific mathematical chain (Section 1.2): Dirac operator decomposition on product manifolds -> boundary term identification -> source term in Einstein-Hilbert action. The chain has gaps (the metric-dependence circularity), but "vague" is not accurate. It is incomplete, not vague. **Overstated from FATAL to SERIOUS.**
+
+- Attack 2.1 (massless fields exist) is labeled FATAL. It IS fatal to the strong claim ("self-consistency requires ALL fields to be massive") but Position 2's weaker claim survives: self-consistency with gravitational coupling distinguishes between conformal and non-conformal fields, and the Starobinsky mechanism generates effective mass for the latter. Photons are massless because they are conformally coupled in 4D. This is consistent. **Partially overstated.**
+
+**3b. Position 3 conflates three different claims.** The skeptic does not consistently distinguish between:
+- **Mass existence** (m > 0 for some fields)
+- **Mass spectrum** (specific values m_e = 0.511 MeV, etc.)
+- **Mass gap** (minimum nonzero mass)
+
+Much of Position 3's rhetoric attacks the strongest claim (deriving the full mass spectrum) while using the resulting skepticism to dismiss the weakest claim (explaining why massive fields exist at all). Attacks 3.1 (19 free parameters), 3.3 (scale hierarchy), and 3.4 (historical precedent) are devastating against spectrum prediction but have no force against the question of mass existence. **Severity of the conflation: SERIOUS.** The skeptic's strongest arguments address a claim that neither Position 1 nor Position 2 actually makes in their careful formulations.
+
+**3c. The CFT counterexample is strong but not as decisive as claimed.** Position 3's attack 2.2 is correct: CFTs are self-consistent and massless. But the relevant question is not "can self-consistent QFTs be massless?" (yes) but "can the self-consistent coupled gravity-matter system on a compact 4-manifold with nontrivial smooth structures be massless?" These are different questions. A CFT on flat Minkowski space does not satisfy the SCE (it requires $G_{\mu\nu} = 0$ identically, which constrains the global geometry to be Ricci-flat). The counterexample operates in a regime (decoupled from gravity, flat background) that is not the regime of the hierarchy. **The counterexample kills the abstract logical claim; it does not kill the physical claim.**
+
+**3d. The proposed "honest formulation" is too conservative.** Position 3 concludes that mass should be treated as pure input. But this ignores the co-emergence thesis: the hierarchy paper has established (at Sketch level) that mass, signature, time, and Hilbert space are co-defined. Treating mass as "just input" loses the structural insight that mass is not an arbitrary parameter but is entangled with the other structures in a way that constrains its possible values. The honest formulation should be: "Mass is currently an input, constrained by self-consistency, with a conjectural path to derivation that has not been established." This is weaker than Positions 1 and 2 claim but stronger than Position 3 allows.
+
+---
+
+## Pass 2: Defense Assessment
+
+| Criticism | Target | Verdict | Reasoning |
+|-----------|--------|---------|-----------|
+| Metric circularity (1a) | Pos 1 | SERIOUS BUT SOLVABLE | Co-emergence framework expects cross-level dependence. Reframe as joint fixed point, not sequential derivation. |
+| Ad hoc fermion ID (1b) | Pos 1 | SERIOUS BUT SOLVABLE | Could be resolved by deriving the identification from a principle, but currently lacks one. |
+| No independent verification (1c) | Pos 1 | SERIOUS BUT SOLVABLE | Sociological, not mathematical. Could change with verification effort. |
+| Spectral gap not proven (1d) | Pos 1 | SERIOUS BUT SOLVABLE | A specific mathematical question with a definite answer. Research could resolve it. |
+| Trivial H_2 (1e, from Pos 3) | Pos 1 | MISUNDERSTANDING | Position 1 does not rely on intersection form. |
+| CFT counterexample (2a) | Pos 2 strong | FATAL | Self-consistency does not logically require mass. Strong claim dead. |
+| Banach failure is technical (2b) | Pos 2 strong | FATAL | Proof failure ≠ impossibility. |
+| Analogies not proofs (2c) | Pos 2 | MISUNDERSTANDING if taken as proof | Correctly framed as motivation, they survive. |
+| Starobinsky effective mass (2d) | Pos 2 weak | SURVIVES | Generates effective mass for non-conformal fields specifically. |
+| Mass not dynamical (2e) | Pos 2 | SERIOUS BUT SOLVABLE | Requires extension of the fixed-point framework. |
+| 19+ free parameters (3.1, from Pos 3) | Both | LEGITIMATE CONTEXT | Correctly establishes burden of proof. Not an argument against mass existence. |
+| Yang-Mills mass gap (3.2, from Pos 3) | Both | LEGITIMATE CONTEXT | Correctly calibrates difficulty. Not an impossibility proof. |
+| Scale hierarchy (3.3, from Pos 3) | Both | SERIOUS | No known mechanism bridges topology to the electroweak scale. |
+| Historical precedent (3.4, from Pos 3) | Both | LEGITIMATE CONTEXT | Pattern of failure is informative, not dispositive. |
+
+---
+
+## Structural Convergence
+
+### What all three positions agree on
+
+1. **The Banach contraction is Rigorous for massive fields and open for massless fields.** No position disputes the companion paper's result. The disagreement is about interpretation: is the massless failure fundamental (Position 2) or technical (Position 3)?
+
+2. **The hierarchy's proven content does not include mass derivation.** All three positions, when pressed, acknowledge that no existing mathematics derives any mass value from the hierarchy's axioms.
+
+3. **Mass values (the spectrum) are not derivable from current tools.** Even Position 1, which is most optimistic about topology generating mass, concedes that "no specific knot has been identified with a specific fermion."
+
+4. **Dimension 4 is special for exotic smooth structures.** All positions accept this mathematical fact and its relevance to the hierarchy.
+
+5. **The co-emergence thesis is structurally sound.** Mass, signature, time, and Hilbert space are genuinely interlinked. The disagreement is about whether this linkage *derives* mass or merely *organizes* the consequences of mass.
+
+### Where positions converge despite different starting points
+
+**Position 1 and Position 2 converge on the joint fixed-point picture.** Position 1 provides the mechanism (exotic smoothness -> field content), Position 2 provides the selection principle (self-consistency selects which field content survives). Neither alone is sufficient:
+- Position 1 without Position 2 generates fields that may or may not be massive.
+- Position 2 without Position 1 has no mechanism to generate fields at all.
+
+Together: exotic smooth structures generate candidate field content (Position 1), and the self-consistency requirement selects the subset with m > 0 because only massive fields support convergent fixed points (Position 2, weak version). This combined position survives the CFT counterexample because the CFT is decoupled from the exotic smoothness mechanism.
+
+**Position 2 and Position 3 converge on the conditional formulation.** Position 2's weak version ("self-consistency works better with mass") and Position 3's proposed formulation ("given mass, self-consistency constrains the geometry") are compatible. The disagreement is about whether the "given" can eventually be removed.
+
+### The strongest surviving claim
+
+**Conditional mass selection (Sketch):** Given that Level 0-1 structure (exotic smooth structures) generates candidate field content, the self-consistency requirement at Level 2 preferentially selects configurations with m > 0, because:
+
+(a) The Banach contraction converges exponentially for massive fields and fails (or converges more slowly) for massless fields, making massive fixed points attractors and massless fixed points (if they exist) non-attractors.
+
+(b) The Starobinsky de Sitter fixed point generates effective mass for non-conformally-coupled fields, even if bare mass is zero.
+
+(c) Only massive fields support the Level 3 structure (local time, local Hilbert space, density matrices from marginalization), so cross-level consistency eliminates configurations where all fields are massless.
+
+This claim is weaker than both Position 1 (which claims topology generates mass) and Position 2 (which claims self-consistency requires mass). It is stronger than Position 3 (which claims mass is pure input). It is honest.
+
+---
+
+## Answers to the Key Questions
+
+### 1. Is mass an axiom, a consequence, or a conjecture in this framework?
+
+**A conjecture with structural motivation.** Mass is not an axiom (it does not appear in Axioms 1-3). It is not a proven consequence (no derivation exists). Conjecture 3.1 aspires to derive it from topology; the co-emergence thesis provides structural reasons to expect it; the Asselmeyer-Maluga program provides a candidate mechanism. But at the current state of the mathematics, mass is best treated as **constrained input**: it enters at Level 2 as a parameter of the matter field theory, and self-consistency constrains which values are allowed.
+
+The hierarchy paper should present mass status honestly: "The origin of mass is the deepest open problem in the hierarchy. Conjecture 3.1, if correct, implies mass emerges from topology at Level 0-1. The co-emergence thesis (mass <-> signature <-> time <-> Hilbert space) provides structural evidence that mass is not independent of the other structures. But no derivation exists, and the conjecture remains open."
+
+### 2. Does the Asselmeyer-Maluga program provide a viable mechanism?
+
+**It is the only concrete mechanism on offer, but it is insufficiently verified to rely on.** The program provides a specific mathematical chain (exotic R^4 -> Casson handles -> 3-manifold boundaries -> Dirac action) with identifiable steps where it could fail. This is valuable — it is a hypothesis that can be tested mathematically. But:
+
+- The program has not been independently verified.
+- The fermion identification is ad hoc.
+- The mass gap (spectral gap of the Dirac operator on hyperbolic 3-manifolds) is conjectured, not proven.
+- The mechanism requires metric-level structure (Dirac operator), creating circularity with the Level 0-1 origin claim.
+
+**Recommendation for the hierarchy paper:** Reference the Asselmeyer-Maluga program as relevant prior art and the leading candidate mechanism for Conjecture 3.1, but do not build the argument on it. State it as: "The Asselmeyer-Maluga program [citations] provides the most concrete existing proposal for generating matter from exotic smooth structures. If its central claims are verified, the mass gap could originate at the Level 0-1 boundary. Independent verification of the program's central claims is a priority."
+
+### 3. Does the self-consistency requirement genuinely select m > 0?
+
+**Not in the strong sense. Partially in the weak sense.** The strong claim ("self-consistency requires mass") is killed by the CFT counterexample. The weak claim survives in three forms:
+
+(a) **Convergence selection (Sketch):** The Banach fixed point for massive fields is an exponential attractor; massless fixed points, if they exist, are not. If one interprets "self-consistency" as "accessible by iteration" (Conjecture 1.1), massive configurations are selected.
+
+(b) **Starobinsky mass generation (Sketch):** The de Sitter fixed point generates effective mass for non-conformal fields. Conformal fields remain massless — consistent with the existence of photons.
+
+(c) **Cross-level selection (Conjecture):** Level 3 requires local Hilbert space, which requires local time, which requires massive subsystems. Configurations where ALL fields are massless fail Level 3. At least some fields must be massive for the hierarchy to be self-consistent across all levels.
+
+The honest statement: "Self-consistency does not require all fields to be massive. But cross-level consistency requires at least some massive fields to support the Level 3 structure. The self-consistency map preferentially selects massive configurations through the Banach attractor mechanism."
+
+### 4. What is the most honest statement the hierarchy paper can make about mass?
+
+> Mass enters the hierarchy at Level 2 as a parameter of the matter field content. The self-consistency of the semiclassical Einstein equation is proven (Rigorous) for massive fields with m << M_P, and open for massless fields. Cross-level consistency requires at least some massive fields (Conjecture): without mass, there are no timelike geodesics, no local proper time, no local Hilbert space, and therefore no Level 3 structure.
+>
+> Whether the mass spectrum can be derived from Levels 0-1 is the hierarchy's deepest open problem (Conjecture 3.1). The Asselmeyer-Maluga program provides the leading candidate mechanism; the co-emergence of mass, signature, time, and Hilbert space provides structural motivation; but no derivation exists. The hierarchy's proven results do not depend on resolving this question — they hold for any mass input satisfying the perturbative bound.
+
+### 5. What concrete research would resolve the question?
+
+In order of tractability:
+
+1. **Prove or disprove: does the SCE have a fixed point for massless, conformally coupled fields?** This is a specific mathematical question. A positive answer would confirm that massless fields are self-consistent with gravity (weakening Position 2). A negative answer would dramatically strengthen Position 2.
+
+2. **Prove or disprove: does the Dirac operator on a compact hyperbolic 3-manifold with boundary have a spectral gap?** This is the key mathematical input for Position 1. The spectral theory of Dirac operators on hyperbolic manifolds is a well-studied area; the specific case (compact with boundary, knot complement topology) may be within reach.
+
+3. **Independent verification of the Asselmeyer-Maluga boundary term calculation.** Reproduce the computation of Section 1.2 of Position 1: does the Einstein-Hilbert boundary term on the 3-manifold boundary of a Casson handle decomposition genuinely reduce to a Dirac action? This is a concrete computation that does not require accepting the full program.
+
+4. **Formalize the Level 3 failure for Riemannian signature.** State precisely what "local Hilbert space requires Lorentzian signature" means. Can the Page-Wootters mechanism be adapted to show that conditioning on a massive clock subsystem requires hyperbolicity?
+
+5. **Classify self-consistent field contents.** Given the Starobinsky de Sitter background and the Banach contraction at Level 2, which combinations of field masses and couplings are self-consistent? Does the self-consistency constraint carve out a discrete set, a continuous family, or essentially everything below the Planck scale?
+
+---
+
+## FRAMEWORK.md Hidden-Assumption Check (Applied to the Synthesis)
+
+**Time evolution.** The co-emergence thesis and the "mass generates time" language are vulnerable to temporal reading. The synthesis must be clear: mass does not *create* time. The self-consistent block has massive subsystems, and these subsystems have timelike worldlines. The proper time along these worldlines is a geometric property of the block, not a process. The chain "mass -> signature -> time -> Hilbert space" is an explanatory sequence, not a causal or temporal one.
+
+**Background dependence.** The Asselmeyer-Maluga mechanism uses standard R^4 as a reference (to define "exotic"). The Banach contraction uses a classical background metric as an expansion point. Both are methodological choices, not fundamental backgrounds. The fixed point does not depend on the expansion point (within the convergence ball). The exotic structure is defined relative to standard R^4, but the physical content is the diffeomorphism class, not the comparison.
+
+**Metric signature assumed.** The co-emergence thesis explicitly addresses this: signature is not assumed but is selected by cross-level consistency. The synthesis is consistent with the framework on this point.
+
+**Dimensionality assumed.** Both the exotic smoothness mechanism and the Banach contraction are specific to dimension 4. The synthesis inherits this assumption. The framework's aspiration to derive dimensionality is not addressed here.
+
+**Observer-dependent language.** The synthesis avoids "measurement" and "collapse." Level 3's "local Hilbert space" is defined by marginalization, not by observation.
+
+**Map vs territory.** The iterative convergence of the Banach map is how we compute the fixed point, not how the universe constructs itself. The synthesis maintains this distinction.
+
+---
+
+## Verdict
+
+The debate produces a **nuanced negative result**. The hierarchy cannot currently derive mass. But the negative result is informative:
+
+- **Mass existence** (why any fields are massive at all) has a plausible conditional explanation through cross-level consistency: the hierarchy's Level 3 requires massive subsystems.
+- **Mass selection** (why self-consistency prefers massive fields) has a Sketch-level argument through the Banach attractor mechanism and the Starobinsky effective mass.
+- **Mass values** (why m_e = 0.511 MeV) are completely out of reach of the current framework. No known mechanism connects topology to specific mass values, and the historical record of geometric approaches to mass prediction is uniformly negative.
+- **The Asselmeyer-Maluga program** is the only game in town for Conjecture 3.1, but it is a one-group effort without independent verification. The hierarchy paper should reference it as a candidate, not rely on it.
+
+The hierarchy paper's honest position on mass: it is constrained input with a conjectural path to derivation. The co-emergence thesis provides the structural reason to believe the path exists. Walking the path is the deepest open problem in the program.

--- a/programs/co-emergence/explorations/2026-03-03-mass-signature-time-hilbert.md
+++ b/programs/co-emergence/explorations/2026-03-03-mass-signature-time-hilbert.md
@@ -1,0 +1,121 @@
+# Exploration: Mass, Signature, Time, and Hilbert Space as Co-Emergent
+
+**Date:** 2026-03-03
+**Type:** Conceptual synthesis
+**Outcome:** A unified reframing of the signature problem. Mass, Lorentzian signature, local time, and local Hilbert space are four aspects of a single structure that emerges from cross-level self-consistency.
+
+---
+
+## Observations
+
+Three established facts and one conjecture motivate this synthesis.
+
+### 1. Mass is the common feature of GR and QFT
+
+In GR, mass-energy is the source of curvature: $G_{\mu\nu} = 8\pi G\, T_{\mu\nu}$. In QFT, mass defines the spectrum: massive particles are irreducible representations of the Poincaré group with $p^2 = -m^2$ (Wigner 1939). Mass is the one concept that appears in both theories with the same physical meaning. It is the bridge.
+
+### 2. Massive and massless particles have fundamentally different geodesics
+
+- **Massive particles** follow timelike geodesics. They experience proper time $d\tau^2 = -g_{\mu\nu} dx^\mu dx^\nu > 0$.
+- **Massless particles** follow null geodesics. Proper time along a null geodesic is zero.
+
+This is not interpretation. It is the geodesic equation applied to the two cases. The distinction between timelike and null IS the Lorentzian signature. On a Riemannian manifold, all geodesics have the same character — there is no timelike/null/spacelike trichotomy.
+
+### 3. GR prohibits universal time evolution
+
+General relativity proves there is no universal time parameter. Clocks at different locations in a gravitational field tick at different rates (gravitational time dilation, experimentally confirmed). Any formulation that reintroduces a universal clock contradicts established physics (FRAMEWORK.md, Axiom 2).
+
+But mass provides **local** time. A massive particle carries a clock: its proper time along its worldline. This is not universal — it is worldline-dependent, local, and exists only for massive objects. Massless particles do not carry clocks.
+
+### 4. Hilbert space is not fundamental (Conjecture)
+
+The Hilbert space formalism depends on a time parameter:
+- The Schrödinger equation $i\hbar\, \partial|\psi\rangle/\partial t = H|\psi\rangle$ requires $t$.
+- The inner product $\langle\psi|\phi\rangle$ is defined on a spatial slice at fixed $t$.
+- Unitarity ($\langle\psi(t)|\phi(t)\rangle = \langle\psi(0)|\phi(0)\rangle$) requires a preferred foliation.
+
+If there is no universal time (observation 3), there is no universal Hilbert space. But if mass provides local time (observation 2 + 3), then a local Hilbert space exists for massive subsystems — subsystems that carry their own clocks.
+
+---
+
+## The co-emergence thesis
+
+These four concepts are not independent. They are a single structure seen from four angles:
+
+$$\text{mass} \;\longleftrightarrow\; \text{Lorentzian signature} \;\longleftrightarrow\; \text{local time} \;\longleftrightarrow\; \text{local Hilbert space}$$
+
+Each requires the others:
+
+- **Without mass:** No timelike geodesics → no proper time → no local clocks → no Hilbert space formalism. The conformal structure (null cones) exists, but the full metric is undetermined within its conformal class. The signature distinction is meaningless — there is nothing to distinguish "timelike" from "spacelike."
+
+- **Without Lorentzian signature:** No timelike/null/spacelike trichotomy → the parameter $m^2$ in the field equation $(\Delta + m^2)\phi = 0$ shifts the Laplacian spectrum but does not define a mass shell, a dispersion relation, or propagating degrees of freedom. The parameter exists; the physics does not.
+
+- **Without local time:** No $\partial/\partial t$ → no Schrödinger equation → no unitary evolution → no Hilbert space. This is not a deficiency to be repaired; it is the correct description at the fundamental level (Axiom 2).
+
+- **Without Hilbert space:** No quantum mechanics for subsystems → no $\langle\hat{T}_{\mu\nu}\rangle$ → no self-consistent semiclassical gravity. Level 2 of the hierarchy requires an effective quantum theory to source the Einstein equation.
+
+The circle closes: mass → signature → time → Hilbert space → $\langle T_{\mu\nu}\rangle$ → gravity → mass.
+
+---
+
+## Implications for the hierarchy
+
+### The signature problem dissolves into the mass problem
+
+The hierarchy doesn't have four independent open problems (signature, measure, marginalization, Hilbert space). It has **one**: where does mass come from? If the self-consistency constraints at Levels 0–1 generate field content with a mass gap, everything else follows:
+
+- Mass gap → hyperbolicity of the wave operator → Lorentzian signature (the only signature that supports propagation on a mass shell)
+- Mass → timelike geodesics → local proper time (local clocks for massive subsystems)
+- Local proper time → local Hilbert space (the Schrödinger formalism applies for subsystems with clocks)
+- Local Hilbert space → $\langle\hat{T}_{\mu\nu}\rangle$ → Level 2 SCE fixed point (already established, Rigorous)
+
+### The Riemannian fixed point fails at Level 3, not Level 2
+
+The Banach contraction analysis (B1 result, confirmed in this session) shows that the contraction constant $\kappa \sim (m/M_P)^2$ is the same on both Riemannian and Lorentzian manifolds. The self-consistency map has fixed points on both signatures. This is not a bug — it is informative.
+
+The Riemannian fixed point passes Level 2 (the SCE is satisfied) but fails Level 3: there are no timelike geodesics, no proper time, no local clocks, and therefore no local Hilbert space. The marginalization of the smooth-structure measure cannot produce a density matrix because there is no time parameter to define the Hilbert space it would act on.
+
+Signature is selected not by any single level, but by the requirement that **all levels be simultaneously consistent** — precisely the content of Axiom 1.
+
+### Levels are resolutions, not stages
+
+This must be stated with emphasis because the co-emergence thesis is especially vulnerable to the "temporal stages" misreading (FRAMEWORK.md warning). The statement "mass gap → Lorentzian signature → local time → local Hilbert space" reads as a causal chain. It is not. These are simultaneous aspects of the self-consistent block, expressed in the only order available to linear text.
+
+The block does not first acquire a mass gap, then a signature, then time, then quantum mechanics. It satisfies all constraints at all levels at once. The chain is our explanation, not its construction.
+
+---
+
+## What this does NOT solve
+
+1. **The mass gap origin.** Where does mass come from? This is now the single most important open problem. The Asselmeyer-Maluga program (exotic smooth structures generating gravitational sources and fermion fields from pure topology) is the closest prior art but is unverified. Without a mechanism for the mass gap, the co-emergence thesis is a conditional: IF mass, THEN everything else.
+
+2. **The marginalization conjecture.** Even granting local Hilbert spaces for massive subsystems, the mathematical mechanism by which marginalizing $\mu^*$ produces a density matrix is unspecified.
+
+3. **Vacuous circle vs productive fixed point.** The co-emergence of mass, signature, time, and Hilbert space is presented as a fixed point. But not every circle is a productive fixed point. The difference is whether the coupled system has nontrivial solutions accessible by iteration (Conjecture 1.1). The existence of the physical universe proves a solution exists. The hierarchy's constraints must be shown to select it.
+
+---
+
+## Rigor assessment
+
+- **Observations 1–3:** Rigorous. These are established physics/mathematics.
+- **Conjecture (observation 4):** Conjecture. The claim that Hilbert space is emergent is well-motivated but unproven. The Page-Wootters mechanism provides a partial model; the full marginalization conjecture is open.
+- **Co-emergence thesis:** Conjecture. The connections are individually established, but the claim that they form a self-selecting fixed point is not proven. The conditional form ("IF mass gap THEN the rest follows") is at the Sketch level; the unconditional form is Conjecture.
+- **Riemannian failure at Level 3:** Sketch. The argument that Riemannian fixed points cannot support Level 3 is plausible and structurally sound, but the marginalization conjecture at Level 3 is not sufficiently developed to make this rigorous.
+
+---
+
+## Relationship to prior explorations
+
+- **B1 (negative):** Level 2 does not distinguish signatures → confirmed by Banach contraction analysis. The co-emergence thesis explains WHY: the signature selection operates at the cross-level constraint, not at Level 2 alone.
+- **C1 (negative):** Intersection form does not force Lorentzian signature → the co-emergence thesis abandons the direct topological route. The signature bridge passes through mass, not through the intersection form.
+- **Signature-mass codependence debate:** The co-emergence thesis subsumes and sharpens the debate's joint fixed-point conjecture. Position 3's "nontrivial fixed points only for Lorentzian" becomes "Level 3 consistency only for Lorentzian," which is a more precise claim.
+
+---
+
+## Concrete next steps
+
+1. **Verify the Asselmeyer-Maluga program.** Does exotic smooth structure on $\mathbb{R}^4$ generate massive field content? This is the critical antecedent. Paper-grade citation verification required.
+
+2. **Formalize the Level 3 failure for Riemannian signature.** State precisely what "local Hilbert space requires local time" means mathematically. Can the Page-Wootters mechanism be adapted to show that conditioning on a massive clock subsystem requires Lorentzian signature?
+
+3. **Rewrite Section 8 of the hierarchy paper.** Replace the intersection form → metric signature conjecture with the co-emergence thesis. State the Signature Selection Principle as: nontrivial cross-level self-consistency requires Lorentzian signature with $m > 0$.

--- a/programs/co-emergence/explorations/2026-03-03-massless-fixed-point.md
+++ b/programs/co-emergence/explorations/2026-03-03-massless-fixed-point.md
@@ -1,0 +1,76 @@
+# Exploration: Massless Fixed Points of the SCE
+
+**Date:** 2026-03-03
+**Type:** Research investigation
+**Outcome:** The Starobinsky de Sitter solution is a massless self-consistent fixed point. It is signature-blind (the round S⁴ is the Riemannian analogue). This confirms that Level 2 self-consistency does not distinguish signatures for ANY field content — massive or massless. Signature selection must operate at the cross-level constraint.
+
+---
+
+## Question
+
+Does the SCE have a fixed point for massless conformally coupled fields? If so, does it distinguish metric signatures?
+
+## Answer
+
+**Yes, and no.**
+
+### The Starobinsky de Sitter solution is massless and self-consistent (Rigorous)
+
+The SCE on FRW spacetime with conformal matter admits an exact de Sitter solution (Starobinsky 1980). The mechanism is the trace anomaly: ⟨T^μ_μ⟩ = aE₄ + cW² gives a nonzero stress-energy even for massless fields. On de Sitter (conformally flat, so W = 0), the full stress-energy is ⟨T_μν⟩ = ρ_eff g_μν by SO(1,4) symmetry (Bunch-Davies 1978). Self-consistency is exact for the full tensor, not just the trace.
+
+This is a self-consistent Level 2 fixed point with m = 0.
+
+**Caveat:** "Conformal matter" here means fields whose classical action is conformally invariant but whose quantum trace anomaly is nonzero — spin-1/2 fermions, spin-1 gauge bosons, or non-minimally coupled scalars. A single conformally coupled scalar (ξ = 1/6, m = 0) has zero trace anomaly in 4D; the Starobinsky mechanism requires multiple fields or fields of higher spin.
+
+### The massless fixed point is signature-blind (Rigorous)
+
+The round 4-sphere S⁴ is a self-consistent Riemannian solution of the SCE with conformal matter, by exactly the same symmetry argument:
+
+- S⁴ is conformally flat (W = 0), maximally symmetric (SO(5))
+- ⟨T_μν⟩ = ρ_eff g_μν by SO(5) symmetry
+- The self-consistency condition is the same algebraic equation for the radius
+
+The 4-sphere is the Euclidean section of de Sitter (the Hartle-Hawking instanton). Both are self-consistent. Level 2 does not distinguish signatures for massless fields, just as B1 showed it does not distinguish signatures for massive fields.
+
+### The massless fixed point does not support Level 3 (Sketch)
+
+De Sitter with only conformal massless matter has:
+
+- A well-defined Lorentzian metric ✓
+- Timelike geodesics (the metric is Lorentzian) ✓
+- **No massive particles** ✗
+- **No local clocks** (no proper time along massive worldlines — there are no massive objects) ✗
+- **No decoherence, no classicality, no effective QM** ✗
+
+The Starobinsky solution is a self-consistent geometry in equilibrium with quantum vacuum fluctuations. It is consistent at Level 2 but empty at Level 3.
+
+### Stability
+
+Within FRW: the Starobinsky de Sitter is a stable attractor (Rigorous). Anisotropic perturbations isotropize (Sketch — strong evidence from R² gravity). General perturbative stability is open.
+
+For the Banach contraction: fails for m = 0. The non-local kernel decays algebraically (not exponentially), and the Hilbert-Schmidt bound diverges. The Schauder theorem might establish existence without the contraction property, but gives existence without uniqueness. Multiple massless fixed points near a given classical background are possible (Conjecture).
+
+## Implications
+
+### Level 2 is completely signature-blind
+
+This is now established for all field content:
+
+| | Massive (Banach) | Massless (Starobinsky) |
+|---|---|---|
+| Lorentzian fixed point | Exists (Rigorous) | Exists (Rigorous) |
+| Riemannian fixed point | Exists (B1 result) | Exists (S⁴, Rigorous) |
+| Signature sensitivity | None | None |
+| Level 3 support | Yes | No |
+
+Signature selection does not happen at Level 2 — not for massive fields, not for massless fields, not perturbatively, not exactly. If signature is selected, it is selected by cross-level consistency: Levels 0-1-2-3 simultaneously.
+
+### The co-emergence thesis is sharpened
+
+The refined conjecture: among all self-consistent fixed points of the SCE (Level 2), only those with Lorentzian signature AND massive field content support Level 3 (effective QM, local Hilbert space, local time). The Starobinsky/S⁴ solutions are both Level 2 consistent and both Level 3 empty.
+
+Mass is what separates "geometrically consistent" from "physically inhabited."
+
+### The Starobinsky solution as inflationary background
+
+In standard cosmology, the Starobinsky de Sitter is the inflationary phase that precedes the matter-dominated universe. It is physically relevant not as the final state but as the initial state from which massive excitations emerge (via reheating). In the hierarchy's language: the Starobinsky fixed point is where Level 2 first becomes self-consistent; the transition to massive field content is where Level 3 turns on. This temporal description must be handled carefully per FRAMEWORK.md — the block satisfies all constraints simultaneously, not sequentially.

--- a/programs/co-emergence/explorations/2026-03-03-position1-exotic-mass.md
+++ b/programs/co-emergence/explorations/2026-03-03-position1-exotic-mass.md
@@ -1,0 +1,252 @@
+# Position 1: Exotic Smooth Structures Generate Mass from Pure Topology
+
+**Date:** 2026-03-03
+**Type:** Position paper (debate on mass gap origin)
+**Position:** The mass gap in the self-consistency hierarchy originates at Level 0-1 (topological/smooth), not Level 2 (metric). Exotic smooth structures on 4-manifolds generate massive field content from pure topology.
+
+---
+
+## Executive Summary
+
+The Asselmeyer-Maluga program, developed over two decades, provides the most concrete existing mechanism for generating matter --- including fermions with spin-1/2 --- from pure 4-dimensional differential topology. The mechanism operates at the Level 0-1 boundary of the self-consistency hierarchy: a topologically trivial 4-manifold (R^4) equipped with an exotic smooth structure necessarily contains non-trivial compact 3-manifolds in its interior, and these 3-manifolds generate source terms in the Einstein-Hilbert action that are identifiable as fermion fields. The mathematical chain is: exotic smooth structure -> Casson handle decomposition -> non-trivial 3-manifold boundaries -> Einstein-Hilbert boundary terms -> Dirac action for spinor fields. This is the strongest existing candidate for placing the mass gap's origin at the topological/smooth level.
+
+---
+
+## 1. The Mathematical Mechanism
+
+### 1.1. Exotic R^4 and Non-Trivial 3-Manifold Boundaries
+
+**(Rigorous)** Every small exotic R^4 has the following property: every compact 4-dimensional submanifold is surrounded by a neighborhood whose boundary is a non-trivial compact 3-manifold (not homeomorphic to S^3). This is a theorem, following from the construction of exotic R^4 via Casson handles.
+
+The construction proceeds as follows:
+
+1. **Casson handles.** A Casson handle is built by iteratively attaching kinky handles (D^2 x D^2 with self-plumbings) to resolve intersection points. Each stage resolves the self-intersections of the previous stage, pushing them to the next level. The direct limit is a topological 2-handle (by Freedman's theorem) but NOT a smooth 2-handle --- this is precisely the gap between topological and smooth categories that makes dimension 4 special.
+
+2. **Bizaca's explicit construction.** Bizaca constructed explicit exotic R^4's using handle decompositions of Casson handles [Bizaca, "An explicit family of exotic Casson handles," *Proc. Amer. Math. Soc.* 123 (1995)]. The small exotic R^4 is determined by an Akbulut cork and its embedding via an attached Casson handle.
+
+3. **3-manifold boundaries.** For the simplest small exotic R^4, the surrounding 3-manifold Sigma arises from 0-framed surgery along Whitehead doubles of pretzel knots. By the JSJ decomposition theorem (Jaco-Shalen, Johannson), this decomposes as:
+
+   Sigma = H_1 ∪_{T^2} H_2 ∪_{T^2} G
+
+   where H_1, H_2 are hyperbolic 3-manifolds (knot complements), G is a graph manifold (D^2 x S^1), and the T^2 are torus interfaces.
+
+**Citation:** T. Asselmeyer-Maluga and C.H. Brans, "How to include fermions into General Relativity by exotic smoothness," *Gen. Relativ. Gravit.* 47, 30 (2015). [Verified: arXiv:1502.02087, published in GRG vol. 47]
+
+### 1.2. From 3-Manifold Boundaries to Spinor Fields
+
+**(Sketch)** The key step connecting topology to fermion physics proceeds through the Einstein-Hilbert boundary term. Given an embedding iota: Sigma -> M of the 3-manifold boundary into the 4-manifold:
+
+1. A small tubular neighborhood U_epsilon = iota(Sigma) x [0, epsilon] carries a product metric with normal vector field.
+
+2. The 4-dimensional Dirac operator D^M restricted to U_epsilon decomposes as:
+
+   D^M Phi = D^Sigma phi - H phi
+
+   where H is the mean curvature of the embedding and phi is the 3-dimensional spinor restriction.
+
+3. Setting D^M Phi = 0 (the massless Dirac equation in 4D) yields the constraint:
+
+   D^Sigma phi = H phi
+
+   with |phi|^2 = const. This transforms the mean curvature into an eigenvalue of the 3-dimensional Dirac operator.
+
+4. The Einstein-Hilbert boundary integral then becomes:
+
+   integral_Sigma H sqrt(h) d^3x = integral_Sigma phi-bar D^Sigma phi sqrt(h) d^3x
+
+   The left side is a gravitational boundary term; the right side is a Dirac action. The difference in boundary actions between the standard and exotic smooth structures generates the fermion source term.
+
+**Status:** The individual steps (Dirac operator decomposition on product manifolds, boundary term identification) are standard differential geometry. The identification of the boundary term difference as a physical fermion field is the conjectural step.
+
+### 1.3. Fermions as Hyperbolic Knot Complements
+
+**(Conjecture)** The Asselmeyer-Maluga program proposes the identification:
+
+> **Fermions <-> hyperbolic knot complements**
+> **Bosons <-> torus bundles**
+
+This is motivated by several correspondences:
+
+1. **Spin-1/2 from topology.** Friedman and Sorkin showed that asymptotically flat 3-manifolds with non-trivial topology can carry half-integral angular momentum [J.L. Friedman and R.D. Sorkin, "Spin 1/2 from gravity," *Phys. Rev. Lett.* 44, 1100 (1980)]. The key result: a 2pi rotation is NOT continuously deformable to the identity for certain 3-manifold topologies, producing spinorial behavior from pure geometry. Knot complements with hyperbolic geometry fall into this class.
+
+2. **Mostow rigidity.** For hyperbolic 3-manifolds of finite volume, Mostow's rigidity theorem guarantees that the geometry is completely determined by the topology: any diffeomorphism is induced by an isometry. This means the volume vol(H) is a topological invariant. In cosmological models with scale factor a(t), the energy density associated with these objects scales as rho ~ a^{-3}, matching the equation of state for pressureless matter (p = 0). This is the correct scaling for massive particles.
+
+3. **Three fermion generations.** In the model of [T. Asselmeyer-Maluga, "Braids, 3-manifolds, elementary particles: number theory and symmetry in particle physics," *Symmetry* 11(10), 1298 (2019)], every 3-manifold can be represented as a 3-fold branched cover of S^3 (Alexander's theorem). For knot complements, this yields 3-fold branched covers of D^3 branched along 3-braids. The three sheets of the branched cover are proposed to correspond to three fermion generations. There are only three classes of torus bundles, proposed to correspond to the three gauge groups.
+
+**Citation status:** Friedman-Sorkin (1980) is verified. Mostow rigidity is a standard theorem. The Asselmeyer-Maluga (2019) paper is verified (published in *Symmetry*). The physical identifications (knot complement = fermion, torus bundle = boson, branching = generations) are conjectures.
+
+---
+
+## 2. The Brans Conjecture: Exotic Smoothness as Gravitational Source
+
+**(Sketch)** The foundational claim of this program is the **Brans conjecture**: exotic smoothness can serve as an additional source of gravity. The status:
+
+- **Compact manifolds:** Confirmed by Asselmeyer using direct computation of the Einstein-Hilbert action [T. Asselmeyer, "Generation of source terms in general relativity by differential structures," *Class. Quantum Grav.* 14, 749 (1996)]. The change in smooth structure modifies the curvature tensor, generating non-zero source terms even on topologically trivial manifolds.
+
+- **Exotic R^4:** Confirmed by Sladkowski using Taylor's invariant [J. Sladkowski, "Exotic smoothness, noncommutative geometry, and particle physics," *Int. J. Theor. Phys.* 35, 2075 (1996)]. Exotic differential structures on R^4 generate gravitational effects without modifying the Einstein equations or introducing new matter fields.
+
+- **Identification of sources as fermions:** Partially established in the 2015 Asselmeyer-Maluga & Brans paper (Section 1.2 above). The boundary terms are identifiable with the Dirac action, but the full identification of specific fermion properties (charge, mass values, coupling constants) with knot invariants remains open.
+
+**Key point for this debate:** The Brans conjecture, at the level it has been confirmed, establishes that exotic smoothness generates gravitational *source terms*. It does NOT establish that these sources have a mass gap. The sources could, in principle, be massless.
+
+---
+
+## 3. Does Exotic Smoothness Generate a Mass GAP?
+
+This is the critical question. Three levels of strength are possible:
+
+### 3.1. Generating fields that HAVE a mass parameter (Weak claim)
+
+**(Sketch)** The Dirac action generated from the boundary term is:
+
+integral_Sigma phi-bar D^Sigma phi sqrt(h) d^3x
+
+The 3-dimensional Dirac operator D^Sigma on a hyperbolic 3-manifold has a discrete spectrum (the manifold is compact with boundary). The eigenvalues of D^Sigma play the role of mass parameters for the fermion modes. Since the spectrum is discrete and generically non-zero, mass parameters exist and are generically non-zero.
+
+The Mostow rigidity theorem guarantees that these eigenvalues are topological invariants --- they depend only on the knot type, not on any metric choice. This is remarkable: the mass parameters are determined by topology alone.
+
+**Assessment:** This argument is plausible but has gaps. The identification of eigenvalues of D^Sigma with physical masses requires the full 4-dimensional dynamics, not just the boundary term. The spectrum of D^Sigma on a compact hyperbolic manifold with boundary is not fully characterized in general.
+
+### 3.2. Generating a mass GAP m > 0 (Strong claim)
+
+**(Conjecture)** For a hyperbolic 3-manifold H with volume vol(H), the lowest non-zero eigenvalue of the Dirac operator is bounded below by a positive constant that depends on vol(H) and the injectivity radius. If the 3-manifold is a knot complement with finite hyperbolic volume, there are no zero modes of D^Sigma (the Atiyah-Singer index theorem on odd-dimensional manifolds gives zero index, but this does not preclude zero eigenvalues; the hyperbolic metric with its negative curvature generically lifts them).
+
+The mass gap claim would be: for every hyperbolic knot complement appearing in the JSJ decomposition of a small exotic R^4, the lowest eigenvalue of D^Sigma is strictly positive. This would mean that exotic smoothness forces m > 0.
+
+**Assessment:** This is the strongest version of the position and the one most relevant to the co-emergence thesis. It has NOT been rigorously established. The spectral theory of the Dirac operator on hyperbolic 3-manifolds with boundary is non-trivial, and general results guaranteeing a spectral gap are not available. This is the single most important gap in the program.
+
+### 3.3. Determining specific mass VALUES (Strongest claim)
+
+**(Conjecture, partially supported)** The Asselmeyer-Maluga and Krol paper on neutrino masses provides the most concrete result in this direction:
+
+- Exotic smoothness on S^3 x R induces topological transitions in the spatial slices.
+- The first transition corresponds to the GUT energy scale; the second to the electroweak scale.
+- These energy scales are topological invariants (determined by volumes of hyperbolic pieces via Mostow rigidity).
+- The seesaw mechanism, combined with these topologically determined energy scales, yields neutrino masses "in very good agreement with experiments."
+
+**Citation:** T. Asselmeyer-Maluga and J. Krol, "A topological approach to Neutrino masses by using exotic smoothness," *Mod. Phys. Lett. A* 34, 1950105 (2019). [Verified: arXiv:1801.10419, published in MPLA]
+
+**Assessment:** This is the most impressive quantitative result of the program. However, the derivation involves multiple conjectural steps (identification of topological transitions with physical energy scales, application of the seesaw mechanism in this context). The agreement with experiment is suggestive but not definitive.
+
+### 3.4. The cosmological constant
+
+**(Sketch)** Asselmeyer-Maluga and Krol derive the cosmological constant as a topological invariant of a small exotic R^4 embedded in standard R^4, obtaining a value in agreement with Planck satellite measurements.
+
+**Citation:** T. Asselmeyer-Maluga and J. Krol, "How to obtain a cosmological constant from small exotic R^4," *Phys. Dark Universe* 19, 66 (2018). [Verified: arXiv:1709.03314, published in PDU]
+
+**Assessment:** The derivation relies on admitting hyperbolic geometry for the exotic R^4, with the cosmological constant expressed as a combination of topological invariants. The use of K3#CP-bar(2) as the ambient surface introduces structure that may not be fully justified.
+
+---
+
+## 4. Relationship to the Self-Consistency Hierarchy
+
+### 4.1. Where the mechanism operates
+
+The exotic smoothness mechanism operates precisely at the Level 0 -> Level 1 boundary:
+
+- **Level 0 (Topological):** The PL manifold type is specified. For exotic R^4, the underlying topological manifold is standard R^4.
+- **Level 1 (Smooth):** The choice of exotic smooth structure determines which compact 3-manifolds appear as boundaries of compact subsets. Different exotic structures yield different 3-manifold inventories, hence different field content.
+
+The measure mu* on smooth structures (Level 1) directly determines the matter content. This is exactly what the hierarchy paper proposes: the smooth-structure measure replaces both the wavefunction and the path integral measure.
+
+### 4.2. Connection to the co-emergence thesis
+
+If exotic smoothness generates a mass gap (Section 3.2), the co-emergence chain completes:
+
+1. Exotic smooth structure on R^4 -> non-trivial hyperbolic 3-manifold boundaries (Level 1)
+2. Hyperbolic 3-manifolds -> spinor source terms with discrete spectrum, m > 0 (Level 1 -> Level 2 bridge)
+3. m > 0 -> Lorentzian signature required for propagation on mass shell (Level 2)
+4. Lorentzian signature -> local proper time for massive subsystems (Level 2 -> Level 3 bridge)
+5. Local proper time -> local Hilbert space -> density matrix from marginalization (Level 3)
+
+The circle closes because the SCE fixed point at Level 2, sourced by <T_{mu nu}> from the fermion fields, constrains the metric, which constrains which smooth structures are self-consistent, which constrains the matter content.
+
+### 4.3. The measure problem
+
+The hierarchy paper's central open problem is constructing a natural measure mu* on the space Sm(M) of smooth structures. The Asselmeyer-Maluga program suggests a specific candidate: the "smoothness part" of the gravitational path integral. In [T. Asselmeyer-Maluga, "Exotic Smoothness and Quantum Gravity," *Class. Quantum Grav.* 27, 165002 (2010)], the author computes expectation values by summing over exotic smooth structures generated by knot surgery (Fintushel-Stern construction), using Mostow rigidity to assign topological weights.
+
+This is not yet a complete construction of mu*, but it provides a concrete starting point: the measure on Sm(M) is inherited from the combinatorics of knot surgery operations that generate different exotic structures.
+
+---
+
+## 5. FRAMEWORK.md Warning Checks
+
+### 5.1. Does this mechanism smuggle in time evolution?
+
+**Partially.** The Asselmeyer-Maluga program frequently uses cosmological language: "topology change," "phase transitions," "evolution from S^3 to a homology 3-sphere and back." The neutrino mass calculation (Section 3.3) explicitly invokes a cosmological timeline with "first" and "second" topological transitions. This language implies temporal ordering.
+
+However, the underlying mathematics is about the 4-dimensional smooth structure as a whole. The "topology changes" are features of the block --- different spatial slices have different topologies because the 4-manifold has a particular smooth structure. The temporal language is a description of the block's structure in a particular slicing, not a fundamental time evolution. Whether this distinction can be maintained rigorously depends on whether the results can be restated as constraints on the 4-dimensional block without reference to any preferred foliation.
+
+**Verdict:** The mechanism itself (exotic smooth structure -> 3-manifold boundaries -> spinor fields) does not require time. The specific applications (cosmological evolution, neutrino masses) use temporal language that may or may not be eliminable. This requires careful attention.
+
+### 5.2. Does it assume a background?
+
+**Yes, partially.** The construction of exotic R^4 as "standard R^4 with a different smooth structure" uses the standard R^4 as a reference. More seriously, the identification of the fermion source terms requires an embedding of the 3-manifold boundary into the 4-manifold, which introduces a preferred submanifold. In the co-emergence framework, this embedding should emerge from self-consistency, not be put in by hand.
+
+### 5.3. Does it assume dimensionality?
+
+**Yes.** The entire mechanism depends on dimension 4 being special (exotic smooth structures exist only in dimension 4 for R^n). The framework's aspiration is to derive dimensionality, not assume it. However, one could argue this is acceptable: if the self-consistency constraints select dimension 4, and exotic smoothness exists only in dimension 4, then the existence of matter is a consequence of the dimensionality selection.
+
+### 5.4. Does it assume the metric signature?
+
+**No, mostly.** The construction of exotic R^4 and the 3-manifold boundaries is purely smooth-topological --- no metric is assumed. However, the identification of the boundary terms as Dirac spinor fields requires a spin structure, which requires orientability and a metric. The Mostow rigidity results apply to Riemannian (positive-definite) hyperbolic metrics on the 3-manifolds. The extension to Lorentzian signature is not trivial and is not addressed in the program.
+
+**This is a significant gap.** The position claims mass originates at Level 0-1 (before the metric), but the mathematical identification of the source terms as fermions requires metric-level structure. This is a circularity that the co-emergence thesis acknowledges but does not resolve.
+
+---
+
+## 6. Honest Assessment of Weaknesses
+
+1. **The mass gap is not proven.** The strongest claim (Section 3.2) --- that the Dirac operator on the relevant hyperbolic 3-manifolds has a spectral gap --- is conjectured, not established. Without this, the mechanism generates fields that *may* have mass, but does not force m > 0.
+
+2. **The fermion identification is conjectural.** The proposal that hyperbolic knot complements ARE fermions is motivated by analogies (spin-1/2 from Friedman-Sorkin, a^{-3} scaling from Mostow rigidity, three generations from 3-fold branched covers) but is not derived from first principles. Crucially, no specific knot has been identified with a specific fermion (electron, muon, tau, quarks).
+
+3. **The metric is needed for the Dirac operator.** The mechanism claims to operate at Level 0-1 (before the metric), but the Dirac operator and spinor fields are metric-dependent objects. The position is that the *topology* determines the field content, and the *metric* determines the dynamics, but this separation is cleaner in words than in the mathematics.
+
+4. **Background dependence.** The construction uses standard R^4 as a reference and embeds 3-manifolds with a preferred embedding. A fully background-independent formulation is not available.
+
+5. **Limited community uptake.** The Asselmeyer-Maluga program is a relatively isolated research effort. It has not been widely adopted or independently verified by the broader mathematical physics community. The key papers are published in peer-reviewed journals (*Gen. Relativ. Gravit.*, *Class. Quantum Grav.*, *Mod. Phys. Lett. A*, *Phys. Dark Universe*, *Symmetry*), but the results have not been independently reproduced.
+
+6. **Quantitative predictions are limited.** Beyond the neutrino mass calculation and cosmological constant, there are no other quantitative predictions that have been checked against experiment. The program does not predict electron mass, proton mass, or other Standard Model parameters from topology.
+
+---
+
+## 7. What This Position Contributes to the Debate
+
+Despite its weaknesses, this position provides three things that no other approach offers:
+
+1. **A concrete mathematical chain from topology to matter.** The path exotic R^4 -> Casson handle -> 3-manifold boundary -> Dirac action is specific and calculable. It is not a vague hope that "topology might explain matter" --- it is a detailed mechanism with identifiable steps where it could fail (and therefore where it can be tested).
+
+2. **Mostow rigidity as a mass-determination principle.** The topological invariance of hyperbolic volumes, guaranteed by Mostow rigidity, provides a mechanism by which mass parameters could be determined by topology alone, with no free parameters. This is exactly what the self-consistency hierarchy needs: a way for Level 0-1 to determine Level 2's matter content without Level 2 input.
+
+3. **A natural home in the self-consistency hierarchy.** The mechanism operates at precisely the right level (Level 0-1) and produces precisely the right output (fermion fields with topologically determined parameters) to serve as the "mass gap origin" that the co-emergence thesis requires.
+
+---
+
+## Verified Citations
+
+1. T. Asselmeyer-Maluga and C.H. Brans, "How to include fermions into General Relativity by exotic smoothness," *Gen. Relativ. Gravit.* 47, 30 (2015). arXiv:1502.02087.
+2. T. Asselmeyer-Maluga and C.H. Brans, *Exotic Smoothness and Physics: Differential Topology and Spacetime Models* (World Scientific, 2007). ISBN 978-981-02-4195-7.
+3. T. Asselmeyer-Maluga, "Exotic Smoothness and Quantum Gravity," *Class. Quantum Grav.* 27, 165002 (2010). arXiv:1003.5506.
+4. T. Asselmeyer-Maluga and J. Krol, "A topological approach to Neutrino masses by using exotic smoothness," *Mod. Phys. Lett. A* 34, 1950105 (2019). arXiv:1801.10419.
+5. T. Asselmeyer-Maluga and J. Krol, "How to obtain a cosmological constant from small exotic R^4," *Phys. Dark Universe* 19, 66 (2018). arXiv:1709.03314.
+6. T. Asselmeyer-Maluga, "Braids, 3-manifolds, elementary particles: number theory and symmetry in particle physics," *Symmetry* 11(10), 1298 (2019). arXiv:1910.09966.
+7. J. Sladkowski, "Exotic smoothness, noncommutative geometry, and particle physics," *Int. J. Theor. Phys.* 35, 2075 (1996).
+8. J.L. Friedman and R.D. Sorkin, "Spin 1/2 from gravity," *Phys. Rev. Lett.* 44, 1100 (1980).
+9. T. Asselmeyer-Maluga and H. Rose, "On the geometrization of matter by exotic smoothness," *Gen. Relativ. Gravit.* 44, 2825 (2012).
+10. T. Asselmeyer-Maluga, *The Wild Fractal Nature of Spacetime: Smooth Quantum Gravity and Cosmology* (World Scientific, forthcoming July 2025).
+
+---
+
+## Rigor Summary
+
+| Claim | Level | Key Gap |
+|-------|-------|---------|
+| Exotic R^4 contains non-trivial 3-manifold boundaries | **Rigorous** | None (theorem) |
+| Brans conjecture: exotic smoothness generates gravitational sources | **Sketch** | Full characterization of sources incomplete |
+| 3-manifold boundary terms = Dirac action | **Sketch** | Requires metric; identification is formal |
+| Fermions = hyperbolic knot complements | **Conjecture** | No specific fermion-knot identification |
+| Mass gap from Dirac spectrum on hyperbolic 3-manifolds | **Conjecture** | Spectral gap not proven |
+| Neutrino masses from exotic S^3 x R | **Conjecture** (with quantitative support) | Multiple conjectural steps |
+| Cosmological constant from exotic R^4 | **Sketch** (with quantitative support) | Ambient space construction not fully justified |
+| Three generations from 3-fold branched covers | **Conjecture** | Numerological without further derivation |

--- a/programs/co-emergence/explorations/2026-03-03-position2-self-consistent-mass.md
+++ b/programs/co-emergence/explorations/2026-03-03-position2-self-consistent-mass.md
@@ -1,0 +1,258 @@
+# Position 2: Mass from Self-Consistency
+
+**Date:** 2026-03-03
+**Type:** Position paper (debate on mass gap origin)
+**Position:** Mass is not an input to the hierarchy — it is determined by the self-consistency constraint itself. The requirement that the semiclassical Einstein equation have a convergent fixed point SELECTS m > 0.
+
+---
+
+## Core Argument
+
+The companion paper (`programs/fixed-point-existence/index.tex`) establishes the Banach contraction for the semiclassical Einstein equation with contraction constant:
+
+$$\kappa \sim \frac{1}{2\pi}\left(\frac{m}{M_P}\right)^2 \ell_P^2 R \ll 1$$
+
+This is **Rigorous** for massive fields (m > 0). The paper explicitly states that the massless case remains open because the argument breaks down at two specific points. The central claim of this position is: that breakdown is not a technical limitation — it is an obstruction. The self-consistency map has no well-defined fixed point for m = 0, and this means the consistency constraint *requires* m > 0.
+
+---
+
+## 1. The Massless Failure Is Fundamental, Not Technical
+
+### What breaks for m = 0
+
+The companion paper's Lemma 3 (kernel bound) identifies two places where m > 0 is essential:
+
+1. **Non-local kernel decay (Step 4).** For m > 0, the Klein-Gordon resolvent $(-\Delta_\Sigma + m^2 + \xi R|_\Sigma)^{-1}$ has an integral kernel that decays exponentially: $|K(x,y)| \leq C e^{-m \cdot d(x,y)}$. This is a standard property of elliptic resolvents with a spectral gap. For m = 0, the resolvent $(-\Delta_\Sigma + \xi R|_\Sigma)^{-1}$ has only algebraic (power-law) decay. On a compact Cauchy surface $\Sigma$, the operator $-\Delta_\Sigma$ has a zero eigenvalue (constant mode), and the resolvent kernel diverges as $1/\text{Vol}(\Sigma)$ in the zero-mode sector.
+
+2. **Local coefficient infrared behavior (Step 3).** The one-loop coefficients in the local part of the response kernel scale as $\hbar m^2/(4\pi)^2$. For m = 0, these coefficients vanish at leading order, but the next-order contributions involve infrared-sensitive integrals that may diverge.
+
+### Why this is structural, not technical
+
+The exponential decay of the massive kernel is a consequence of the **spectral gap** in the Klein-Gordon operator. The spectral gap is $m^2$ — this is the defining property of mass. The Hilbert-Schmidt bound on the non-local kernel (eq. 14 in the companion paper) requires:
+
+$$\|K_{\text{nl}}\|_{L^2(\Sigma \times \Sigma)} < \infty$$
+
+For exponentially decaying kernels on a compact manifold, this is automatic. For algebraically decaying kernels ($\sim d(x,y)^{-\alpha}$), the Hilbert-Schmidt norm diverges when $\alpha \leq n/2$ (where $n = \dim \Sigma = 3$). The massless propagator in $d = 3$ spatial dimensions decays as $d^{-1}$, which gives $\alpha = 1 < 3/2$, so the Hilbert-Schmidt norm is finite on a compact 3-manifold — but only barely, and the resulting bound grows without limit as $\text{Vol}(\Sigma) \to \infty$ or as the geometry approaches degeneracy.
+
+More seriously: even if the Hilbert-Schmidt norm is finite, the contraction constant $\kappa$ involves $m^2$ in the numerator (from the one-loop scale). For m = 0, the leading-order contribution to $\kappa$ vanishes, and one must go to higher loop order. But at higher orders, the perturbative expansion itself is infrared-unsafe for massless fields — this is the well-known infrared problem in QFT on curved spacetimes, not a peculiarity of this argument. **(Sketch)**
+
+**Assessment:** The failure for m = 0 is not a gap in the proof that could be closed with a better technique. It reflects a genuine structural difference: the self-consistency map for massless fields does not contract, because there is no spectral gap to suppress the non-local correlations that would otherwise prevent convergence. **(Conjecture — the claim that no alternative proof strategy could establish contraction for m = 0 is not proven, but the physical mechanism is clear.)**
+
+---
+
+## 2. Precedents: Self-Consistent Mass Generation in Physics
+
+This position has precise analogues in known physics. In each case, a system with no explicit mass parameter develops a mass gap through a self-consistency (fixed-point) condition.
+
+### 2a. Dynamical Chiral Symmetry Breaking (QCD)
+
+The QCD Lagrangian for light quarks is approximately chirally symmetric — the bare quark masses are nearly zero. Yet the proton mass is 938 MeV, and most of this mass comes not from the bare quark masses (~5 MeV for u, d) but from the quark condensate $\langle \bar{q}q \rangle \neq 0$.
+
+The mechanism is a **self-consistent gap equation** (Schwinger-Dyson equation). The quark self-energy $\Sigma(p)$ satisfies:
+
+$$\Sigma(p) = \int \frac{d^4k}{(2\pi)^4} g^2 D_{\mu\nu}(p-k) \gamma^\mu S(k) \Gamma^\nu(k,p)$$
+
+where $S(k) = (k\!\!\!/ - \Sigma(k))^{-1}$ is the full propagator — which itself depends on $\Sigma$. This is a fixed-point equation: $\Sigma$ appears on both sides. The equation has a trivial solution $\Sigma = 0$ (massless quarks) and, above a critical coupling $g > g_c$, a nontrivial solution $\Sigma \neq 0$ (massive constituent quarks). The nontrivial solution is selected because it has lower free energy.
+
+**The parallel:** The SCE fixed-point map $\mathcal{F}: g \mapsto g'$ is exactly this structure. The metric $g$ determines the quantum state, which determines $\langle T_{\mu\nu} \rangle$, which determines the metric. The m = 0 case corresponds to the trivial solution of the gap equation; the m > 0 case corresponds to the nontrivial solution. The self-consistency constraint selects the nontrivial solution. **(Sketch — the analogy is structural, not a derivation.)**
+
+### 2b. BCS Gap Equation (Superconductivity)
+
+In BCS theory, the superconducting gap $\Delta$ satisfies:
+
+$$\Delta = V \sum_k \frac{\Delta}{2\sqrt{\xi_k^2 + \Delta^2}}$$
+
+This has the trivial solution $\Delta = 0$ (normal metal) and, for sufficiently strong attractive interaction $V$, a nontrivial solution $\Delta > 0$ (superconductor). The nontrivial solution exists for ANY nonzero attractive interaction in a metal with a Fermi surface — no minimum coupling strength is needed.
+
+**The parallel:** If the gravitational self-consistency constraint acts like an attractive interaction on the space of metrics, even a weak coupling (which it is: $\kappa \ll 1$) could generate a nonzero mass gap through the self-consistent feedback loop. **(Conjecture — the BCS analogy is suggestive but the mathematical structures are different.)**
+
+### 2c. Nambu-Jona-Lasinio Model
+
+The NJL model starts with massless fermions interacting via a four-fermion contact interaction. There is no mass parameter in the Lagrangian:
+
+$$\mathcal{L} = \bar{\psi}(i\partial\!\!\!/ )\psi + G[(\bar{\psi}\psi)^2 + (\bar{\psi}i\gamma_5\psi)^2]$$
+
+The self-consistent mean-field approximation gives a gap equation:
+
+$$M = 2G\langle\bar{\psi}\psi\rangle = 2G \cdot N_c \int \frac{d^4p}{(2\pi)^4} \frac{M}{p^2 + M^2}$$
+
+For $G > G_c$ (a critical coupling), the nontrivial solution $M > 0$ exists and is energetically preferred. Mass is generated purely from the self-consistency of the fermion condensate.
+
+**The parallel is exact in structure:** the NJL gap equation is a fixed-point equation for the fermion mass, just as the SCE is a fixed-point equation for the metric. In both cases, the "trivial" solution (M = 0 / flat spacetime with m = 0) exists but may be unstable to the formation of a nontrivial self-consistent state. **(Sketch)**
+
+### 2d. Coleman-Weinberg Mechanism
+
+Coleman and Weinberg (1973) showed that in a classically scale-invariant theory (no mass parameters at tree level), radiative corrections can generate a mass scale through dimensional transmutation. The effective potential develops a minimum away from the origin, spontaneously breaking scale invariance.
+
+Recent work by Alvarez-Luna et al. (2023) has extended this to the **gravitational Coleman-Weinberg mechanism**: in a conformal classical Lagrangian with a non-minimally coupled scalar field, graviton loops trigger a nonzero vacuum expectation value and generate an effective Planck mass. The dimensional transmutation induces the Planck scale without assuming it at tree level.
+
+**The parallel:** If the self-consistency hierarchy operates on a classically conformal theory (no mass parameters at the fundamental level), gravitational loop corrections could generate mass through the Coleman-Weinberg mechanism. The mass would emerge from the self-consistency of the quantum-corrected geometry. **(Conjecture — the gravitational CW mechanism is established for specific models but has not been shown to operate within the SCE fixed-point framework.)**
+
+---
+
+## 3. The Mass-Scale Bootstrap
+
+The contraction constant $\kappa \sim (m/M_P)^2$ involves two mass scales: the field mass $m$ and the Planck mass $M_P = \sqrt{\hbar c/G}$. The Planck mass depends on $G$, the gravitational coupling that appears in the Einstein equation. This suggests a bootstrap structure:
+
+1. **$m$ determines $\kappa$.** The contraction constant depends on the field mass. Larger mass means weaker quantum corrections (larger $\kappa$, but still $\ll 1$).
+
+2. **$\kappa$ determines the quantum correction.** The fixed-point metric $g^* = \bar{g} + O(\kappa)$ differs from the classical metric by $O(\kappa)$.
+
+3. **The quantum correction modifies the effective mass.** On curved spacetime, the effective mass of a scalar field receives curvature corrections: $m_{\text{eff}}^2 = m^2 + \xi R$. The quantum-corrected geometry changes $R$, which changes $m_{\text{eff}}$.
+
+4. **The fixed point of this loop determines $m$.** Self-consistency requires that the mass used to compute $\kappa$ is the same mass that emerges from the quantum-corrected geometry.
+
+This is not circular — it is a fixed-point equation for $m$ itself. Define $m^* = F(m)$ where $F$ maps an input mass to the effective mass on the self-consistent geometry computed using that input mass. Then $m^*$ is the fixed point of $F$.
+
+**Does this equation have nontrivial solutions?** For the curvature coupling $\xi R$, the correction to $m^2$ is of order $\xi \cdot \kappa \cdot R_{\text{classical}} \sim \xi (m/M_P)^2 R$. This is a tiny correction to $m^2$ — it doesn't generate mass from nothing. The bootstrap at this level only determines the self-consistent value of an already-nonzero mass. **(Rigorous — this is just the perturbative fixed point applied to the mass parameter.)**
+
+However, at the non-perturbative level, the situation changes. The Starobinsky fixed point (Section 3 of the companion paper) has $H_0^2 = 180\pi/(G|a_2|)$, which gives a curvature scale set entirely by the trace anomaly coefficient $a_2$ and the Planck scale. On this background, $m_{\text{eff}}^2 = m^2 + \xi \cdot 12H_0^2$. If $m^2$ were zero, the effective mass would be $m_{\text{eff}}^2 = 12\xi H_0^2 \neq 0$ for non-conformally-coupled fields ($\xi \neq 1/6$). The de Sitter background itself generates an effective mass gap.
+
+**This is significant:** even starting from $m = 0$, the Starobinsky de Sitter fixed point generates an effective mass $m_{\text{eff}} \sim \sqrt{\xi} H_0$ for non-conformally-coupled fields. This effective mass then enables the Banach contraction for the perturbative fixed point around the de Sitter background. **(Sketch — the two-step argument (first Starobinsky, then Banach) is structurally sound but the compatibility of the two fixed points has not been proven.)**
+
+---
+
+## 4. Dimensional Transmutation in the Hierarchy
+
+In QCD, the dimensionless coupling $g$ generates a mass scale $\Lambda_{\text{QCD}} \approx 220$ MeV through dimensional transmutation: the running coupling $g(\mu)$ diverges at $\mu = \Lambda_{\text{QCD}}$, so the scale where non-perturbative physics becomes important is set by the coupling's evolution.
+
+Could the self-consistency hierarchy have an analogous mechanism? The hierarchy contains dimensionless quantities at Level 0:
+
+- The Euler characteristic $\chi$ (an integer)
+- The intersection form signature $\sigma$ (an integer)
+- The number of exotic smooth structures (an integer or $\aleph_0$ or $2^{\aleph_0}$)
+
+And it contains dimensional quantities at Level 2:
+
+- The Planck mass $M_P$
+- Particle masses $m_i$
+- The cosmological constant $\Lambda$
+
+The question is whether there is a mechanism linking the two — a "topological dimensional transmutation" where a dimensionless topological invariant generates a mass scale.
+
+**Candidate mechanism:** The trace anomaly provides exactly this link. The trace anomaly coefficients:
+
+$$\langle T^\mu{}_\mu \rangle = a E_4 + c W^2 + b \Box R$$
+
+involve dimensionless numbers $a$, $c$, $b$ that count field content (each massless field contributes a specific rational number to each coefficient). The Starobinsky de Sitter solution $H_0^2 = 180\pi/(G|a_2|)$ then converts these dimensionless field-counting numbers into a dimensional mass scale. The mass scale is:
+
+$$M_{\text{Starobinsky}} = H_0 = \sqrt{\frac{180\pi}{G|a_2|}} \sim \frac{M_P}{\sqrt{|a_2|}}$$
+
+This is a form of dimensional transmutation: the dimensionless coefficient $a_2$ (which counts the effective number of fields) combines with the Planck scale to generate the Hubble scale.
+
+**The self-consistency constraint enters here:** Not any field content is self-consistent. The field content determines $a_2$, which determines $H_0$, which determines the background geometry, which must be consistent with the field content propagating on it. If certain field contents lead to inconsistencies (e.g., the effective mass generated by the de Sitter background changes the particle spectrum in a way that changes $a_2$ in a way that changes $H_0$ in a way that invalidates the original calculation), then the self-consistency constraint restricts the allowed field content — and hence the allowed masses.
+
+**Assessment:** This is the most speculative part of the position, but it is structurally compelling. The trace anomaly provides a concrete link between field-counting (a topological/combinatorial quantity) and mass scales (a geometric quantity). The self-consistency of the Starobinsky fixed point constrains which field contents are allowed. Whether this constraint is strong enough to determine specific masses is unknown. **(Conjecture)**
+
+---
+
+## 5. The Conformal Anomaly as Mass Selector
+
+The Starobinsky fixed point demonstrates that the trace anomaly can drive self-consistent cosmological evolution. But the trace anomaly knows about all fields — massive and massless — through their contributions to $a$, $c$, and $b$.
+
+A massive field with $m \gg H_0$ decouples from the trace anomaly (its contribution is suppressed by $(H_0/m)^4$). A massless field contributes fully. This creates a selection effect:
+
+- Fields with $m = 0$ contribute maximally to the trace anomaly and therefore to the de Sitter solution.
+- Fields with $m \gg H_0$ decouple and do not affect the solution.
+- Fields with $m \sim H_0$ are in the intermediate regime where their contribution depends sensitively on $m$.
+
+The self-consistency of the Starobinsky fixed point therefore constrains the mass spectrum most tightly in the region $m \sim H_0$. This is not the electroweak or QCD scale — it is the Hubble scale. But it establishes the principle: the self-consistency of the trace-anomaly-driven fixed point constrains masses.
+
+At higher energies (earlier cosmological epochs, or equivalently higher curvature scales), the relevant Hubble scale is larger, and the constraint applies to heavier fields. In the extreme UV (Planck scale), ALL fields are in the "intermediate" regime, and the self-consistency constraint on the mass spectrum is maximally restrictive.
+
+**Assessment:** This mechanism is physically reasonable and connects to established physics (decoupling of heavy fields, trace anomaly structure). But the claim that it could determine specific mass values (as opposed to constraining the number of light species) is not established. **(Sketch for the principle; Conjecture for the specific determination of masses.)**
+
+---
+
+## 6. The Bifurcation Argument
+
+The strongest version of the position can be stated as a bifurcation theorem (by analogy with the Schwinger-Dyson bifurcation):
+
+**Conjecture (Mass Bifurcation).** Consider the self-consistency map $\mathcal{F}$ for the coupled system (metric + matter fields) on a compact globally hyperbolic spacetime. For coupling strength $G$ below a critical value $G_c$, the only fixed point has $m = 0$ and trivial (flat or conformally flat) geometry. For $G > G_c$, a nontrivial branch bifurcates with $m > 0$ and non-trivially curved geometry.
+
+This would be the gravitational analogue of the chiral phase transition in QCD, where above a critical coupling, the system spontaneously generates mass. The critical coupling $G_c$ would be related to the Planck scale.
+
+**Evidence for the conjecture:**
+- The Schwinger-Dyson analogy (Section 2a) shows this bifurcation structure is generic in self-consistent quantum systems.
+- The Starobinsky fixed point already demonstrates that a nontrivial geometric solution exists when the trace anomaly is nonzero.
+- The massless failure in the Banach argument (Section 1) shows that the m = 0 fixed point, if it exists, has qualitatively different convergence properties — consistent with being on the "trivial branch" below the bifurcation.
+
+**Evidence against:**
+- The Banach argument establishes contraction for massive fields but does not show non-existence of fixed points for massless fields. The Schauder argument (which doesn't need contraction) might still apply.
+- The bifurcation structure requires a nonlinearity that couples mass to geometry. In the SCE, the coupling is through $\langle T_{\mu\nu} \rangle$, but this depends on $m$ as a parameter, not as a dynamical variable. The mass is not a degree of freedom of the SCE — it is an external input.
+
+**(Conjecture — the bifurcation is plausible by analogy but not derived from the SCE framework.)**
+
+---
+
+## Honest Assessment of Weaknesses
+
+### Weakness 1: Mass is not a dynamical variable in the SCE
+
+The most serious weakness of this position is that in the companion paper, $m$ is a fixed external parameter. The SCE is a fixed-point equation for the metric $g_{\mu\nu}$, not for the mass. The self-consistency map $\mathcal{F}$ takes a metric as input and returns a metric as output. Mass enters as a parameter of the matter field theory, not as something determined by the fixed point.
+
+To make the position work, one needs a mechanism by which the fixed-point equation for $g$ implicitly determines $m$. The mass-scale bootstrap (Section 3) provides one candidate: the effective mass $m_{\text{eff}}^2 = m^2 + \xi R$ depends on $R$, which depends on the fixed-point geometry, which depends on $m_{\text{eff}}$. But this only shifts an existing mass — it doesn't generate one from zero.
+
+**The deeper mechanism would need to come from Level 0 or Level 1** — from the topological or smooth structure. This position establishes that self-consistency *requires* mass; it does not establish where mass *comes from*. These are different claims.
+
+### Weakness 2: The massless failure might be resolvable
+
+The companion paper states the massless case as an "open problem," not an impossibility. It is possible that:
+- A different function space (not $H^s$) could give a well-defined map for massless fields.
+- Infrared regularization (finite volume, thermal state) could control the divergences.
+- A non-perturbative argument (Schauder-type, which doesn't need contraction) could establish existence without controlling convergence rate.
+
+If the massless case is resolved, the argument that "self-consistency requires mass" loses its foundation.
+
+### Weakness 3: Confusing convergence rate with existence
+
+The Banach argument fails for m = 0, but this only means the contraction estimate breaks — not that no fixed point exists. The Schauder theorem requires only continuity and compactness, not contraction. A massless SCE fixed point might exist (via Schauder) without being the limit of a convergent iteration (Banach). The iteration not converging does not mean the solution doesn't exist.
+
+However: if the fixed point exists but is not an attractor, this has physical consequences. A non-attractive fixed point is unstable — small perturbations grow rather than decay. A self-consistent solution that is unstable to perturbations is not one that would be observed. This partially rescues the argument: even if the m = 0 fixed point exists, it might be unstable, while the m > 0 fixed point is stable (exponentially attractive by the Banach theorem). **(Sketch)**
+
+### Weakness 4: FRAMEWORK.md warning — temporal language
+
+The "mass-scale bootstrap" (Section 3) and "bifurcation argument" (Section 6) use language that can be read as temporal: "starting from m = 0, the geometry generates an effective mass." This must be understood as a description of the fixed-point structure, not a temporal process. The block does not start massless and then acquire mass. The self-consistent solution simply has $m > 0$ — the "generation" is our description of why, not the block's history.
+
+### Weakness 5: The analogies are only analogies
+
+The QCD gap equation, BCS gap, and NJL model are genuine self-consistent mass generation mechanisms. But they operate in flat spacetime with known Lagrangians. The SCE operates on curved spacetime with the quantum stress-energy tensor sourcing the geometry. The mathematical structures (the relevant function spaces, the nonlinearities, the compactness properties) are different. An analogy with flat-spacetime self-consistency does not constitute a proof of gravitational self-consistency.
+
+---
+
+## Summary of the Position
+
+**Central claim:** The self-consistency constraint of the semiclassical Einstein equation requires m > 0 for the fixed-point iteration to converge. This is not a technical limitation but reflects the structural role of the spectral gap in suppressing non-local correlations.
+
+**Supporting evidence:**
+1. The massless failure in the Banach argument is tied to the absence of a spectral gap — a structural feature, not a proof technique. **(Sketch)**
+2. Self-consistent mass generation from massless starting points has exact precedents: QCD chiral symmetry breaking, BCS superconductivity, NJL model, Coleman-Weinberg mechanism. **(Rigorous — these are established results in their own domains.)**
+3. The Starobinsky de Sitter fixed point generates an effective mass $m_{\text{eff}} \sim \sqrt{\xi} H_0$ for non-conformally-coupled fields, providing a concrete mechanism by which the self-consistent geometry produces a mass gap. **(Sketch)**
+4. The trace anomaly provides a channel for dimensional transmutation: dimensionless field-counting numbers generate mass scales through the self-consistency condition. **(Conjecture)**
+5. The mass bifurcation conjecture — that the coupled system undergoes a phase transition from m = 0 (trivial) to m > 0 (nontrivial) at a critical coupling — has the correct structure by analogy with known condensed matter and particle physics systems. **(Conjecture)**
+
+**What this position does NOT claim:**
+- It does not claim to know the specific values of masses.
+- It does not provide the mechanism that generates bare mass from topology (that is Position 1's territory).
+- It does not explain why specific particles have specific masses — only that the generic feature of a mass gap is required by self-consistency.
+
+**Strongest version:** The self-consistency hierarchy has a mass gap because self-consistency without one is impossible (the iteration does not converge, or the fixed point is unstable). Mass is the price of self-consistency.
+
+**Weakest version:** The self-consistency hierarchy works much better with a mass gap (convergence is exponential, the fixed point is an attractor), and known physics provides multiple mechanisms by which self-consistent systems generate mass gaps from massless starting points. It would be surprising if this system didn't.
+
+---
+
+## Relationship to Other Positions
+
+- **Position 1 (Exotic smooth structures generate mass):** Complementary. Position 1 provides the mechanism; Position 2 provides the selection principle. Even if exotic smooth structures can generate mass, the self-consistency requirement determines *which* mass values are selected.
+- **Position 3 (Mass is an irreducible input):** In tension. If this position is correct, mass is derived, not input. However, Position 3 may be correct at the current level of understanding — we may not yet have the mathematics to derive mass from self-consistency, even if it is in principle derivable.
+
+---
+
+## FRAMEWORK.md Compliance Check
+
+- **Axiom 1 (unique self-consistent solution):** This position directly implements Axiom 1 — the mass gap is selected by self-consistency.
+- **Axiom 2 (no evolution parameter):** The mass-scale bootstrap and bifurcation argument use "generation" language that must be read as structural, not temporal. The fixed point simply has m > 0; nothing "generates" mass in time.
+- **Axiom 3 (purely geometric constraints):** Mass must ultimately have a geometric origin. This position shows self-consistency requires mass but does not show mass is geometric. The connection to geometry depends on Position 1 or an alternative mechanism.
+- **Hidden assumption — time smuggled in:** The Starobinsky de Sitter solution is explicitly time-dependent ($a(t) = a_0 e^{H_0 t}$). This appears to violate Axiom 2. However, the solution is a fixed point of the self-consistency map on FRW metrics — the "time dependence" is a coordinate description of a geometric property of the de Sitter block, not an evolution. The de Sitter spacetime is maximally symmetric and can be described without a preferred time.
+- **Hidden assumption — background smuggled in:** The Banach argument starts from a classical background $\bar{g}$ and perturbs around it. This is a choice of expansion point, not a fundamental background. The fixed point $g^*$ does not depend on $\bar{g}$ (uniqueness guarantees this within the convergence ball).

--- a/programs/co-emergence/explorations/2026-03-03-position3-mass-as-input.md
+++ b/programs/co-emergence/explorations/2026-03-03-position3-mass-as-input.md
@@ -1,0 +1,292 @@
+# Position 3: Mass Is an Irreducible Input
+
+**Date:** 2026-03-03
+**Type:** Position paper (adversarial critique)
+**Position:** The self-consistency hierarchy CANNOT derive mass from its axioms. Mass, or at minimum the mass spectrum, must be accepted as additional input beyond the three axioms and their conjectures.
+
+---
+
+## Executive Summary
+
+The other two positions in this debate argue that mass emerges from exotic smooth structures (Position 1) or from the self-consistency constraint itself (Position 2). Both are almost certainly wrong. The arguments below are organized as specific attacks against each position, followed by structural arguments that apply to both.
+
+**Verdict:** The hierarchy is a framework for organizing self-consistency constraints. It is not, and cannot plausibly become, a mechanism for generating the mass spectrum. The honest version of the hierarchy accepts mass as input at Level 2 and investigates the consequences of that input for cross-level consistency. Claiming to derive mass from topology is an extraordinary claim with no supporting evidence and a long history of analogous failures.
+
+---
+
+## Part I: Against Position 1 (Exotic Smooth Structures Generate Mass)
+
+### Attack 1.1: The Asselmeyer-Maluga Program Is Speculative and Unverified
+
+**Severity: SERIOUS (approaching fatal)**
+
+The claim that exotic smooth structures on R^4 generate matter fields rests almost entirely on the work of Torsten Asselmeyer-Maluga, in collaboration with Carl Brans and Jerzy Krol, spanning roughly two decades (2002-present). The specific mechanism proposed is:
+
+- Exotic R^4 contains embedded 3-manifolds (hyperbolic knot complements, torus bundles)
+- By Thurston's geometrization, these 3-manifolds carry canonical geometric structures
+- Hyperbolic knot complements are identified with fermions; torus bundles with bosons
+- The embedding into the exotic R^4 "generates" source terms in the Einstein-Hilbert action
+
+The problems:
+
+1. **No independent verification.** A search of the literature reveals no independent group that has reproduced or verified the central claims. The program has been developed by essentially one research group over 20+ years. A book summarizing 20 years of this work ("The Wild Fractal Nature of Spacetime") is scheduled for release in July 2025, but this is a monograph by the original author, not an independent assessment. For a claim this extraordinary -- that the mass spectrum of particle physics emerges from pure topology -- the absence of independent verification after two decades is a serious red flag.
+
+2. **Publication venue.** The key papers appear primarily in General Relativity and Gravitation and in MDPI journals (Entropy, Universe, Symmetry). While GRG is a respected journal, the MDPI publications are in journals with less rigorous peer review standards. The work has not appeared in Physical Review Letters, Journal of High Energy Physics, Communications in Mathematical Physics, or other top-tier venues where extraordinary claims would face the most stringent scrutiny.
+
+3. **Citation impact.** The core papers have modest citation counts. "Exotic Smoothness and Quantum Gravity" (2010) and subsequent papers have not generated a significant follow-up literature. Compare this to other geometric approaches to quantum gravity (loop quantum gravity, causal dynamical triangulations, amplituhedra) which have each generated hundreds to thousands of citations and active research communities. The Asselmeyer-Maluga program remains a one-group effort.
+
+4. **The identification is ad hoc.** The claim "hyperbolic knot complements = fermions" and "torus bundles = bosons" is an identification, not a derivation. Why these particular 3-manifold types? Why this particular map to particle types? Thurston's geometrization gives eight model geometries for 3-manifolds. The choice to identify two of them with fermions and bosons is a modeling decision, not a theorem. Nothing in the mathematics forces this identification.
+
+### Attack 1.2: Exotic R^4 Has Trivial H_2
+
+**Severity: FATAL for intersection-form-based arguments**
+
+Every exotic R^4 is homeomorphic to the standard R^4. Therefore:
+
+- H_0(R^4; Z) = Z
+- H_k(R^4; Z) = 0 for all k > 0
+
+In particular, H_2 = 0. The intersection form -- the central mathematical object that makes 4-manifold topology rich (Freedman's theorem, Donaldson's theorem, the 11/8 conjecture) -- is defined on H_2. On R^4 the intersection form is the empty form on the trivial group.
+
+This means: the manifolds where exotic smooth structures are most abundant (uncountably many on R^4) are precisely the manifolds where the intersection form machinery is trivially empty. The mathematical tools that make dimension 4 special -- Donaldson invariants, Seiberg-Witten invariants defined via the intersection form -- have nothing to grab onto.
+
+Position 1 must therefore explain how topology generates field content WITHOUT the intersection form. The remaining mechanism is the smooth structure itself -- the difference between diffeomorphism classes of manifolds that are homeomorphic. But smooth structure is an extremely abstract invariant. The gap between "these two manifolds are not diffeomorphic" and "this smooth structure corresponds to an electron with mass 0.511 MeV" is not a gap that has been bridged by any known mathematics.
+
+### Attack 1.3: The Mechanism Is Vague at the Critical Step
+
+**Severity: FATAL**
+
+The Asselmeyer-Maluga program claims:
+
+1. Exotic R^4 contains topologically nontrivial 3-manifolds (Akbulut corks, Casson handles)
+2. These 3-manifolds carry geometric structures (Thurston geometrization)
+3. The geometric structures "generate source terms" in the Einstein-Hilbert action
+4. These source terms are "equivalent to" matter fields
+
+Step 3 is where the magic happens, and it is precisely the step that is most opaque. What does "generate source terms" mean mathematically? The Einstein-Hilbert action is a functional of the metric. Source terms appear when you couple matter to gravity. But coupling matter to gravity requires specifying a matter Lagrangian -- an action for the matter fields. Where does this Lagrangian come from?
+
+If the answer is "the geometry of the embedded 3-manifold defines the Lagrangian," then the claim is that the topology of a knot complement determines a specific field theory with a specific mass. This is an extraordinary claim. The mathematics of knot complements is rich but has no known mechanism for producing Lagrangians of quantum field theories.
+
+If the answer is "the 3-manifold contributes a deficit angle or conical singularity that looks like a source term in the linearized Einstein equation," then we have a classical gravitational source, not a quantum field. The gap between "classical source" and "quantum field with a mass spectrum" is the entirety of quantum field theory.
+
+The mechanism is either so extraordinary as to require rigorous proof (which does not exist) or so vague as to be unfalsifiable.
+
+---
+
+## Part II: Against Position 2 (Self-Consistent Mass Generation)
+
+### Attack 2.1: The Massless Banach Failure Is Technical, Not Fundamental
+
+**Severity: FATAL to the strong claim; SERIOUS to the weak claim**
+
+The argument from Position 2 runs: the Banach contraction estimate for the semiclassical Einstein equation requires m > 0 because the contraction constant kappa ~ (m/M_P)^2, which diverges or becomes ill-defined as m -> 0. Therefore, self-consistency REQUIRES mass.
+
+This argument proves too much. Nature contains massless fields:
+- Photons (the electromagnetic field)
+- Gluons (the strong force carriers)
+- Gravitons (if they exist as quantum particles)
+
+The universe is manifestly self-consistent AND contains massless fields. If the self-consistency constraint truly required m > 0 for ALL fields, it would predict that photons do not exist. They do. The argument fails by reductio ad absurdum.
+
+The correct interpretation: the BANACH CONTRACTION approach to the SCE fixed point breaks down for massless fields. This means the mathematical tool is incomplete, not that nature forbids massless fields. The fixed point may still exist for massless fields but require a different proof technique (perhaps Schauder's theorem, which does not require the contraction property, or a nonperturbative argument).
+
+The companion paper (fixed-point-existence) already acknowledges this: the Banach result is perturbative and applies to massive fields. The Schauder extension is conditional. The gap for massless fields is a gap in the PROOF, not in nature.
+
+### Attack 2.2: Conformal Field Theories Are Self-Consistent and Massless
+
+**Severity: FATAL to the claim "self-consistency requires mass"**
+
+Conformal field theories (CFTs) are self-consistent quantum field theories with no mass gap. They are:
+
+- Exactly scale-invariant (no characteristic length scale)
+- Perfectly well-defined mathematically (some are rigorously constructed)
+- Self-consistent in every sense of the word: they satisfy all Wightman axioms, have positive-definite Hilbert spaces, respect unitarity, and are closed under the operator algebra
+
+Examples:
+- 2D CFTs (minimal models, free boson, WZW models) -- rigorously constructed
+- 4D N=4 super-Yang-Mills -- the most studied QFT in string theory, exactly conformal
+- The critical Ising model in any dimension -- a CFT at the critical point
+- Banks-Zaks fixed points in QCD-like theories -- CFTs in 4D from asymptotically free gauge theories
+
+If self-consistency required mass, none of these theories could exist. They do. Therefore, self-consistency does not require mass. QED.
+
+The defense that "these CFTs exist on flat space, not as coupled gravity-matter systems" is partially valid -- CFTs coupled to gravity break conformal invariance because gravity introduces a scale (the Planck mass). But this is a feature of the GRAVITATIONAL coupling, not of self-consistency per se. It means that the SCE with conformal matter is a special case requiring separate analysis, not that self-consistency forbids it.
+
+### Attack 2.3: No Mechanism Determines the Mass SCALE
+
+**Severity: FATAL to any claim of predicting the mass spectrum**
+
+Even if one grants -- for the sake of argument -- that self-consistency requires SOME fields to have m > 0, the constraint says nothing about how MUCH mass. The Banach contraction constant is kappa ~ (m/M_P)^2. This is satisfied for ANY m in the range 0 < m << M_P. It is satisfied for m = 0.511 MeV (electron). It is also satisfied for m = 5.11 MeV, m = 51.1 MeV, m = 0.0511 MeV, or any other value below the Planck scale.
+
+The self-consistency constraint is:
+- Blind to the electron mass being 0.511 MeV rather than 5.11 MeV
+- Blind to the muon-electron mass ratio of ~207
+- Blind to the top-bottom mass ratio of ~40
+- Blind to the enormous hierarchy between neutrino masses (~0.1 eV) and the top quark mass (~173 GeV)
+
+This is not a minor gap. The mass spectrum IS the physics. Knowing that "some fields have mass" without knowing which masses is like knowing that "some elements exist" without the periodic table. The entire predictive content of particle physics resides in the specific mass values and their relationships.
+
+---
+
+## Part III: Arguments Against Both Positions
+
+### Attack 3.1: The Standard Model Has 19+ Free Parameters
+
+**Severity: STRUCTURAL**
+
+The Standard Model of particle physics has at minimum 19 free parameters (26 if neutrino masses and mixing angles are included):
+
+- 6 quark masses: (u, d, s, c, b, t)
+- 3 charged lepton masses: (e, mu, tau)
+- 3 neutrino masses (if nonzero)
+- 4 CKM mixing parameters
+- 4 PMNS mixing parameters (if neutrinos are massive)
+- 3 gauge coupling constants: (g_1, g_2, g_3)
+- Higgs vacuum expectation value
+- Higgs self-coupling (or equivalently, the Higgs mass)
+- QCD theta parameter
+
+No known theory -- not string theory, not loop quantum gravity, not causal set theory, not any approach to quantum gravity -- derives ANY of these parameters from geometry or topology. If the self-consistency hierarchy could derive even ONE mass value from pure geometry, it would be the most significant result in theoretical physics since the Standard Model itself. The claim that the hierarchy derives the ENTIRE mass spectrum from topology alone is proportionally more extraordinary.
+
+Extraordinary claims require extraordinary evidence. The hierarchy provides no evidence -- not a single calculated mass value, not a single derived ratio, not a single prediction that could be compared to experiment. The claim is purely aspirational.
+
+### Attack 3.2: The Yang-Mills Mass Gap Is a Millennium Prize Problem
+
+**Severity: STRUCTURAL**
+
+The Clay Mathematics Institute offers $1,000,000 for proving that Yang-Mills theory (with any compact simple gauge group) on R^4 has a mass gap. This is the problem of proving m > 0 for a SPECIFIC theory, with a SPECIFIC Lagrangian, on FLAT Euclidean space, using the KNOWN gauge group SU(3).
+
+This problem has been open since 2000. It was unsolved as of the last published status report. The world's best mathematical physicists -- Jaffe, Witten, Rivasseau, and many others -- have worked on it without success.
+
+The claim that the self-consistency hierarchy derives the mass gap from topology alone is VASTLY more ambitious:
+- It does not specify the gauge group (which must also emerge from topology)
+- It does not specify the Lagrangian (which must also emerge)
+- It does not work on flat space (it must work on curved, dynamical spacetime)
+- It derives the gap for ALL fields, not just one specific theory
+
+If the simpler version (specific theory, specific gauge group, flat space, known Lagrangian) is worth $1 million and remains unsolved after 25+ years, the harder version (unknown theory, unknown gauge group, curved space, unknown Lagrangian) should be treated with extreme skepticism.
+
+### Attack 3.3: Dimensional Analysis -- The Scale Hierarchy
+
+**Severity: SERIOUS**
+
+The hierarchy has two natural scales:
+- Zero (from topology, which is scale-free)
+- The Planck mass M_P ~ 1.2 x 10^19 GeV (from the gravitational coupling at Level 2)
+
+All observed particle masses are enormously far from both:
+- Electron mass: m_e ~ 0.511 MeV ~ 4 x 10^{-23} M_P
+- Top quark mass: m_t ~ 173 GeV ~ 1.4 x 10^{-17} M_P
+- Neutrino masses: m_nu ~ 0.1 eV ~ 10^{-28} M_P
+
+The ratio m_e / M_P ~ 10^{-22} is not a number that emerges naturally from any known geometric or topological construction. In standard physics, this hierarchy is the "naturalness problem" or "hierarchy problem" -- why is the electroweak scale (and fermion masses) so much smaller than the Planck scale?
+
+Proposed solutions (supersymmetry, extra dimensions, technicolor) all introduce NEW structures beyond geometry. The self-consistency hierarchy has no such mechanism. The hierarchy between 0 and M_P must be bridged by some structure that selects specific intermediate scales. Nothing in the axioms provides this structure.
+
+This is not merely a quantitative gap. It is a qualitative gap: the framework has no dimensionless parameters that could be tuned to produce the observed hierarchy. All the complexity of the mass spectrum would have to emerge from topology, and topology is discrete, not continuous. How does a discrete topological invariant produce a continuous spectrum of mass values spanning 28 orders of magnitude?
+
+### Attack 3.4: The Honest Historical Precedent
+
+**Severity: STRUCTURAL (cautionary, not logical)**
+
+Every "theory of everything" that has claimed to derive particle masses from geometry has failed:
+
+1. **Kaluza-Klein theory (1921-1926).** Klein attempted to derive the electron mass from the radius of the compactified fifth dimension. The predicted mass was of order the Planck mass -- wrong by a factor of ~10^{18}. This failure was recognized immediately and the original Kaluza-Klein program was abandoned as a route to particle physics.
+
+2. **String theory (1984-present).** String theory determines particle masses from the geometry of the compactification manifold (Calabi-Yau spaces). However, the landscape of possible compactifications is estimated at 10^{500} or more, each giving different physics. String theory does not predict the mass spectrum; it accommodates it with an enormous number of free choices. The "landscape problem" is widely regarded as the most serious conceptual issue in string theory.
+
+3. **Loop quantum gravity (1986-present).** LQG predicts discrete area and volume spectra from the spin network structure. But these are Planck-scale discretizations, not Standard Model masses. LQG has not derived any particle mass.
+
+4. **Garrett Lisi's E_8 theory (2007).** An Exceptionally Simple Theory of Everything proposed to derive particle content from the E_8 Lie group. It was criticized for fundamental mathematical errors (Jacques Distler and Skip Garibaldi showed the theory cannot work as stated) and remains unviable.
+
+The pattern: geometric approaches to mass generation either fail outright (Kaluza-Klein), produce an uncontrollable landscape (string theory), or remain silent on the question (LQG). No geometric theory has ever derived a single Standard Model mass value from first principles.
+
+This does not prove the self-consistency hierarchy will fail. But it places the burden of proof squarely on the hierarchy: given the uniform failure of all prior geometric approaches to mass generation, what specific mathematical mechanism makes this attempt different? Absent such a mechanism, the default expectation is failure.
+
+---
+
+## Part IV: The FRAMEWORK.md Test
+
+### Does the framework's own logic require deriving mass?
+
+This is the most important structural question. Let us check the axioms:
+
+**Axiom 1 (Self-consistency):** "The coarse-grained structure of the universe is the unique solution to its own consistency constraints." This requires the universe's structure to be self-consistent. It does NOT require the consistency constraints to have no free parameters. A self-consistent universe with mass as an input parameter is still self-consistent.
+
+**Axiom 2 (No evolution parameter):** Says nothing about mass.
+
+**Axiom 3 (Geometric purity):** "No non-geometric entities appear in the fundamental description." This is the relevant axiom. If mass is a non-geometric quantity that must be added by hand, it violates Axiom 3.
+
+**But is mass geometric?** In general relativity, mass-energy IS geometric -- it is the source of spacetime curvature via the Einstein equation. The mass of a particle determines the curvature it produces. In the hierarchy, mass enters at Level 2 through the stress-energy tensor in the SCE. The question is whether the mass VALUES that appear in T_{\mu\nu} are determined by the geometry (Levels 0-1) or must be specified independently.
+
+**Conjecture 3.1:** "The fundamental geometric constraints are topological. Metric structure and matter both emerge from topology." If taken literally, this conjecture requires mass to emerge from topology. But Conjecture 3.1 is labeled as a CONJECTURE, not an axiom. The framework is consistent even if Conjecture 3.1 is false or must be weakened.
+
+**The honest assessment:** The axioms are compatible with mass as input. Conjecture 3.1 aspires to derive mass from topology, but the conjecture is unproven and may be unprovable. Weakening Conjecture 3.1 to "metric structure emerges from topology; matter content is an additional input constrained by self-consistency" would preserve all three axioms and is a more defensible position.
+
+---
+
+## Part V: What the Hierarchy Can and Cannot Honestly Claim
+
+### What it CAN claim (with evidence)
+
+1. **Given mass, self-consistency constrains the geometry.** The Banach contraction result (Rigorous) shows that for massive fields with m << M_P, the SCE has a unique fixed point near the classical solution. This is a genuine, proven result.
+
+2. **Given mass, signature is plausibly constrained.** The co-emergence argument (Conjecture) provides a plausible path from m > 0 to Lorentzian signature via the hyperbolic/elliptic dichotomy. This is suggestive and worth pursuing.
+
+3. **The hierarchy organizes constraints coherently.** The four-level structure (topological, smooth, metric, effective QM) is a useful organizational principle regardless of whether mass is derived or input.
+
+4. **Dimensionality is constrained by the framework.** The uniqueness of exotic smooth structures in dimension 4 is a genuine mathematical fact that motivates the framework's dimensionality.
+
+### What it CANNOT claim (without evidence it does not have)
+
+1. **That mass emerges from topology.** No mechanism, no calculation, no prediction. This is an aspiration, not a result.
+
+2. **That the mass spectrum is determined by self-consistency.** No connection between the self-consistency constraints and specific mass values. The constraints are compatible with any mass in (0, M_P).
+
+3. **That the mass gap (m > 0 for non-conformal fields) is a consequence of the hierarchy.** CFTs prove that self-consistent QFTs can be massless. The mass gap is an empirical fact about the actual universe, not a consequence of self-consistency.
+
+4. **That Conjecture 3.1 is viable for matter content.** The conjecture that "matter emerges from topology" has no supporting evidence and faces the obstacles documented above.
+
+### The honest formulation
+
+The hierarchy should be presented as:
+
+> **Given** a 4-manifold with exotic smooth structures, **given** field content with specified masses, the self-consistency hierarchy constrains the metric, the measure on smooth structures, and the effective quantum mechanics of subsystems. The mass spectrum is an input to the hierarchy, constrained by self-consistency (kappa << 1 requires m << M_P) but not determined by it.
+
+> Whether the mass spectrum can be derived from Levels 0-1 (Conjecture 3.1) is the deepest open question in the framework. The honest answer is: we do not know, and no known mathematics provides a mechanism.
+
+---
+
+## Summary of Attack Severity
+
+| Attack | Target | Severity | Can Position Survive? |
+|--------|--------|----------|----------------------|
+| 1.1 Asselmeyer-Maluga unverified | Position 1 | SERIOUS | Survives only if independent verification emerges |
+| 1.2 Trivial H_2 on R^4 | Position 1 | FATAL for intersection form route | Must abandon intersection form mechanism |
+| 1.3 Vague mechanism | Position 1 | FATAL | No surviving mechanism specified |
+| 2.1 Massless fields exist | Position 2 | FATAL for strong claim | Weak claim ("mass gap helps contraction") survives |
+| 2.2 CFTs are self-consistent | Position 2 | FATAL for "self-consistency requires mass" | The claim must be abandoned |
+| 2.3 No mass scale mechanism | Position 2 | FATAL for spectrum prediction | Neither position can predict masses |
+| 3.1 19+ free parameters | Both | STRUCTURAL | Extraordinary claim requires extraordinary evidence |
+| 3.2 Yang-Mills mass gap | Both | STRUCTURAL | Even the easier problem is unsolved |
+| 3.3 Scale hierarchy | Both | SERIOUS | No known geometric mechanism bridges the gap |
+| 3.4 Historical precedent | Both | STRUCTURAL (cautionary) | Pattern of failure, not proof of impossibility |
+
+---
+
+## Conclusion
+
+The self-consistency hierarchy is a coherent framework for organizing geometric self-consistency constraints across four levels. Its proven results (Banach contraction at Level 2) are genuine contributions. Its conjectural results (signature selection, marginalization) are interesting open problems.
+
+But the claim that mass emerges from topology is not supported by any known mathematics, contradicts the behavior of rigorously constructed massless theories (CFTs), faces the same obstacles that have defeated every prior geometric approach to mass generation, and would constitute the most significant result in theoretical physics if true -- a claim for which extraordinary evidence is required and none is provided.
+
+The honest version of the hierarchy accepts mass as input and investigates what self-consistency implies given that input. This is still a nontrivial and potentially valuable framework. Overpromising on mass derivation risks the credibility of the genuine results.
+
+---
+
+## Rigor Assessment
+
+- **Attacks 1.2, 2.1, 2.2:** Rigorous. Based on established mathematical facts (trivial homology of R^4, existence of massless fields, existence of CFTs).
+- **Attacks 1.1, 1.3:** Sketch. Based on literature review and assessment of the state of the art, not on new mathematical results.
+- **Attacks 3.1-3.4:** Structural/contextual. These are arguments from the sociology and history of physics, not from mathematics. They establish burden of proof, not impossibility.
+- **Attack 2.3, 3.3:** Rigorous for the dimensional analysis; Sketch for the "no mechanism" claim (absence of evidence is not evidence of absence, but the absence is striking).

--- a/programs/co-emergence/explorations/position-1-os-reconstruction.md
+++ b/programs/co-emergence/explorations/position-1-os-reconstruction.md
@@ -1,0 +1,244 @@
+# Position 1: The Osterwalder-Schrader Reconstruction Path to Lorentzian Signature
+
+**Position Agent for the Signature Bridge Debate**
+**Date:** March 2026
+
+---
+
+## Executive Summary
+
+The Osterwalder-Schrader (OS) reconstruction theorem provides the mathematical mechanism by which Lorentzian metric signature emerges from the self-consistency constraints of the hierarchy, given massive field content. The chain is: topology determines field content with a mass gap; the mass gap ensures reflection positivity; reflection positivity, via OS reconstruction, implies the existence of a unique Lorentzian QFT; therefore Lorentzian signature is the unique physical interpretation of the self-consistent block. This position argues that metric signature and mass are co-defined --- neither is meaningful without the other --- and the OS theorem is the mathematical formalization of this co-definition.
+
+---
+
+## 1. The Osterwalder-Schrader Axioms
+
+The OS axioms (Osterwalder and Schrader 1973, 1975) are conditions on the Schwinger functions (Euclidean Green's functions) $S_n(x_1, \ldots, x_n)$ of a Euclidean QFT that guarantee the existence of a corresponding Lorentzian (Wightman) QFT.
+
+**OS0 (Temperedness/Analyticity).** The Schwinger functions are tempered distributions, satisfying growth bounds. **(Rigorous)** --- this is a regularity condition, typically automatic for well-defined QFTs.
+
+**OS1 (Euclidean Covariance).** The Schwinger functions are invariant under the Euclidean group $E(4) = SO(4) \ltimes \mathbb{R}^4$. **(Rigorous)** --- this is a symmetry requirement. On flat $\mathbb{R}^4$, it is automatic for any theory without preferred directions.
+
+**OS2 (Reflection Positivity).** This is the key axiom. Let $\theta$ denote reflection in the hyperplane $x^0 = 0$ (i.e., $\theta(x^0, \vec{x}) = (-x^0, \vec{x})$). For any finite collection of test functions $f_1, \ldots, f_N$ supported in the half-space $x^0 > 0$, the matrix
+
+$$M_{ij} = S(\overline{\theta f_i} \cdot f_j)$$
+
+must be positive semidefinite. **(Rigorous)** as a definition. The content is in establishing when specific theories satisfy it.
+
+**OS3 (Symmetry).** The Schwinger functions are symmetric under permutations of their arguments (for bosonic fields). **(Rigorous)** --- automatic for commuting Euclidean fields.
+
+**OS4 (Cluster Property/Ergodicity).** Schwinger functions factorize at large separations:
+$$S_{n+m}(x_1, \ldots, x_n, y_1 + a, \ldots, y_m + a) \to S_n(x_1, \ldots, x_n) S_m(y_1, \ldots, y_m)$$
+as $|a| \to \infty$. **(Rigorous)** --- this is equivalent to uniqueness of the vacuum in the reconstructed Lorentzian theory.
+
+### The Reconstruction Theorem
+
+**Theorem (Osterwalder-Schrader, 1973/1975).** *(Rigorous.)* If the Schwinger functions $\{S_n\}$ satisfy OS0--OS4 (plus a linear growth condition, strengthened in the 1975 paper), then there exists a unique set of Wightman distributions $\{W_n\}$ satisfying the Wightman axioms --- including Lorentz covariance, spectral condition (positive energy), and locality --- obtained by analytic continuation $x^0_E \to ix^0_M$.
+
+**References (verified):**
+- K. Osterwalder and R. Schrader, "Axioms for Euclidean Green's functions," *Comm. Math. Phys.* **31**, 83--112 (1973).
+- K. Osterwalder and R. Schrader, "Axioms for Euclidean Green's functions II," *Comm. Math. Phys.* **42**, 281--305 (1975).
+
+---
+
+## 2. The Argument Chain
+
+### Link 1: Topology determines field content with a mass gap
+
+**(Conjecture.)** The self-consistency constraints at Levels 0--1 of the hierarchy (topological type + smooth structure measure) determine field content that includes a mass gap $m > 0$.
+
+**Argument.** In the hierarchy, matter content is not postulated --- it emerges from the self-consistency of the smooth-structure measure $\mu^*$ with the metric-level Einstein equation. The claim is that any self-consistent solution must include massive excitations. The physical intuition: a theory with only massless fields has no intrinsic scale, and therefore cannot select a preferred smooth structure (smooth structures are distinguished by their behavior at finite scales, not in the conformal limit). A mass gap provides the scale that makes the smooth-structure measure nontrivial.
+
+**Supporting evidence:** The Yang-Mills mass gap (a Millennium Prize problem) is expected to hold for non-Abelian gauge theories. The Standard Model has a mass gap (the lightest massive particle is the electron, $m_e \approx 0.511$ MeV). Lattice QCD simulations consistently produce a mass gap. The companion paper's Banach contraction constant $\kappa \sim (m/M_P)^2$ explicitly requires $m > 0$ for the perturbative fixed point to be contractive.
+
+**Weakness:** This is the weakest link. There is no known mathematical mechanism connecting topology to a mass gap. The argument is motivational, not deductive. I flag this honestly but argue below (Section 4) that the weakness is addressable.
+
+### Link 2: Mass gap implies reflection positivity
+
+**(Sketch.)** A Euclidean QFT with mass gap $m > 0$ automatically satisfies reflection positivity (OS2).
+
+**Argument.** For a free massive scalar field with propagator $C(x-y) = \int \frac{d^4p}{(2\pi)^4} \frac{e^{ip \cdot (x-y)}}{p^2 + m^2}$, reflection positivity is a direct computation. The Euclidean propagator of a massive field decays as $e^{-m|x^0|}$ in the temporal direction, which ensures the positive-semidefiniteness of the matrix $M_{ij}$ in OS2.
+
+More precisely: for test functions $f, g$ supported in $x^0 > 0$,
+$$\langle \theta f, C g \rangle = \int_{x^0 > 0} \int_{y^0 > 0} \overline{f(-x^0, \vec{x})} \, C(x-y) \, g(y^0, \vec{y}) \, d^4x \, d^4y \geq 0$$
+
+The mass gap ensures exponential decay of correlations across the reflection plane, which is the mechanism that makes the quadratic form positive.
+
+For interacting theories, reflection positivity is established in constructive QFT for several models:
+- $\phi^4$ in 2 and 3 dimensions (Glimm, Jaffe, and Spencer; verified --- see Glimm and Jaffe, *Quantum Physics*, Springer, 1987).
+- Yukawa theory in 2 dimensions.
+- Yang-Mills theory on a lattice (where reflection positivity is built into the Wilson action).
+
+**Reference (verified):** A. Jaffe, "Reflection Positivity Then and Now," arXiv:1802.07880 (2018). Provides a comprehensive review.
+
+**The converse direction:** Reflection positivity does not *require* a mass gap. Massless theories can satisfy reflection positivity (e.g., free massless scalar fields do satisfy OS2). But a mass gap *guarantees* it and provides the exponential clustering (OS4) needed for vacuum uniqueness. The mass gap is a sufficient condition, not a necessary one.
+
+**Rigor assessment:** For free massive fields, this is **Rigorous**. For interacting theories, it is **Rigorous** in the constructive QFT examples cited, and **Sketch** for general interacting theories (where the existence of the Euclidean theory itself is not always established).
+
+### Link 3: Reflection positivity selects a distinguished direction
+
+**(Rigorous.)** Reflection positivity with respect to a hyperplane $\{x^0 = 0\}$ breaks the $SO(4)$ Euclidean symmetry to $SO(3)$ rotations of the orthogonal complement, thereby selecting a distinguished direction.
+
+**Mechanism.** The reflection $\theta: x^0 \mapsto -x^0$ defines a $\mathbb{Z}_2$ grading of $\mathbb{R}^4$. Reflection positivity promotes this grading to a physical structure: the direction orthogonal to the reflection plane becomes the "time" direction upon analytic continuation. The Euclidean group $SO(4) \ltimes \mathbb{R}^4$ does not map to the full Poincare group; rather, the subgroup preserving the reflection structure maps to the Lorentz group $SO(3,1)$.
+
+Concretely: the OS reconstruction maps
+- $SO(3)$ rotations (preserving the reflection plane) $\to$ spatial rotations in Minkowski space
+- Translations in the $x^0$ direction $\to$ imaginary-time translations $\to$ the Hamiltonian $H$ via $e^{-\tau H}$
+- The positivity of $e^{-\tau H}$ (guaranteed by reflection positivity) $\to$ the spectral condition $H \geq 0$
+
+The analytic continuation $x^0_E = it$ sends $SO(4)$ generators to $SO(3,1)$ generators. The key point: reflection positivity is *not* automatic for $SO(4)$-invariant theories. It is an additional constraint that, when satisfied, picks out a unique direction for the continuation, yielding Lorentz rather than Euclidean signature.
+
+**Reference (verified):** J. Frohlich, K. Osterwalder, and E. Seiler, "On virtual representations of symmetric spaces and their analytic continuation," *Ann. Math.* **118**, 461--489 (1983). This establishes the group-theoretic content of the SO(4) to SO(3,1) transition.
+
+**Caution:** The reflection plane must be specified as input. On flat $\mathbb{R}^4$, any hyperplane works (by Euclidean invariance), so no direction is truly "selected" --- rather, the existence of *any* reflection-positive structure guarantees that the theory *can* be continued to a Lorentzian theory, and all choices give the same Lorentzian theory (by the uniqueness part of OS reconstruction). The distinguished direction is a gauge choice in the reconstruction, not a physical preferred direction.
+
+### Link 4: OS reconstruction yields the unique Lorentzian QFT
+
+**(Rigorous.)** The Osterwalder-Schrader reconstruction theorem, applied to Schwinger functions satisfying OS0--OS4, produces a unique Wightman QFT on Minkowski spacetime.
+
+This is the content of the theorem stated in Section 1. The reconstructed theory satisfies:
+- Lorentz covariance (from Euclidean covariance + analytic continuation)
+- Positive energy / spectral condition (from reflection positivity)
+- Locality / microscopic causality (from the Euclidean theory's commutativity at spacelike separation, continued to Minkowski)
+- Uniqueness of the vacuum (from the cluster property)
+
+### Link 5: The reconstructed Lorentzian theory is the physical content of the block
+
+**(Conjecture.)** The Lorentzian Wightman QFT obtained by OS reconstruction is the physical, metric-level description of the self-consistent block. The Riemannian (Euclidean) description is its analytic section; the Lorentzian description is the physical one. The metric signature $(-,+,+,+)$ is not assumed --- it is *derived* from the reflection-positive structure of the self-consistency measure.
+
+---
+
+## 3. The Co-Definition Thesis
+
+The deepest insight motivating this position is that **metric signature and mass are co-defined**. Neither concept is meaningful without the other:
+
+- **Mass requires signature.** The dispersion relation $E^2 = p^2 + m^2$ presupposes the Lorentzian split between energy $E$ (timelike) and momentum $p$ (spacelike). In a Riemannian metric, all directions are equivalent, and the concept of a "mass shell" --- a hyperboloid in momentum space --- does not exist. There are only spheres.
+
+- **Signature requires mass (or more precisely, a scale).** In a conformal field theory (all fields massless), there is no intrinsic distinction between timelike and spacelike directions at the level of the correlation functions. The conformal group $SO(4,2)$ in Lorentzian signature and $SO(5,1)$ in Euclidean signature are different real forms of the same complex group $SO(6, \mathbb{C})$. Without a mass to break conformal invariance, both signatures give equivalent physics in the sense that the correlation functions analytically continue between them without obstruction. A mass gap $m > 0$ breaks this degeneracy: the Euclidean propagator $1/(p^2 + m^2)$ has a pole at $p^2 = -m^2$ in the complexified momentum space, and the location of this pole distinguishes timelike from spacelike directions.
+
+- **OS formalizes this co-definition.** The OS theorem is precisely the mathematical statement that a Euclidean theory with reflection positivity (guaranteed by a mass gap) determines a unique Lorentzian theory. It is the rigorous version of "mass and signature co-emerge."
+
+This is the reason the signature bridge must pass through field content. The hierarchy paper (Section 5) looks for a direct topological path from intersection form signature to metric signature --- a path from $H_2$ to the tangent bundle. This position argues that such a direct path may not exist, and does not need to. The path goes:
+
+$$\text{Intersection form} \xrightarrow{\text{Level 0-1}} \text{Field content (mass gap)} \xrightarrow{\text{OS}} \text{Lorentzian signature}$$
+
+The intersection form constrains the smooth structures (Level 1); the smooth structures, via the self-consistency measure, determine the field content (Level 2); the field content, via OS reconstruction, determines the signature. The bridge is indirect but each link is either rigorous or has a clear mathematical target.
+
+---
+
+## 4. Weaknesses and Honest Assessment
+
+### Weakness 1: OS is formulated on flat $\mathbb{R}^4$
+
+**Severity: Serious but likely addressable.**
+
+The OS axioms assume Euclidean covariance under $SO(4) \ltimes \mathbb{R}^4$, and the reconstruction produces a QFT on Minkowski spacetime $\mathbb{R}^{3,1}$. The hierarchy's Level 2 operates on a curved manifold, not flat space.
+
+**Partial mitigation:**
+- For *static* curved spacetimes with a timelike Killing vector, Wick rotation is well-defined, and a version of OS reconstruction applies. The reflection is with respect to a surface of time-symmetry, and the Killing vector provides the distinguished direction.
+- Kontsevich and Segal (2021, arXiv:2105.10161; **verified**) propose a generalization: the partition function should extend analytically to a domain of *complex-valued* metrics, with Riemannian metrics in the interior and Lorentzian metrics on the boundary. This "allowable metrics" framework does not require $SO(4)$ invariance and works on curved backgrounds. It replaces OS2 (reflection positivity) with a positivity condition on the partition function for complex metrics.
+- In algebraic QFT on curved spacetimes, the microlocal spectrum condition replaces the spectral condition, and local covariance replaces Poincare covariance. A full curved-space OS reconstruction theorem does not yet exist, but the ingredients are being assembled.
+
+**What remains open:** A complete OS-type reconstruction theorem for QFT on general curved backgrounds. This is a major open problem in mathematical physics, but it is a problem that the mathematical physics community is actively working on, not a dead end.
+
+### Weakness 2: The Wightman axioms assume Minkowski space --- is the reconstruction circular?
+
+**Severity: Moderate. The circularity is apparent, not real.**
+
+The worry: OS reconstruction produces a Wightman QFT, and the Wightman axioms presuppose Minkowski spacetime with Lorentzian signature. So the reconstruction appears to assume what it is trying to derive.
+
+**Resolution:** The circularity dissolves when we distinguish the *mathematical content* of the reconstruction from its *historical formulation*. What OS reconstruction actually proves is:
+
+1. Starting from a Euclidean QFT on $\mathbb{R}^4$ with positive-definite metric and $SO(4)$ symmetry...
+2. ...the condition of reflection positivity is *equivalent* to the existence of an analytic continuation to a theory on $\mathbb{R}^4$ with Lorentzian metric and $SO(3,1)$ symmetry.
+
+The Minkowski space is not an *input* to the reconstruction --- it is the *output*. The theorem constructs the Hilbert space, the Hamiltonian, and the Lorentzian correlators from the Euclidean data. The fact that the resulting structure satisfies the Wightman axioms (which were formulated historically with Minkowski space as input) is the *content* of the theorem, not an assumption.
+
+In the hierarchy's language: we start at Level 1 with a Riemannian (positive-definite) structure. The self-consistency measure, if it satisfies reflection positivity, *determines* that the physical metric-level description is Lorentzian. Minkowski space is not assumed; it is the local approximation to the reconstructed Lorentzian geometry.
+
+### Weakness 3: Link 1 (topology to mass gap) has no known mechanism
+
+**Severity: Serious. This is the main gap.**
+
+There is no known theorem or even a well-developed conjecture connecting the topology of a PL 4-manifold, its smooth structures, and the existence of a mass gap in the emergent field theory. This link is purely motivational at present.
+
+**Why it is not fatal:**
+1. The mass gap is *expected* on physical grounds. The Standard Model has a mass gap. Pure Yang-Mills theory is expected to have a mass gap (Millennium Prize problem). The only known massless fields in nature (photon, graviton) arise from unbroken gauge symmetries, which are themselves constrained by topology (characteristic classes).
+2. The Banach contraction in the companion paper *requires* $m > 0$. If the self-consistency fixed point exists (as the companion paper argues), then $m > 0$ is a *consequence* of Level-2 self-consistency, not an additional assumption.
+3. The argument can be run conditionally: "If the self-consistent field content has a mass gap, then Lorentzian signature follows via OS." This conditional statement is valuable even without proving the antecedent.
+
+### Weakness 4: The conformal factor problem for gravity
+
+**Severity: Serious for the gravitational sector specifically.**
+
+The Euclidean gravitational action is not bounded below. Under conformal rescalings $g_{\mu\nu} \to \Omega^2 g_{\mu\nu}$, the Einstein-Hilbert action can be made arbitrarily negative. This means the Euclidean path integral for gravity does not converge, and the standard OS framework (which assumes a well-defined Euclidean measure) breaks down for the gravitational sector.
+
+The Gibbons-Hawking-Perry prescription (rotating the conformal factor contour to the imaginary axis) is a partial fix but has known limitations, particularly when the conformal mode couples to other degrees of freedom.
+
+**Partial mitigation:**
+- In the hierarchy, the gravitational sector is at Level 2 (metric), while the OS reconstruction operates primarily on the matter sector. The metric is determined by the self-consistency fixed point, not by a path integral over metrics. So the conformal factor problem, which arises from the gravitational path integral, may not directly apply.
+- The hierarchy replaces the sum over metrics (gravitational path integral) with a sum over smooth structures (Level 1). The smooth-structure measure $\mu^*$ is a different mathematical object from the metric path integral, and the conformal factor problem is specific to the latter.
+- This does not fully resolve the issue: one still needs the Euclidean matter QFT on a given smooth structure to be reflection-positive, and the coupling of matter to gravity introduces the conformal factor.
+
+---
+
+## 5. Why This Path Is Most Promising
+
+Despite the weaknesses identified above, the OS reconstruction path is the most promising approach to the signature bridge for three reasons:
+
+**1. It is the only known rigorous mechanism for deriving Lorentzian signature from Euclidean data.**
+
+No other theorem in mathematical physics performs this function. The OS reconstruction theorem is the *unique* mathematical result that converts positive-definite (Riemannian/Euclidean) structure into indefinite (Lorentzian) structure. If the hierarchy's Level 0--1 produces a Euclidean-signature theory (which it naturally does, since Riemannian metrics are the generic smooth-structure compatible metrics), then OS is the canonical --- and essentially the only --- path to Lorentzian signature.
+
+**2. The co-definition thesis resolves a conceptual puzzle in the hierarchy.**
+
+The hierarchy paper identifies the signature bridge as "potentially fatal" because there is no known theorem connecting intersection form type to metric signature. The OS path explains *why* no such direct theorem exists: the bridge must pass through field content. Signature is not a purely topological property --- it is a property that emerges from the interaction between topology (which determines field content) and dynamics (which, via the mass gap and reflection positivity, selects the Lorentzian interpretation). The apparent gap in the hierarchy is not a gap in the *framework* but a gap in the *level at which the question is posed*.
+
+**3. It provides a clear mathematical research program.**
+
+The OS path reduces the signature bridge to a chain of well-defined mathematical problems:
+- *Topology to field content:* What field content is compatible with the self-consistency measure on a given PL 4-manifold? (Level 0--1 problem.)
+- *Field content to mass gap:* Does the self-consistent field content have a mass gap? (Connected to the Yang-Mills Millennium Prize problem.)
+- *Mass gap to reflection positivity:* Does the Euclidean theory on a curved background satisfy a generalized reflection positivity? (Connected to the Kontsevich-Segal program.)
+- *Reflection positivity to Lorentzian signature:* Can OS reconstruction be extended to curved backgrounds? (Active area of mathematical physics research.)
+
+Each of these is a hard open problem, but each is a *well-posed* mathematical question with existing partial results. The direct path (intersection form to metric signature) is not even a well-posed mathematical question at present --- there is no candidate theorem to prove or disprove.
+
+**4. It naturally explains the Kontsevich-Segal observation.**
+
+Kontsevich and Segal (2021) observed that QFT partition functions, when they extend analytically to complex-valued metrics, place Riemannian metrics in the interior and Lorentzian metrics on the boundary of the domain of analyticity. This is exactly what the OS path predicts: the Euclidean (Riemannian) formulation is the "interior" description, and the physical Lorentzian formulation lives on its boundary via analytic continuation. The self-consistency measure $\mu^*$ is naturally defined in the Riemannian interior; its Lorentzian physical content is obtained by continuation to the boundary.
+
+---
+
+## 6. Summary: The Argument with Rigor Labels
+
+| Link | Statement | Rigor |
+|------|-----------|-------|
+| 0 | OS axioms and reconstruction theorem | **Rigorous** (Osterwalder-Schrader 1973/1975) |
+| 1 | Topology + self-consistency $\to$ field content with mass gap | **Conjecture** |
+| 2 | Mass gap $\to$ reflection positivity (free fields) | **Rigorous** |
+| 2' | Mass gap $\to$ reflection positivity (interacting fields) | **Sketch** (constructive QFT examples exist) |
+| 3 | Reflection positivity $\to$ distinguished direction | **Rigorous** |
+| 4 | OS reconstruction $\to$ unique Lorentzian QFT (flat space) | **Rigorous** |
+| 4' | OS reconstruction on curved backgrounds | **Conjecture** (Kontsevich-Segal program) |
+| 5 | Reconstructed Lorentzian theory = physical block content | **Conjecture** |
+| Co-def | Mass and signature co-define each other | **Sketch** (mathematically precise for free fields) |
+
+**Overall assessment:** The chain from mass gap to Lorentzian signature (Links 2--4) is mathematically rigorous on flat space. The extension to curved space (Link 4') is a well-defined open problem with active research. The main gap is Link 1 (topology to mass gap), which is the least developed but can be treated conditionally.
+
+---
+
+## References
+
+**Verified (paper-grade):**
+- K. Osterwalder and R. Schrader, "Axioms for Euclidean Green's functions," *Comm. Math. Phys.* **31**, 83--112 (1973).
+- K. Osterwalder and R. Schrader, "Axioms for Euclidean Green's functions II," *Comm. Math. Phys.* **42**, 281--305 (1975).
+- M. Kontsevich and G. Segal, "Wick rotation and the positivity of energy in quantum field theory," *Quart. J. Math.* **72**, 673--699 (2021). arXiv:2105.10161.
+- A. Jaffe, "Reflection Positivity Then and Now," arXiv:1802.07880 (2018).
+
+**Verified (existence confirmed, precise page numbers not checked):**
+- J. Glimm and A. Jaffe, *Quantum Physics: A Functional Integral Point of View*, 2nd ed., Springer (1987). [Standard reference for constructive QFT and reflection positivity of interacting theories.]
+- J. Frohlich, K. Osterwalder, and E. Seiler, "On virtual representations of symmetric spaces and their analytic continuation," *Ann. Math.* **118**, 461--489 (1983). [Group-theoretic content of SO(4) to SO(3,1) transition.]
+
+**Unverified (exploratory):**
+- I believe Gibbons, Hawking, and Perry discuss the conformal factor problem in "Path integrals and the indefiniteness of the gravitational action," *Nucl. Phys. B* **138**, 141--150 (1978), but I have not verified the precise journal reference. The general result is well-established in the Euclidean quantum gravity literature.


### PR DESCRIPTION
## What

Restores the 13 exploration files deleted with the `self-consistency-hierarchy` program (commit 782414f, 2026-03-03) into `programs/co-emergence/explorations/`, verbatim from `782414f^`, and updates the co-emergence README's relationship note to record the removal and the new location.

## Why

The co-emergence README cites three of the deleted files — B1, C1, and the massless fixed-point exploration — as the **sources for results labeled Rigorous** in its key-results table, and its relationship note called the deleted directory "the research record for this one." METHODOLOGY.md treats explorations as first-class artifacts and forbids deleting losing debate positions (also AUTONOMY.md NEVER rule 5); the signature-mass and mass-gap debate positions were among the deleted files. Until this PR, agents working co-emergence issues could not read that record without git archaeology.

Files are restored unmodified; provenance is recorded in the README note and this PR. No `.tex` changes.

## Relations

informs #33, #32, #29 (co-emergence issues whose background record this restores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)