### PR TITLE
Docs: refresh AGENTS.md repository structure; scaffold explorations/governance/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,19 @@ Each program has its own directory under `programs/` with a `README.md` describi
 ```
 programs/                          — Each program has its own directory
   <program-name>/
-    index.tex                      — The paper
+    index.tex                      — The paper (early-stage programs may have notes/ only)
+    README.md                      — Status, key results, "In plain English" abstract
+    OBJECTIVES.md                  — Ordered milestones with done-conditions
     explorations/                  — Research investigations for this program
+explorations/governance/           — Cross-program governance explorations
+automation/routines/               — Autonomous-mode role definitions (protected path)
+docs/                              — Workflow docs and historical experiment data
+metrics/                           — Autonomous-experiment metrics
+scripts/hooks/                     — Quality-gate hooks (protected path)
+tools/                             — CI tooling: citation verification (protected path)
 METHODOLOGY.md                     — Research-as-code workflow (read before contributing)
+AUTONOMY.md                        — Constitution of the autonomous experiment mode
+EXPERIMENT.md                      — Pre-registered autonomous experiment design
 ```
 
 ## Build

--- a/explorations/governance/README.md
+++ b/explorations/governance/README.md
@@ -1,0 +1,10 @@
+# Governance explorations
+
+Cross-program governance explorations, per `AUTONOMY.md` ("Explorations under
+autonomy"): direction debates, OBJECTIVES changes, and experiment audit
+verdicts that span programs rather than belonging to one.
+
+Files are dated and titled: `YYYY-MM-DD-short-title.md`. They are opened as
+PRs carrying the `agent-pr` and `governance` labels and pass the full gate
+stack; the governor routine reads this directory as its predecessors' record.
+Program-scoped explorations belong in `programs/<name>/explorations/` instead.


### PR DESCRIPTION
Documentation only — two pieces:

1. **AGENTS.md repository-structure refresh.** The structure block predated the autonomy bootstrap and the current program layout. It now documents: per-program `README.md` and `OBJECTIVES.md`, `notes/`-only early-stage programs (signature-change-boundary), `explorations/governance/`, and the `automation/`, `docs/`, `metrics/`, `scripts/hooks/`, `tools/` directories with their protected-path markers, plus `AUTONOMY.md` and `EXPERIMENT.md`.

2. **Scaffold `explorations/governance/`.** AUTONOMY.md ("Explorations under autonomy") routes cross-program governance explorations to this directory, but it didn't exist — the governor currently has nowhere to put what the constitution says it should write. The README states the conventions (dated filenames, `agent-pr` + `governance` labels, full gate stack).

## Merge path note

`AGENTS.md` is a **protected path**: `constitution-guard` requires the experimenter's approving review, and GitHub forbids approving a self-authored PR. Per the AUTONOMY.md amendment-procedure pattern, this experimenter-authored PR is intended to be merged with an explicit admin override (`gh pr merge --admin`) once the deterministic checks pass. `explorations/` is not a protected path; it rides along here to keep the docs change atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
