### PR TITLE
CE: correct toy-model weight to m^{1−iθ} and state θ→−θ conjugation invariance (issue #88)

### DIFF
--- a/programs/co-emergence/index.tex
+++ b/programs/co-emergence/index.tex
@@ -312,8 +312,10 @@ merely its entropy: since the curvature map $R_\sigma(\psi)$ depends
 on $\psi$ only through $|\psi_\sigma|^2$, both the Lorentzian and
 Riemannian fixed-point equations reduce to the same equation for the
 magnitudes $|\psi^*_\sigma|$. The Lorentzian fixed point is
-$|\psi^*_\sigma|^{1+i\theta}$ (up to normalization) and the Riemannian
-is $|\psi^*_\sigma|$, with the same $|\psi^*_\sigma|$ in both cases.
+$|\psi^*_\sigma|^{1-i\theta}$ (up to normalization; see
+Remark~\ref{rem:entropy_application} for the sign convention) and the
+Riemannian is $|\psi^*_\sigma|$, with the same $|\psi^*_\sigma|$ in
+both cases.
 Phase-stripping recovers the Riemannian state by construction, so the
 entropy excess is entirely a phase effect.
 Lemma~\ref{lem:entropy_excess} proves that this excess is guaranteed
@@ -459,11 +461,23 @@ The toy model entries $m_\sigma = e^{-R_\sigma}$ fall in this regime.
 \label{rem:entropy_application}
 In the toy model, the Lorentzian fixed point
 $\psi^*_\sigma \propto \exp((-1 + i\theta)\, R_\sigma)$ has magnitude
-$|\psi^*_\sigma| \propto e^{-R_\sigma}$ and phase $\theta R_\sigma$,
-which is exactly the structure $m^{1+i\theta}$ of
-Lemma~\ref{lem:entropy_excess} with $m_\sigma = e^{-R_\sigma}$. The
-Riemannian fixed point has $\theta = 0$, giving the same magnitudes
-but no phases.
+$|\psi^*_\sigma| \propto e^{-R_\sigma}$ and phase $\theta R_\sigma$.
+With $m_\sigma = e^{-R_\sigma}$ one has $\log m_\sigma = -R_\sigma$,
+so the phase locked to the magnitude is $\theta R_\sigma = -\theta
+\log m_\sigma$: the fixed point realizes the structure
+$m_\sigma^{1-i\theta}$, i.e., the construction of
+Lemma~\ref{lem:entropy_excess} at parameter $-\theta$ rather than
+$+\theta$. The sign is a harmless orientation convention
+\emph{(Rigorous)}: replacing $\theta$ by $-\theta$ conjugates the
+matrix entrywise, $M(-\theta) = \overline{M(\theta)}$, hence
+$\rho(-\theta) = \overline{M(\theta)}^{\dagger}\,\overline{M(\theta)}
+= \overline{\rho(\theta)}$, and a matrix and its entrywise complex
+conjugate have the same singular values. All purities and
+entropies---and the conclusions of Lemma~\ref{lem:entropy_excess}(a)
+and (b), including the equality characterization---are therefore
+invariant under $\theta \to -\theta$ and apply verbatim to the toy
+model. The Riemannian fixed point has $\theta = 0$, giving the same
+magnitudes but no phases.
 
 Lemma~\ref{lem:entropy_excess}(a) rigorously guarantees that the
 Lorentzian state has lower purity (higher R\'enyi-2 entropy) than the


### PR DESCRIPTION
Closes #88

## Summary

`rem:entropy_application` claimed the toy-model Lorentzian fixed point is "exactly the structure $m^{1+i\theta}$" of Lemma `lem:entropy_excess`. This had a sign mismatch: with $m_\sigma = e^{-R_\sigma}$, the fixed point $\psi^*_\sigma \propto e^{(-1+i\theta)R_\sigma}$ has phase $\theta R_\sigma = -\theta \log m_\sigma$, i.e. the structure $m_\sigma^{1-i\theta}$ — the lemma's construction at parameter $-\theta$.

Changes (two hunks in `programs/co-emergence/index.tex`):

1. **`rem:entropy_application`** — corrects the identification to $m_\sigma^{1-i\theta}$, derives the sign explicitly ($\log m_\sigma = -R_\sigma$), and states the conjugation invariance: $M(-\theta) = \overline{M(\theta)}$, hence $\rho(-\theta) = \overline{\rho(\theta)}$; a matrix and its entrywise conjugate share all singular values, so purities, entropies, and the conclusions of Lemma `lem:entropy_excess`(a), (b) — including the equality characterization — are invariant under $\theta \to -\theta$ and apply verbatim. The sign is a harmless orientation convention.
2. **Section 3 overview (line ~315)** — the same sign error appeared once more ("The Lorentzian fixed point is $|\psi^*_\sigma|^{1+i\theta}$"); corrected to $|\psi^*_\sigma|^{1-i\theta}$ with a pointer to the remark for the sign convention. Fixing only the remark would have left the paper internally inconsistent.

No rigor labels of existing results change; no headline-result status change, so the README "In plain English" abstract is untouched. The new conjugation-invariance statement is labeled **(Rigorous)** inline.

## Rigor level

- Corrected identification $m_\sigma^{1-i\theta}$: **Rigorous** (direct computation: $(e^{-R})^{1-i\theta} = e^{-R}e^{+i\theta R}$, matching the fixed point's phase $+\theta R_\sigma$).
- $\theta \to -\theta$ invariance: **Rigorous** ($\rho(-\theta) = \overline{M(\theta)}^{\dagger}\overline{M(\theta)} = \overline{\rho(\theta)}$; conjugation preserves singular values, hence all Rényi and von Neumann entropies).

## Self-checks

- **Dimensional analysis:** N/A in the strict sense (all quantities dimensionless: $\theta$, $R_\sigma$, matrix entries). Exponent consistency checked: $e^{(-1+i\theta)R} = (e^{-R})^{1-i\theta}$ ✓.
- **Limiting cases:** $\theta = 0$: both conventions coincide, Riemannian statement unchanged ✓. $\theta \to -\theta$: $\rho \to \overline{\rho}$, spectra identical, entropy excess unchanged ✓.
- **Consistency:** Agrees with Lemma `lem:entropy_excess`'s phase-lock formula $\varphi_{ij} = \theta \log m_{ij}$ (the toy model's $+\theta R_\sigma$ is recovered at parameter $-\theta$). Consistent with the equality characterization (phase differences enter only through magnitudes, symmetric in $\theta$). Consistent with the numerically observed conjugation behavior reported on issue #81 / PR #89 (conjugate fixed points, equal entropies, opposite-sign imaginary coherences) — referenced informationally only; nothing in this PR depends on unmerged work.
- **Order-of-magnitude sanity:** No numerical claims changed; the reported $S_{\mathrm{Lor}}/S_{\mathrm{Riem}} \approx 1.69$ is sign-independent by the invariance argument ✓.

## Recommended adversarial review mode

Verification (check the two-line conjugation argument and the exponent algebra). Stress testing not indicated: no new prediction, no result used as a lemma downstream beyond what the existing lemma already provides.

## Relations

- **informs** #76 (equality/strictness characterization lives in the same remark)
- **informs** #45 (Lean formalization should use the corrected sign convention)

routine: worker · model: claude-fable-5
