### PR TITLE
CE: derive the θ↔signature identification from temporal mode structure (issue #81)

### DIFF
--- a/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
+++ b/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
@@ -1,0 +1,431 @@
+# Deriving the θ↔signature identification: the self-consistency weight from temporal mode structure
+
+**Date:** 2026-06-10
+**Program:** co-emergence
+**Issue:** #81 (experimenter-priority)
+**Status:** Complete — positive result with a precisely localized residual obstruction
+**Numerics:** `../tests/derived_weight.py`, `../tests/test_derived_weight.py` (18 tests)
+**Relations:** informs #88 (θ→−θ is orientation reversal), informs #32 / CE-1 (real-polarization sector is an edge case for the interference metric), informs the paper §3 framing (follow-up issue required for any text change)
+
+---
+
+## Summary of findings
+
+The toy model's weight `w_σ = exp((−1+iθ)R_σ)` identifies θ≠0 with Lorentzian
+signature by analogy with `e^{iS}` vs `e^{−S_E}` (paper §3). This exploration
+replaces the stipulation with a construction: the weight is the amplitude of a
+free scalar's temporal mode accumulated over each configuration's temporal
+extent, using exactly the mode dichotomy established in the
+`signature-change-boundary` fixed-background note (§5): oscillatory on the
+Lorentzian side, exponentially decaying on the Euclidean side, at the same
+rate constants. The note is cited, not extended; all work here lives in
+`co-emergence`.
+
+Four results, with rigor labels:
+
+1. **(Rigorous, elementary.) Cancellation capacity is derived from signature.**
+   The elliptic (Euclidean) temporal operator has a unique bounded branch,
+   which is real and strictly positive — a weight built from it can never
+   cancel. Every solution of the hyperbolic (Lorentzian) equation satisfies
+   `φ(u + π/ω) = −φ(u)`: exact destructive cancellation between extents a
+   half-period apart, for *every* polarization. Interference capacity ⟺
+   hyperbolicity, with no choice involved (Lemmas 1–2).
+
+2. **(Rigorous given the junction conditions.) Complexness is NOT derived by a
+   real signature change.** Matching the Euclidean decaying branch across the
+   degenerate surface Σ with the no-surface-layer junction conditions (value
+   and canonical momentum continuity — the conditions the SCB note shows hold
+   automatically and two-sidedly) yields the **real** oscillatory mode
+   `cos ωu − sin ωu`, an equal-modulus superposition of `e^{±iωu}`. Junction
+   transport is a real-linear map and cannot select a complex line (Lemma 3).
+   The genuinely complex weight `e^{iωu}` requires a *complex polarization* of
+   the two-dimensional oscillatory solution space — the Wick-contour /
+   positive-frequency choice, which the SCB note itself flags as
+   contour-dependent (its §9, point 4). The two complex choices are conjugate:
+   the sign of θ is an orientation choice (informs #88).
+
+3. **(Sketch + numerically verified.) Phase locking survives; damping does
+   not.** With the complex polarization, the *pure*-Lorentzian derived weight
+   is unimodular (`γ_derived = ic`, not `−1+iθ`). The fixed point has exactly
+   uniform magnitudes and exact phase locking `φ_σ = c·R_σ(ψ*)`; its
+   entanglement is *entirely* phase-generated (the phase-stripped state is the
+   zero-entropy product state, not the Riemannian fixed point). The damping
+   part of the stipulated weight (−1) corresponds precisely to **Euclidean
+   admixture**: a mode accumulating decay over a Euclidean fraction ε of its
+   extent and phase over the rest gives `γ = c(−ε + i(1−ε))`, and the
+   stipulated family is recovered **exactly** at `ε = 1/(1+θ)`, `c = 1+θ`.
+   The paper's identical-magnitude / phase-stripping correspondence is a
+   property of mixed-signature configurations (ε > 0), not of the pure
+   Lorentzian case.
+
+4. **(Localized obstruction, per issue question 3.)** The configuration-space
+   ↔ field-space bridge does not collapse, but it thins at three named points:
+   (a) the action identification `ωτ_σ = c·R_σ`, (b) a single representative
+   mode standing in for a functional integral over fields on σ, (c) the
+   complex-over-real polarization choice. (a) and (b) are modeling gaps of the
+   usual Sketch kind; (c) is the precise residue of the path-integral analogy
+   — the *only* part of the θ↔signature identification that signature alone
+   does not supply.
+
+In plain terms: signature *does* derive the quantum/classical dichotomy in
+the sense of "can the measure cancel," and it does fix the phase-locking
+structure. What it does not fix is the complex form of the cancellation —
+whether amplitudes interfere through U(1) phases or through real signs. That
+last step is a contour/polarization choice, now stated explicitly instead of
+imported silently through the `e^{iS}` analogy.
+
+---
+
+## 1. The construction
+
+### 1.1 Per-configuration mode problem
+
+Each configuration σ ∈ S is assigned a one-dimensional temporal mode problem
+on a prescribed signature background, in the flat per-side coordinates of the
+SCB note (§3): a free scalar mode of frequency `ω = √(m² + k²)` obeys
+
+- Lorentzian side (coordinate u, proper time from Σ): `φ'' = −ω²φ` (hyperbolic),
+- Euclidean side (coordinate v, distance from Σ): `φ'' = +ω²φ` (elliptic).
+
+These are the SCB note's §5 mode equations in flat coordinates; the note shows
+the Fuchsian analysis at the degenerate surface reduces to exactly these
+elementary solution spaces (ν = 1/2 Bessel, hence trigonometric /
+exponential), so nothing beyond elementary ODEs is needed here.
+
+The signature change across Σ is configurational, not temporal (SCB note §1):
+the extent below is a geometric property of σ, not a process. Each
+configuration carries its own mode problem; no time parameter is shared
+across configurations, and the self-consistency map remains parameter-free.
+
+### 1.2 The bridge identification (named gap (a))
+
+Configuration σ is assigned a temporal extent `τ_σ ≥ 0` with
+
+```
+ω τ_σ = c · R_σ(ψ),        c > 0,
+```
+
+where `R_σ(ψ)` is the toy model's mean-field curvature. Motivation: for a
+static mode, the accumulated phase over extent τ is ωτ = S/ℏ, the mode's
+action; and on a fixed 4-volume the Einstein–Hilbert action is proportional
+to the mean curvature, so `S_σ ∝ R_σ`. **Gap (a):** this is a modeling
+identification, not a derivation — the proportionality and the single scale c
+are chosen, and `R_σ > 0` is required for τ_σ ≥ 0 (satisfied throughout the
+toy model's parameter range). Dimensionally, ωτ is dimensionless (ℏ = 1) and
+the toy model's R is dimensionless, so c is a pure number; in field-theoretic
+units c carries [R]⁻¹.
+
+A configuration may have a Euclidean fraction `ε ∈ [0,1]` of its extent
+(mixed-signature configurations contain a degenerate surface; pure cases are
+ε = 0, 1).
+
+### 1.3 The derived weight
+
+The weight is the mode amplitude accumulated over the configuration's extent,
+with the mode selected by a signature-independent principle (boundedness,
+plus transport across Σ where both regions are present):
+
+```
+w(σ) = φ_E(ε τ_σ) · φ_L((1−ε) τ_σ)
+```
+
+with `φ_E(v) = e^{−ωv}` the unique bounded elliptic branch (Lemma 1), and
+φ_L a polarization of the hyperbolic solution space — `e^{iωu}` (complex,
+Wick) or `cos ωu − sin ωu` (real, selected by the real crossing, Lemma 3).
+The self-consistency map is unchanged: `F(ψ) = w(ψ)/‖w(ψ)‖₂`.
+
+With the complex polarization this evaluates to
+
+```
+w(σ) = exp( c(−ε + i(1−ε)) · R_σ ),
+```
+
+i.e. an effective `γ_derived = c(−ε + i(1−ε))`.
+
+---
+
+## 2. The mode-level dichotomy
+
+**Lemma 1 (elliptic positivity). (Rigorous.)** The solution space of
+`φ'' = ω²φ` bounded on `[0,∞)` is the one-dimensional real line
+`ℝ·e^{−ωv}`. Normalized to φ(0) = 1, the weight `w(v) = e^{−ωv}` is strictly
+positive and monotone: for any extents v₁, v₂, `|w(v₁)+w(v₂)| = w(v₁)+w(v₂)`.
+A weight built from the Euclidean bounded branch can never cancel. ∎
+
+**Lemma 2 (hyperbolic cancellation, polarization-independent). (Rigorous.)**
+On the solution space of `φ'' = −ω²φ`, translation by a half-period acts as
+−1: every solution satisfies `φ(u + π/ω) = −φ(u)` for every u (immediate from
+the basis {cos ωu, sin ωu}). Hence for *any* polarization — any complex line
+or real line in the two-dimensional solution space — weights at extents a
+half-period apart cancel exactly. ∎
+
+These two lemmas are the derived content of the issue's question 1, and they
+are stronger than the form the question anticipated in one respect:
+cancellation capacity needs *no* polarization choice. Oscillation versus
+positivity — the structural difference between `e^{iS}` and `e^{−S_E}` that
+the paper's §3 argument actually uses — is a theorem about operator type
+(hyperbolic vs elliptic), not an analogy.
+
+The toy-model diagnostic of self-checks (§6) confirms the dichotomy
+operationally: a Euclidean-derived weight produces a real positive measure
+and classical correlations only; a Lorentzian-derived weight (either
+polarization) produces a measure with cancellation.
+
+## 3. What a real signature change selects (Lemma 3)
+
+The natural candidate selection principle for the Lorentzian polarization is
+the one the issue's lead suggests: transport the Euclidean boundedness
+selection across the degenerate surface. The SCB note shows the field and its
+canonical momentum `π = √|g| g^{00} ∂₀φ` are finite and two-sided at Σ, and
+that π-continuity is the standard no-surface-layer junction condition. Apply
+it (conventions: metric `ds² = λ(x⁰)(dx⁰)² + dx⃗²`; Euclidean region x⁰ < 0
+with distance v from Σ, `dv/dx⁰ = −√λ`; Lorentzian region x⁰ > 0 with proper
+time u from Σ, `du/dx⁰ = √(−λ)`):
+
+- **Euclidean side**, decaying branch `φ = e^{−ωv}`:
+  `∂₀φ = (−ωe^{−ωv})(−√λ) = ω√λ e^{−ωv}`, so
+  `π = √λ·(1/λ)·ω√λ e^{−ωv} = ω e^{−ωv}` → at Σ: `φ = 1, π = ω`.
+- **Lorentzian side**, `φ = A cos ωu + B sin ωu`:
+  `π = √(−λ)·(1/λ)·√(−λ)·φ'(u) = −φ'(u)` → at Σ: `φ = A, π = −Bω`.
+
+Matching: `A = 1`, `B = −1`:
+
+```
+φ_L(u) = cos ωu − sin ωu = (1+i)/2 · e^{iωu} + (1−i)/2 · e^{−iωu}.
+```
+
+**The two Hankel coefficients have equal modulus 1/√2: the real crossing
+selects no complex line.** The transported mode is real. (Rigorous, given the
+junction conditions; the sign of B is convention-dependent — orientation of u
+— but reality is not.)
+
+This is not an accident of the decaying branch. The junction transport is a
+real-linear map between solution spaces of real ODEs with real matching
+conditions: real Euclidean data can only produce real Lorentzian modes. The
+conclusion is also robust to the junction-condition controversy in the
+signature-change literature (the lineage the SCB note's "Relation to existing
+work" section records; the competing momentum conditions are real constraints
+and preserve reality just the same — under a `π(Σ) = 0` convention the
+transported mode is `∝ cos ωu`, still real).
+
+**Consequence.** The complex weight `e^{iωu}` — the `e^{iS}` structure — is
+*not* obtained by transporting the Euclidean selection through a real
+signature change. It is obtained by analytic continuation in the extent
+parameter (Euclidean extent → ±i × Lorentzian extent, exactly the
+complexified-geodesic reading of the SCB note's §7), and the SCB note's §9
+point 4 states explicitly that continuation-versus-termination is a global
+contour choice not fixed by local data at Σ. Continuing in the two directions
+gives the conjugate pair `e^{∓iωu}`; so within the complex option, the only
+residual freedom is the sign of θ, an orientation choice (informs #88, and
+verified numerically: conjugate fixed points, equal entropies, opposite-sign
+coherences).
+
+**Status of the polarization choice.** What is derived (Rigorous): the
+candidate weights form the two-real-dimensional oscillatory solution space;
+cancellation holds for every member (Lemma 2); the real crossing picks a real
+member; the complex members come in a conjugate pair picked by the Wick
+contour. What is chosen: complex over real. This choice is exactly where the
+path-integral analogy enters — but it now enters as a stated discrete choice
+between identified alternatives, not as an unexamined identification.
+
+## 4. The derived-weight toy model (complex polarization)
+
+Implemented as `DerivedWeightModel` in `tests/derived_weight.py`, subclassing
+the existing `CoEmergenceModel` and replacing only the weight function.
+Numerical claims below are verified in `tests/test_derived_weight.py`
+(N = 4, paper parameters α = (0.5, 0.3), β = 0.4; paper h and a seeded
+generic h ~ Uniform[0.5, 1.5]).
+
+### 4.1 The stipulated model is the mixed-signature member (exact)
+
+```
+exp((−1+iθ)R) = exp(c(−ε + i(1−ε))R)   at   ε = 1/(1+θ),  c = 1+θ.
+```
+
+Verified to machine precision at the weight level for θ ∈ {0.5, 1, 2}, and at
+the fixed-point level for θ = 1 (ρ-distance < 10⁻⁸ between the derived
+ε = 1/2, c = 2 model and the stipulated γ = −1+i model). **(Rigorous —
+algebraic identity — plus numerics.)** Every stipulated weight with θ > 0 is
+the derived weight of a configuration that spends a fraction 1/(1+θ) of its
+temporal extent in the Euclidean phase. θ = 1 (the paper's default)
+corresponds to equal Euclidean and Lorentzian extents.
+
+More generally, for any ε > 0 the derived weight has the form
+`m^(1+iθ_eff)` of the paper's Lemma (entropy excess) with
+`m_σ = e^{−εcR_σ}` and `θ_eff = (1−ε)/ε`: the paper's phase-locking-to-
+magnitudes structure holds across the whole mixed family, with the lemma's
+hypotheses satisfied exactly as in the stipulated model.
+
+### 4.2 The pure-Lorentzian case: phase locking survives, damping does not
+
+At ε = 0 the derived weight is **unimodular**: `w = e^{icR}`, `|w| = 1`.
+Consequences (analytic, verified numerically):
+
+- Any fixed point has exactly uniform magnitudes `|ψ*_σ| = 1/√N`, so the
+  marginals are uniform and `R_σ(ψ*) = h_σ + Σ_j α_j/d_j + β/N` in closed
+  form; the fixed point is `ψ*_σ = N^{−1/2} e^{ic R_σ(ψ*)}` exactly, reached
+  in two iterations from any start (F∘F is constant). **(Rigorous — trivial
+  computation.)**
+- **Phase locking survives exactly:** `φ_σ = c·R_σ(ψ*)` (numerically exact,
+  10⁻¹⁰). This is the issue's question 2, answered positively — and the
+  locking is now derived (phase = accumulated mode phase = c·R) rather than
+  read off from the stipulated exponent.
+- **Quantum signatures present:** for generic h, imaginary coherences
+  `|Im ρ₀₁| ≈ 0.09` and entanglement entropy `S ≈ 0.257 nats` (vs 0.278 nats
+  for the stipulated θ = 1 model — same order, consistent with the Euclidean
+  admixture only re-weighting magnitudes).
+- **The entanglement is entirely phase-generated:** the phase-stripped state
+  has uniform magnitudes — the rank-one product state with S = 0. This is a
+  *sharper* version of the paper's "the excess is entirely a phase effect":
+  here not just the excess but the whole entanglement comes from phases.
+- **But the phase-stripping correspondence with the Riemannian fixed point
+  breaks:** stripping phases yields the uniform state, not the Boltzmann
+  state (ρ-distance > 10⁻² from the ε = 1 fixed point). The identical-
+  magnitude-profiles-across-signatures feature of the paper's §3 is a
+  property of mixed configurations, not of the pure Lorentzian case. Any
+  follow-up paper revision should state the correspondence accordingly.
+
+(Incidental: with the paper's specific N = 4 field h = (1.0, 0.7, 0.5, 1.2),
+the pure-Lorentzian reduced coherence happens to be exactly real because
+h₀₀ − h₁₀ = −(h₀₁ − h₁₁); the generic-h tests avoid this measure-zero
+degeneracy.)
+
+### 4.3 The real-polarization variant: cancellation without complexness
+
+With `φ_L = cos − sin` (Lemma 3), the weights are real and sign-indefinite.
+Numerically: the fixed point exists, is real up to a global phase, has
+`Im ρ ≡ 0`, and for extent scales placing c·R across a zero of cos − sin the
+fixed-point weights genuinely take both signs while remaining entangled
+(S ≈ 0.05–0.08 nats in the tested configurations). This is a
+**real-amplitude quantum sector**: a self-consistent measure that cancels —
+interference in the sense the paper's §3 argument requires — but whose
+subsystem density matrices are real. (Whether real-amplitude quantum theory
+is physically distinguishable from complex quantum theory is itself debated:
+Renou et al., "Quantum theory based on real numbers can be experimentally
+falsified," Nature **600**, 625–629 (2021) — *existence verified by web
+search* — argues yes in network scenarios, but the conclusion is contested as
+resting on an untestable independence assumption (e.g. arXiv:2603.19208,
+2026 — **exploratory reference, existence seen in search results only,
+content not verified**). Nothing here depends on either side.)
+
+This sector is what the polarization choice of §3 is *between*: the paper's
+"real measures give statistical mechanics" dichotomy refines into
+positive-real (classical, derived for Euclidean) / signed-real (real-QM-like,
+derived for Lorentzian + real crossing) / complex (standard QM, Lorentzian +
+Wick contour). It also marks an edge case for the CE-1 interference metric
+(#32): a state from this sector has `S(Re ρ) − S(ρ) = 0` while its underlying
+measure is cancelling — the metric detects complex polarization specifically,
+not cancellation capacity in general. (Informs #32; comment to be posted.)
+
+## 5. Where the bridge thins (issue question 3)
+
+The anticipated collapse point — "mode structure lives on field space over a
+geometry, the weight acts on configuration space" — does not destroy the
+construction, but it survives only through three named supports:
+
+- **Gap (a) — the action identification** `ωτ_σ = c·R_σ` (§1.2). Status:
+  modeling identification. A derivation would need the Einstein–Hilbert
+  action of each configuration and a canonical mode frequency; in the full
+  framework this is the same Level-2 input the paper already assumes when it
+  takes h from the action.
+- **Gap (b) — one representative mode.** The weight uses a single temporal
+  mode rather than a functional integral over fields on σ. A derivation from
+  the functional integral would have to show the single-mode phase structure
+  survives the k-sum (plausible — the dichotomy is uniform in ω — but not
+  done here).
+- **Gap (c) — the polarization choice** (§3). Unlike (a) and (b), this is not
+  a technical gap but a genuine two-way fork derived to be a fork: signature
+  fixes cancellation, not its complex form. Within the framework, closing it
+  means deriving the Wick contour from self-consistency (e.g. showing the
+  real polarization fails some cross-level consistency requirement — it
+  produces real-QM marginals, so if Level 3 requires complex Hilbert space
+  structure for some independent reason, that would select the complex
+  polarization). That is a well-posed follow-up question, not pursued here.
+
+**Verdict on the issue's done-conditions:** outcome (a), positive, at Sketch
+level overall — the complex weight ⟺ hyperbolic operator link is established
+*up to* the polarization fork, with every remaining gap named; plus a worked
+minimal example showing the derived-weight map reproduces the phase-locked
+fixed point (exactly, in closed form, for the pure case; identically to the
+stipulated model for the mixed case). The obstruction component of outcome
+(b) survives in localized form as gap (c): the path-integral analogy is no
+longer the identification's only support, but it remains the only support of
+its *complex* (as opposed to signed-real) form.
+
+## 6. Hidden-assumption checks and self-checks
+
+**No smuggled time evolution.** The extent τ_σ is a geometric property of
+configuration σ (a temporal *extent* in the block, like the SCB note's
+configurational signature change); the mode amplitude is a property of the
+static mode problem on σ. Nothing evolves; F remains a parameter-free map on
+configuration-space amplitudes.
+
+**No covert global time from the SCB x⁰.** Each configuration carries its own
+mode problem and its own extent; no coordinate, foliation, or parameter is
+shared across configurations. The junction analysis (Lemma 3) is internal to
+a single mixed configuration's geometry.
+
+**No background structure beyond the prescribed toy geometry.** The
+construction adds two parameters (c, ε) and a polarization choice to the toy
+model's existing prescribed data (h, α, β); ε and the polarization are
+properties of the configuration's signature content — the very thing the
+weight is now derived *from* — and c is the same kind of unit choice as the
+stipulated model's normalization of R. No preferred foliation enters beyond
+the one already present in the prescribed product structure (same status as
+h: prescribed, acknowledged).
+
+**No new postulates beyond the framework's axioms.** The construction
+re-derives the form of a weight the framework already stipulated, from
+structures (free scalar modes on prescribed backgrounds) already in use in
+the program's companion note. The polarization fork is flagged as a choice,
+not silently postulated.
+
+**Self-checks.**
+- *Dimensional analysis:* ωτ = cR dimensionless (ℏ = 1; toy-model R
+  dimensionless, c a pure number; in field units c ~ [R]⁻¹). Weights
+  dimensionless. ✓
+- *Limiting cases:* θ → 0 forces (ε, c) → (1, 1), recovering the Riemannian
+  Boltzmann weight γ = −1 continuously. ✓ Uniform R (flat / uniform h limit)
+  gives equal weights → product state, no entanglement, both signatures →
+  matches the toy model's uniform-field diagnostic. ✓ ε = 1 reproduces the
+  existing Riemannian model exactly; ε = 1/(1+θ) the existing Lorentzian
+  model exactly. ✓
+- *Consistency:* No contradiction with Lemma (entropy excess) — the mixed
+  family satisfies its `m^(1+iθ_eff)` hypotheses verbatim (§4.1); the pure
+  Lorentzian case sits at the lemma's degenerate rank-one-magnitude boundary,
+  where its comparison state has S = 0, consistent with §4.2. The SCB note is
+  used strictly within its stated scope (fixed background, test field; its §9
+  contour caveat is load-bearing here, not contradicted). ✓
+- *Order-of-magnitude sanity:* derived pure-Lorentzian entropy 0.257 nats vs
+  stipulated 0.278 nats at matched parameters; coherences ~10⁻¹–10⁻²;
+  real-polarization entropies ~5–8×10⁻² nats. All O(1)-comparable, no
+  anomalous scales. ✓
+
+## 7. Follow-ups this exploration motivates (not part of this PR)
+
+1. **Paper §3 framing change** (the issue's designated follow-up): state the
+   identification as derived-up-to-polarization; replace "the weight is
+   identified with signature via the path-integral analogy" with the
+   Lemma 1–3 structure; restate the phase-stripping correspondence as a
+   mixed-configuration property.
+2. **Polarization selection from self-consistency** (gap (c)): does any
+   cross-level requirement of the framework exclude the real-polarization
+   (real-QM) sector? This would complete the derivation of complex quantum
+   structure from signature within the framework — or, negatively, prove the
+   framework cannot distinguish complex from real quantum mechanics, which
+   would be a significant honest limitation.
+3. **k-sum robustness** (gap (b)): single-mode → mode-sum weight.
+4. **CE-1 interaction:** whether the interference metric should (or should
+   not) flag the signed-real sector, and what that means for its
+   interpretation as *the* quantum/classical separator.
+
+## Files
+
+- `../tests/derived_weight.py` — derived-weight model (mode functions +
+  `DerivedWeightModel` subclass).
+- `../tests/test_derived_weight.py` — 18 tests covering Lemmas 1–2 at mode
+  level, the real-polarization reconstruction of Lemma 3, the
+  derived = stipulated identity (weights and fixed points), pure-Euclidean
+  and pure-Lorentzian behavior, phase locking, phase-generated entanglement,
+  the broken phase-stripping correspondence, sign-indefinite real weights,
+  and θ → −θ conjugation.

--- a/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
+++ b/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
@@ -31,11 +31,13 @@ Four results, with rigor labels:
    half-period apart, for *every* polarization. Interference capacity ⟺
    hyperbolicity, with no choice involved (Lemmas 1–2).
 
-2. **(Rigorous given the junction conditions.) Complexness is NOT derived by a
-   real signature change.** Matching the Euclidean decaying branch across the
-   degenerate surface Σ with the no-surface-layer junction conditions (value
-   and canonical momentum continuity — the conditions the SCB note shows hold
-   automatically and two-sidedly) yields the **real** oscillatory mode
+2. **(Rigorous for the stated no-surface-layer junction conditions; robustness
+   over the junction-condition family is Sketch.) Complexness is NOT derived
+   by a real signature change.** Matching the Euclidean decaying branch across
+   the degenerate surface Σ with the no-surface-layer junction conditions
+   (value and canonical momentum continuity — the conditions the SCB note
+   shows hold automatically and two-sidedly) yields the **real** oscillatory
+   mode
    `cos ωu − sin ωu`, an equal-modulus superposition of `e^{±iωu}`. Junction
    transport is a real-linear map and cannot select a complex line (Lemma 3).
    The genuinely complex weight `e^{iωu}` requires a *complex polarization* of
@@ -195,18 +197,19 @@ Matching: `A = 1`, `B = −1`:
 ```
 
 **The two Hankel coefficients have equal modulus 1/√2: the real crossing
-selects no complex line.** The transported mode is real. (Rigorous, given the
-junction conditions; the sign of B is convention-dependent — orientation of u
-— but reality is not.)
+selects no complex line.** The transported mode is real. (Rigorous for the
+stated no-surface-layer junction conditions; the sign of B is
+convention-dependent — orientation of u — but reality is not.)
 
-This is not an accident of the decaying branch. The junction transport is a
-real-linear map between solution spaces of real ODEs with real matching
-conditions: real Euclidean data can only produce real Lorentzian modes. The
-conclusion is also robust to the junction-condition controversy in the
+The claim that reality is preserved for *any* real junction condition in the
+family is Sketch-grade. **(Sketch.)** For the stated conditions, the junction
+transport is a real-linear map between solution spaces of real ODEs with real
+matching conditions: real Euclidean data can only produce real Lorentzian
+modes. The same conclusion is plausible for the alternative conventions in the
 signature-change literature (the lineage the SCB note's "Relation to existing
-work" section records; the competing momentum conditions are real constraints
-and preserve reality just the same — under a `π(Σ) = 0` convention the
-transported mode is `∝ cos ωu`, still real).
+work" section records; under a `π(Σ) = 0` convention the transported mode is
+`∝ cos ωu`, still real) — but a proof covering every member of the
+junction-condition family is not supplied here.
 
 **Consequence.** The complex weight `e^{iωu}` — the `e^{iS}` structure — is
 *not* obtained by transporting the Euclidean selection through a real
@@ -272,8 +275,9 @@ Consequences (analytic, verified numerically):
   read off from the stipulated exponent.
 - **Quantum signatures present:** for generic h, imaginary coherences
   `|Im ρ₀₁| ≈ 0.09` and entanglement entropy `S ≈ 0.257 nats` (vs 0.278 nats
-  for the stipulated θ = 1 model — same order, consistent with the Euclidean
-  admixture only re-weighting magnitudes).
+  for the stipulated θ = 1 model at the paper's h = (1.0, 0.7, 0.5, 1.2) —
+  different h values, compared for order of magnitude only; consistent with
+  the Euclidean admixture only re-weighting magnitudes).
 - **The entanglement is entirely phase-generated:** the phase-stripped state
   has uniform magnitudes — the rank-one product state with S = 0. This is a
   *sharper* version of the paper's "the excess is entirely a phase effect":
@@ -397,10 +401,11 @@ none is an axiom of the framework.
   where its comparison state has S = 0, consistent with §4.2. The SCB note is
   used strictly within its stated scope (fixed background, test field; its §9
   contour caveat is load-bearing here, not contradicted). ✓
-- *Order-of-magnitude sanity:* derived pure-Lorentzian entropy 0.257 nats vs
-  stipulated 0.278 nats at matched parameters; coherences ~10⁻¹–10⁻²;
-  real-polarization entropies ~5–8×10⁻² nats. All O(1)-comparable, no
-  anomalous scales. ✓
+- *Order-of-magnitude sanity:* derived pure-Lorentzian entropy 0.257 nats
+  (generic h) vs stipulated 0.278 nats (paper h = (1.0, 0.7, 0.5, 1.2));
+  different configurations, compared for order of magnitude only.
+  Coherences ~10⁻¹–10⁻²; real-polarization entropies ~5–8×10⁻² nats.
+  All O(1)-comparable, no anomalous scales. ✓
 
 ## 7. Follow-ups this exploration motivates (not part of this PR)
 

--- a/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
+++ b/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
@@ -251,7 +251,7 @@ temporal extent in the Euclidean phase. θ = 1 (the paper's default)
 corresponds to equal Euclidean and Lorentzian extents.
 
 More generally, for any ε > 0 the derived weight has the form
-`m^(1+iθ_eff)` of the paper's Lemma (entropy excess) with
+`m^(1-iθ_eff)` of the paper's Lemma (entropy excess) with
 `m_σ = e^{−εcR_σ}` and `θ_eff = (1−ε)/ε`: the paper's phase-locking-to-
 magnitudes structure holds across the whole mixed family, with the lemma's
 hypotheses satisfied exactly as in the stipulated model.
@@ -391,7 +391,7 @@ not silently postulated.
   existing Riemannian model exactly; ε = 1/(1+θ) the existing Lorentzian
   model exactly. ✓
 - *Consistency:* No contradiction with Lemma (entropy excess) — the mixed
-  family satisfies its `m^(1+iθ_eff)` hypotheses verbatim (§4.1); the pure
+  family satisfies its `m^(1-iθ_eff)` hypotheses verbatim (§4.1); the pure
   Lorentzian case sits at the lemma's degenerate rank-one-magnitude boundary,
   where its comparison state has S = 0, consistent with §4.2. The SCB note is
   used strictly within its stated scope (fixed background, test field; its §9

--- a/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
+++ b/programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md
@@ -374,11 +374,12 @@ stipulated model's normalization of R. No preferred foliation enters beyond
 the one already present in the prescribed product structure (same status as
 h: prescribed, acknowledged).
 
-**No new postulates beyond the framework's axioms.** The construction
-re-derives the form of a weight the framework already stipulated, from
-structures (free scalar modes on prescribed backgrounds) already in use in
-the program's companion note. The polarization fork is flagged as a choice,
-not silently postulated.
+**No new axioms.** The construction re-derives the form of a weight the
+framework already stipulated, from structures (free scalar modes on prescribed
+backgrounds) already in use in the program's companion note. Three new
+prescribed parameters are introduced — c (gap (a)), ε, and the
+complex/real polarization choice (gap (c)) — all explicitly flagged as gaps;
+none is an axiom of the framework.
 
 **Self-checks.**
 - *Dimensional analysis:* ωτ = cR dimensionless (ℏ = 1; toy-model R
@@ -418,6 +419,13 @@ not silently postulated.
 4. **CE-1 interaction:** whether the interference metric should (or should
    not) flag the signed-real sector, and what that means for its
    interpretation as *the* quantum/classical separator.
+5. **Pre-existing sign slip in merged `index.tex` `rem:entropy_application`**
+   (~line 463): the remark labels the fixed-point structure as `m^{1+iθ}`,
+   but `m^{1+iθ}` carries phase `−θR`; the matching member of the
+   conjugation-symmetric pair is `m^{1-iθ}`. Conjugation symmetry means no
+   entropy result is affected (Lemma depends on magnitudes only), but the
+   label is cosmetically wrong. Reviewer-identified negative finding; filed
+   as a maintenance correction issue against `main` (not `needs-human`).
 
 ## Files
 

--- a/programs/co-emergence/tests/derived_weight.py
+++ b/programs/co-emergence/tests/derived_weight.py
@@ -1,0 +1,113 @@
+"""
+Derived-weight variant of the co-emergence toy model (issue #81).
+
+Instead of stipulating the self-consistency weight w_sigma = exp(gamma * R_sigma)
+with gamma = -1 + i*theta, the weight is *built* from the temporal mode
+structure of a free scalar on each signature, following the fixed-background
+analysis of programs/signature-change-boundary/notes/2026-06-05-fixed-background-note.md
+(section 5): temporal modes are oscillatory (hyperbolic operator) on the
+Lorentzian side and exponentially decaying (elliptic operator) on the
+Euclidean side, at the same rate constants.
+
+Construction
+------------
+Each configuration sigma is assigned a temporal extent tau_sigma with
+omega * tau_sigma = c * R_sigma (the action identification — a named gap of
+the construction, see the 2026-06-10 exploration), of which a fraction eps
+is Euclidean and 1 - eps is Lorentzian. The weight is the amplitude of the
+canonically selected temporal mode accumulated over that extent:
+
+    w(sigma) = phi_E(eps * tau_sigma) * phi_L((1 - eps) * tau_sigma)
+
+with phi_E the unique bounded (decaying) elliptic branch, and phi_L one of
+two polarizations of the hyperbolic solution space:
+
+- 'complex': phi_L(u) = exp(i * omega * u), the Wick-contour / positive-
+  frequency polarization. Then w = exp((-eps + i(1-eps)) * c * R), and the
+  stipulated weight exp((-1 + i*theta) R) is recovered exactly at
+  eps = 1/(1+theta), c = 1+theta.
+- 'real': phi_L(u) = cos(omega u) - sin(omega u), the polarization selected
+  by matching the Euclidean decaying branch across a *real* signature-change
+  boundary (value + canonical momentum continuity). Real and sign-indefinite:
+  cancellation without complex phases.
+
+omega is set to 1 internally; only the product omega * tau = c * R enters.
+"""
+
+import numpy as np
+
+from .toy_model import CoEmergenceModel
+
+
+def elliptic_mode(s):
+    """Euclidean (elliptic) temporal mode: the unique bounded branch.
+
+    phi_E(v) = exp(-omega v), evaluated at s = omega * v. Real, positive,
+    monotone — incapable of cancellation.
+    """
+    return np.exp(-np.asarray(s, dtype=float))
+
+
+def hyperbolic_mode_complex(s):
+    """Lorentzian mode, complex (Wick-contour / positive-frequency) polarization.
+
+    phi_L(u) = exp(i omega u), evaluated at s = omega * u. Unimodular.
+    The conjugate branch exp(-i omega u) is the opposite continuation
+    direction (theta -> -theta, an orientation choice).
+    """
+    return np.exp(1j * np.asarray(s, dtype=float))
+
+
+def hyperbolic_mode_real(s):
+    """Lorentzian mode, real polarization selected by a real crossing of Sigma.
+
+    Matching the Euclidean decaying branch e^{-omega v} across the degenerate
+    boundary with value and canonical-momentum continuity gives
+    phi_L(u) = cos(omega u) - sin(omega u): real, oscillatory,
+    sign-indefinite. Evaluated at s = omega * u.
+    """
+    s = np.asarray(s, dtype=float)
+    return np.cos(s) - np.sin(s)
+
+
+class DerivedWeightModel(CoEmergenceModel):
+    """Toy model whose weight is built from per-configuration mode amplitudes.
+
+    Parameters beyond CoEmergenceModel's: c (action identification
+    omega * tau_sigma = c * R_sigma), eps (Euclidean fraction of the temporal
+    extent, in [0, 1]), polarization ('complex' or 'real').
+
+    For polarization='complex' the weight equals exp(gamma_eff * R) with
+    gamma_eff = (-eps + 1j * (1 - eps)) * c, which is also stored as
+    self.gamma so the parent class's machinery stays consistent.
+    """
+
+    def __init__(self, dims, h, alphas, beta, c, eps, polarization="complex"):
+        if not 0.0 <= eps <= 1.0:
+            raise ValueError("eps must be a fraction in [0, 1]")
+        if polarization not in ("complex", "real"):
+            raise ValueError("polarization must be 'complex' or 'real'")
+        gamma_eff = (-eps + 1j * (1.0 - eps)) * c if polarization == "complex" else None
+        super().__init__(dims, h, alphas, beta, gamma_eff)
+        self.c = c
+        self.eps = eps
+        self.polarization = polarization
+
+    def weights(self, psi):
+        """Weight = mode amplitude over the configuration's temporal extent."""
+        R = self.curvature(psi).real
+        s = self.c * R  # omega * tau_sigma, with omega = 1
+        w_euclidean = elliptic_mode(self.eps * s)
+        if self.polarization == "complex":
+            w_lorentzian = hyperbolic_mode_complex((1.0 - self.eps) * s)
+        else:
+            w_lorentzian = hyperbolic_mode_real((1.0 - self.eps) * s)
+        return w_euclidean * w_lorentzian
+
+
+def entanglement_entropy(psi, dims, keep):
+    """Von Neumann entropy (nats) of the reduced state of a pure state."""
+    rho = CoEmergenceModel.partial_trace(np.asarray(psi), tuple(dims), tuple(keep))
+    evals = np.linalg.eigvalsh(rho)
+    evals = evals[evals > 1e-15]
+    return float(-np.sum(evals * np.log(evals)))

--- a/programs/co-emergence/tests/test_derived_weight.py
+++ b/programs/co-emergence/tests/test_derived_weight.py
@@ -1,0 +1,242 @@
+"""Tests for the derived-weight toy model (issue #81).
+
+Verifies the claims of the 2026-06-10 exploration
+`2026-06-10-derived-weight-from-signature.md`:
+
+1. Mode-level dichotomy: the elliptic (Euclidean) branch is positive and
+   cannot cancel; every hyperbolic (Lorentzian) polarization admits exact
+   destructive cancellation.
+2. The derived weight with complex polarization reproduces the stipulated
+   weight exp((-1 + i theta) R) exactly at eps = 1/(1+theta), c = 1+theta,
+   fixed points included.
+3. Pure Euclidean (eps = 1) recovers the Riemannian Boltzmann model.
+4. Pure Lorentzian (eps = 0) gives a unimodular weight: uniform fixed-point
+   magnitudes, exact phase locking phi_sigma = c R_sigma, nonzero imaginary
+   coherences, entirely phase-generated entanglement — and phase-stripping
+   recovers the uniform product state, NOT the Riemannian fixed point.
+5. The real polarization (selected by a real signature-change crossing)
+   yields a real fixed point with sign-indefinite weights: cancellation
+   without complex structure.
+6. The two complex polarizations (continuation directions) give conjugate
+   fixed points with equal entropy (informs #88).
+"""
+
+import numpy as np
+import pytest
+
+from .toy_model import CoEmergenceModel
+from .derived_weight import (
+    DerivedWeightModel,
+    elliptic_mode,
+    entanglement_entropy,
+    hyperbolic_mode_complex,
+    hyperbolic_mode_real,
+)
+
+DIMS = (2, 2)
+ALPHAS = [0.5, 0.3]
+BETA = 0.4
+H_PAPER = np.array([1.0, 0.7, 0.5, 1.2])  # the paper's N=4 external field
+
+
+def _h_generic(seed=2026, n=4):
+    return np.random.RandomState(seed).uniform(0.5, 1.5, size=n)
+
+
+def _fixed_point(model, seed=42, n_starts=20):
+    np.random.seed(seed)
+    fps = model.find_fixed_points(n_starts=n_starts)
+    assert len(fps) > 0, "no fixed point found"
+    return fps[0]
+
+
+class TestModeDichotomy:
+    """Lemma 1 and Lemma 2 of the exploration, at the mode level."""
+
+    def test_elliptic_branch_positive_no_cancellation(self):
+        s = np.linspace(0.0, 50.0, 1000)
+        w = elliptic_mode(s)
+        assert np.all(w > 0)
+        # No cancellation: superpositions of weights add moduli exactly.
+        assert abs(w[10] + w[500]) == pytest.approx(abs(w[10]) + abs(w[500]))
+
+    def test_hyperbolic_cancellation_every_polarization(self):
+        # Any solution with phi(0) = 1 is cos(s) + a*sin(s); at s = pi it
+        # equals -1 regardless of the (complex) polarization a.
+        rng = np.random.RandomState(7)
+        for _ in range(20):
+            a = rng.randn() + 1j * rng.randn()
+            phi = lambda s: np.cos(s) + a * np.sin(s)
+            assert abs(phi(0.0) + phi(np.pi)) < 1e-12
+        # The two canonical polarizations included.
+        assert abs(hyperbolic_mode_complex(0) + hyperbolic_mode_complex(np.pi)) < 1e-12
+        assert abs(hyperbolic_mode_real(0) + hyperbolic_mode_real(np.pi)) < 1e-12
+
+    def test_real_polarization_is_equal_weight_superposition(self):
+        # cos s - sin s = a e^{is} + b e^{-is} with |a| = |b| = 1/sqrt(2):
+        # the real crossing selects no complex line.
+        s = np.linspace(0, 10, 200)
+        a, b = (1 + 1j) / 2, (1 - 1j) / 2
+        recon = a * np.exp(1j * s) + b * np.exp(-1j * s)
+        assert np.allclose(recon, hyperbolic_mode_real(s), atol=1e-12)
+        assert abs(abs(a) - abs(b)) < 1e-15
+
+
+class TestDerivedEqualsStipulated:
+    """The stipulated gamma = -1 + i theta is the mixed-signature member
+    eps = 1/(1+theta), c = 1+theta of the derived family."""
+
+    @pytest.mark.parametrize("theta", [0.5, 1.0, 2.0])
+    def test_weights_identical(self, theta):
+        c, eps = 1.0 + theta, 1.0 / (1.0 + theta)
+        derived = DerivedWeightModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA, c=c, eps=eps
+        )
+        stipulated = CoEmergenceModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA, gamma=-1.0 + 1j * theta
+        )
+        rng = np.random.RandomState(0)
+        for _ in range(5):
+            psi = rng.randn(4) + 1j * rng.randn(4)
+            psi /= np.linalg.norm(psi)
+            assert np.allclose(derived.weights(psi), stipulated.weights(psi), atol=1e-13)
+
+    def test_fixed_points_identical(self):
+        theta = 1.0
+        derived = DerivedWeightModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA,
+            c=1.0 + theta, eps=1.0 / (1.0 + theta),
+        )
+        stipulated = CoEmergenceModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA, gamma=-1.0 + 1j * theta
+        )
+        fp_d = _fixed_point(derived)
+        fp_s = _fixed_point(stipulated)
+        assert CoEmergenceModel.rho_distance(fp_d, fp_s) < 1e-8
+
+
+class TestPureEuclidean:
+    """eps = 1, c = 1: the derived weight is the Riemannian Boltzmann weight."""
+
+    def test_recovers_riemannian_model(self):
+        derived = DerivedWeightModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA, c=1.0, eps=1.0
+        )
+        riem = CoEmergenceModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA, gamma=-1.0 + 0j
+        )
+        psi = np.ones(4, dtype=complex) / 2.0
+        w = derived.weights(psi)
+        assert np.allclose(w.imag, 0.0, atol=1e-14)
+        assert np.all(w.real > 0)
+        assert np.allclose(w, riem.weights(psi), atol=1e-13)
+        fp = _fixed_point(derived)
+        rho = CoEmergenceModel.partial_trace(fp, DIMS, (0,))
+        assert abs(rho[0, 1].imag) < 1e-10  # classical correlations only
+
+
+class TestPureLorentzian:
+    """eps = 0: unimodular weight. Phase locking survives; damping does not."""
+
+    @pytest.fixture(scope="class")
+    def model(self):
+        return DerivedWeightModel(
+            dims=DIMS, h=_h_generic(), alphas=ALPHAS, beta=BETA, c=1.0, eps=0.0
+        )
+
+    @pytest.fixture(scope="class")
+    def fp(self, model):
+        return _fixed_point(model)
+
+    def test_weight_unimodular(self, model, fp):
+        assert np.allclose(np.abs(model.weights(fp)), 1.0, atol=1e-13)
+
+    def test_fixed_point_converges(self, model, fp):
+        assert CoEmergenceModel.rho_distance(model.F_map(fp), fp) < 1e-10
+
+    def test_uniform_magnitudes(self, fp):
+        assert np.allclose(np.abs(fp), 0.5, atol=1e-10)
+
+    def test_exact_phase_locking(self, model, fp):
+        # phi_sigma - phi_0 = c (R_sigma - R_0) mod 2pi
+        R = model.curvature(fp).real
+        rel_phase = np.angle(fp / fp[0])
+        expected = model.c * (R - R[0])
+        diff = np.mod(rel_phase - expected + np.pi, 2 * np.pi) - np.pi
+        assert np.allclose(diff, 0.0, atol=1e-10)
+
+    def test_imaginary_coherence_nonzero(self, fp):
+        rho = CoEmergenceModel.partial_trace(fp, DIMS, (0,))
+        assert abs(rho[0, 1].imag) > 1e-3
+
+    def test_entanglement_entirely_phase_generated(self, fp):
+        # The Lorentzian state is entangled...
+        S_lor = entanglement_entropy(fp, DIMS, (0,))
+        assert S_lor > 1e-3
+        # ...while its phase-stripped counterpart (uniform magnitudes) is the
+        # rank-one product state with zero entropy.
+        stripped = np.abs(fp).astype(complex)
+        stripped /= np.linalg.norm(stripped)
+        assert entanglement_entropy(stripped, DIMS, (0,)) < 1e-10
+
+    def test_phase_stripping_does_not_recover_euclidean_fixed_point(self, fp):
+        # Unlike the stipulated model, magnitudes differ across signatures:
+        # stripping phases yields the uniform state, not the Boltzmann state.
+        euclidean = DerivedWeightModel(
+            dims=DIMS, h=_h_generic(), alphas=ALPHAS, beta=BETA, c=1.0, eps=1.0
+        )
+        fp_e = _fixed_point(euclidean)
+        stripped = np.abs(fp).astype(complex)
+        stripped /= np.linalg.norm(stripped)
+        assert CoEmergenceModel.rho_distance(stripped, fp_e) > 1e-2
+
+
+class TestRealPolarization:
+    """The real-crossing polarization: cancellation without complexness."""
+
+    def test_fixed_point_real_no_coherences(self):
+        model = DerivedWeightModel(
+            dims=DIMS, h=_h_generic(), alphas=ALPHAS, beta=BETA,
+            c=1.0, eps=0.0, polarization="real",
+        )
+        fp = _fixed_point(model)
+        # Weights are real, so the fixed point is real up to a global phase.
+        fp_aligned = fp * np.exp(-1j * np.angle(fp[np.argmax(np.abs(fp))]))
+        assert np.allclose(fp_aligned.imag, 0.0, atol=1e-8)
+        rho = CoEmergenceModel.partial_trace(fp, DIMS, (0,))
+        assert abs(rho[0, 1].imag) < 1e-8
+
+    def test_weights_sign_indefinite(self):
+        # With an extent scale placing c*R across a zero of cos - sin, the
+        # real-polarization weights take both signs: real cancellation.
+        h = np.array([0.5, 0.6, 1.4, 1.5])
+        model = DerivedWeightModel(
+            dims=DIMS, h=h, alphas=ALPHAS, beta=BETA,
+            c=0.6, eps=0.0, polarization="real",
+        )
+        psi = np.ones(4, dtype=complex) / 2.0
+        w = model.weights(psi).real
+        assert np.any(w > 0) and np.any(w < 0)
+
+
+class TestConjugation:
+    """The two continuation directions give conjugate fixed points with the
+    same entropy: the sign of theta is an orientation choice (informs #88)."""
+
+    def test_conjugate_fixed_points_equal_entropy(self):
+        theta = 1.0
+        plus = CoEmergenceModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA, gamma=-1.0 + 1j * theta
+        )
+        minus = CoEmergenceModel(
+            dims=DIMS, h=H_PAPER, alphas=ALPHAS, beta=BETA, gamma=-1.0 - 1j * theta
+        )
+        fp_p = _fixed_point(plus)
+        fp_m = _fixed_point(minus)
+        assert CoEmergenceModel.rho_distance(np.conj(fp_p), fp_m) < 1e-8
+        S_p = entanglement_entropy(fp_p, DIMS, (0,))
+        S_m = entanglement_entropy(fp_m, DIMS, (0,))
+        assert S_p == pytest.approx(S_m, abs=1e-9)
+        rho_p = CoEmergenceModel.partial_trace(fp_p, DIMS, (0,))
+        rho_m = CoEmergenceModel.partial_trace(fp_m, DIMS, (0,))
+        assert rho_p[0, 1].imag == pytest.approx(-rho_m[0, 1].imag, abs=1e-9)


### PR DESCRIPTION
Closes #81

## Summary

Replaces the *stipulated* θ↔signature identification (`w = exp((−1+iθ)R)`, justified by the `e^{iS}`/`e^{−S_E}` analogy) with a **construction**: the self-consistency weight is the amplitude of a free scalar's temporal mode accumulated over each configuration's temporal extent, using the oscillatory-vs-decaying mode dichotomy of the `signature-change-boundary` fixed-background note (§5; cited, not extended — scope guard respected). Deliverables per the issue: a dated exploration in `programs/co-emergence/explorations/` plus a numerics module and 18 pytest tests. **No `.tex` changes** (paper framing is a designated follow-up).

Findings (issue questions 1–3):

1. **Cancellation is derived; complexness is derived only up to a polarization fork.** The elliptic (Euclidean) bounded branch is unique, real, positive — it can never cancel. Every hyperbolic (Lorentzian) solution satisfies `φ(u+π/ω) = −φ(u)` — exact destructive cancellation for *every* polarization. But matching the Euclidean decaying branch across a **real** signature change (value + canonical-momentum continuity) yields the *real* mode `cos ωu − sin ωu` (equal-modulus Hankel coefficients — no complex line selected; junction transport is real-linear). The complex weight `e^{iωu}` requires the Wick-contour polarization, the same contour choice the SCB note flags as global (its §9, pt 4). The two complex choices are conjugate: sign of θ = orientation (informs #88).
2. **Phase locking survives; damping does not.** Pure-Lorentzian derived weight is unimodular: fixed point `ψ*_σ = N^{−1/2} e^{icR_σ(ψ*)}` exactly — phase locking exact, entanglement entirely phase-generated, but phase-stripping yields the uniform product state, **not** the Riemannian fixed point. The stipulated `γ = −1+iθ` is recovered **exactly** as the mixed-signature member `ε = 1/(1+θ)`, `c = 1+θ` (Euclidean fraction ε of the temporal extent supplies the damping). The paper's identical-magnitude correspondence is a mixed-configuration property.
3. **Bridge obstruction localized, not fatal:** (a) action identification `ωτ_σ = cR_σ`, (b) single representative mode vs functional integral, (c) the complex-over-real polarization choice — (c) being the precise residue of the path-integral analogy.

## Rigor levels

- Lemmas 1–2 (elliptic positivity; polarization-independent hyperbolic cancellation): **Rigorous** (elementary ODE facts).
- Lemma 3 (real crossing selects the real polarization): **Rigorous for the stated no-surface-layer junction conditions**; the robustness sub-claim (any real junction condition in the family preserves reality) is **Sketch** — the argument is plausible and holds for the two concrete conventions checked, but no proof covers the full family.
- Derived = stipulated at `ε = 1/(1+θ)`: **Rigorous** (algebraic identity) + numerics (weights to 1e−13, fixed points to 1e−8).
- Pure-Lorentzian closed-form fixed point and exact phase locking: **Rigorous** (trivial computation) + numerics.
- Overall construction (the bridge, §1.2 of the exploration): **Sketch** — gaps (a)–(c) named explicitly per the rigor lifecycle. The issue requires Sketch, not Rigorous.

## Self-checks

- **Dimensional analysis:** `ωτ = cR` dimensionless (ℏ=1; toy-model R dimensionless, c a pure number; in field units c ~ [R]⁻¹). ✓
- **Limiting cases:** θ→0 forces (ε,c)→(1,1) — Riemannian Boltzmann `γ=−1` recovered continuously. Uniform-R (flat) limit → equal weights → product state, no entanglement, both signatures (matches the existing uniform-field diagnostic). ε=1 reproduces the existing Riemannian model exactly; ε=1/(1+θ) the existing Lorentzian model exactly. ✓
- **Consistency:** Mixed family satisfies the entropy-excess Lemma's `m^(1-iθ_eff)` hypotheses verbatim (`m = e^{−εcR}`, `θ_eff = (1−ε)/ε`); pure-Lorentzian case sits at the Lemma's rank-one-magnitude boundary (comparison state S=0), no contradiction. SCB note used strictly within its declared scope; its contour caveat is load-bearing here, not contradicted. No new axioms; three prescribed parameters (c, ε, polarization) all flagged as gaps (a)/(c). ✓
- **Order-of-magnitude sanity:** derived pure-Lorentzian S ≈ 0.257 nats (generic h) vs stipulated 0.278 nats (paper h = (1.0, 0.7, 0.5, 1.2)); different configurations, compared for order of magnitude only. Coherences ~10⁻¹–10⁻²; real-polarization sector S ≈ 0.05–0.08 nats. All O(1)-comparable. ✓

**Hidden-assumption checks:** no smuggled time evolution (extent is configurational, per the SCB note's own framing; F remains parameter-free); no covert global time from the SCB x⁰ (each configuration carries its own mode problem; no shared parameter/foliation); no background structure beyond the prescribed toy data (ε, polarization are properties of the configuration's signature content; c is a unit choice on par with the stipulated normalization).

## Verification

- `pytest -q`: **77 passed** (59 existing + 18 new), locally on the branch.
- No `.tex` touched (no pdflatex/citation impact). Exploration's two literature mentions: Renou et al. Nature 600 (2021) — existence verified by web search; arXiv:2603.19208 — flagged unverified-exploratory per METHODOLOGY.

## Recommended adversarial review mode

**Verification mode**, with attention to: the Lemma 3 junction computation (sign conventions for the canonical momentum on the two sides of Σ), the claim that junction transport can never select a complex line, and the `ε = 1/(1+θ)` identity. A stress-test pass is *not* required (no Sketch→Rigorous promotion; no `promotion-rigorous` label), but a stress tester wanting a target should attack: "is there any real junction condition at Σ that selects a complex polarization?"

## Relations

- **informs #88** — θ→−θ shown to be orientation reversal / complex conjugation, with conjugate fixed points and equal entropies (tested).
- **informs #32 / CE-1 (PR #74)** — the real-polarization sector has cancelling weights but `I_S = S(Re ρ) − S(ρ) = 0`: the interference metric detects complex polarization, not cancellation capacity in general.
- Builds on the seed note merged in #78 (informs); cites, does not modify, `signature-change-boundary`.

routine: worker · model: claude-fable-5