### PR TITLE
GGD-2: recompute discrimination metrics at corrected τ_DP and extend §5 to dDP

### DIFF
--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -456,10 +456,15 @@ Model & Timescale & $G$-scaling & Profile & Noise temporal correlator \\
 \midrule
 This work & $\hbar/E_\Delta$ & $1/G$ & Gaussian & Static (derived) \\
 Di\'osi--Penrose & $\hbar/E_\Delta$ & $1/G$ & Exponential & White (postulated) \\
+Dissipative DP~\cite{ddp_model} & $\hbar/E_\Delta$ & $1/G$ & Exponential & White $+$ friction \\
 Kafri--Taylor--Milburn & $\sim \omega d^3/(G m)$ & $1/G$ & Exponential & White (postulated) \\
 \bottomrule
 \end{tabular}
-\caption{Comparison of gravitational decoherence models. The Kafri--Taylor--Milburn
+\caption{Comparison of gravitational decoherence models. The dissipative Di\'osi--Penrose
+row gives the coherence profile over the decoherence timescale; the model's distinguishing
+non-Gaussian dynamics are steady-state phase-space effects (\S\ref{sec:ddp}), not
+coherence-profile modifications, and are negligible at proposed platforms. The
+Kafri--Taylor--Milburn
 model~\cite{kafri} applies to two masses $m$ in harmonic traps of frequency $\omega$ at
 separation $d$: its decoherence rate $\Lambda = K/(4m\omega)$, with gravitational spring
 constant $K = 2Gm^2/d^3$, is of the order of the gravitationally induced normal-mode
@@ -495,10 +500,72 @@ $C \approx 0.5$ this demands $N_{\text{run}} \gtrsim 1000$ shots per time point.
 eight time points spanning $t \in [0.1\tau_{DP}, 3\tau_{DP}]$, the total is
 $\sim 8{,}000$ experimental shots.
 
+\textbf{Invariance under the corrected platform parameters.} The discrimination metrics
+above---the maximum fractional difference $\approx 0.22$, the required visibility
+uncertainty $\sigma_V < 0.07$, and the shot budget $\sim 8{,}000$---depend only on the
+dimensionless ratio $\tau_{\text{coh}}/\tau_{DP} \approx 1.13$ (eq.~\ref{eq:tau_coh}), not
+on the absolute decoherence timescale. The errata correction to the BMV microdiamond row
+(real bulk density $3500$~kg/m$^3$, raising $\tau_{DP}$ from the pre-errata $1.2$~ms to
+$11.6$~ms; Table~\ref{tab:platforms}) rescales $\tau_{\text{coh}}$ in proportion
+($13.1$~ms), leaving the ratio---and hence all three metrics---unchanged. What the
+correction does change is the absolute schedule: the eight sampling points now span
+$t \in [1.2, 35]$~ms rather than sub-millisecond, with the maximum-discrimination point at
+$t \approx 0.48\,\tau_{DP} \approx 5.6$~ms. The longer timescale is experimentally
+favorable---millisecond-scale visibility sampling is well within the reach of the BMV
+protocol~\cite{bose}---so the corrected parameters strengthen, rather than weaken, the
+discriminability case.
+
 The profile discrimination requires that environmental decoherence $\Gamma_{\text{env}}$
 be characterized to within a factor of $\sim 2$ (so that $\delta\Gamma_{\text{env}}\cdot
 \tau_{\text{coh}} \lesssim 0.1$). This is achievable by comparing data at different masses
 or between materials with the same environmental coupling but different $E_\Delta$.
+
+\subsection{Discrimination from the dissipative Di\'osi--Penrose model}
+\label{sec:ddp}
+
+The standard Di\'osi--Penrose model shares the unbounded energy growth common to
+objective-collapse models; the dissipative Di\'osi--Penrose (dDP) variant cures this by
+adding linear friction in the mass current, so that the collapse-induced energy relaxes
+toward a finite asymptotic value associated with a noise ``temperature''
+$T$~\cite{ddp_model}. In the zero-friction limit ($T\to\infty$) the dDP master equation
+reduces to standard DP, recovering the exponential coherence decay
+$|\rho_{LR}^{\text{exp}}| = e^{-t/\tau_{DP}}$ of eq.~\eqref{eq:corr_diosi}. The
+discrimination question raised by~\cite{melo_dissipative} is whether the friction deforms
+that exponential enough to mimic---or be confused with---the Gaussian profile of
+eq.~\eqref{eq:tau_coh} at the sensitivities of \S\ref{sec:predictions}.
+
+It does not, at currently proposed platforms. The distinctive dDP signatures are
+phase-space effects, not coherence-profile effects: the friction drives the reduced state
+to a \emph{non-equilibrium steady state} whose Wigner function develops non-Gaussian tails,
+with the non-Gaussianity scaling as the third power of the dissipation
+parameter~\cite{melo_dissipative}. These are energy- and momentum-sector features that
+accumulate as the state approaches its steady state over the thermal-relaxation timescale;
+they are not modifications of the position off-diagonal element on the much shorter
+decoherence timescale $\tau_{DP}$. Over the interferometric window $t \lesssim 3\tau_{DP}$
+the dDP coherence decay therefore coincides with the standard DP exponential up to a
+fractional correction set by the friction strength, which levitated-optomechanics bounds
+already constrain to be weak (collapse temperature $T \gtrsim 10^{-13}$~K for localization
+length $< 10^{-6}$~m)~\cite{ddp_bounds}.
+
+\textbf{Assumption (explicit).} We take the dDP friction over $t \lesssim 3\tau_{DP}$ to
+modify the position-coherence exponent by a fractional amount small compared to the $0.22$
+Gaussian--exponential separation of eq.~\eqref{eq:delta_V}---i.e.\ thermal relaxation is
+slow compared to decoherence on the BMV and MAQRO platforms. This is consistent with both
+the $T\to\infty$ reduction to DP and the steady-state location of the non-Gaussian
+effects~\cite{melo_dissipative}, but a derivation of the exponent correction from the dDP
+master equation for a rigid superposed body is not carried out here.
+
+\textbf{Consequence.} Under this assumption the three-way discrimination collapses to the
+two-way test already quantified in \S\ref{sec:predictions}: dDP and standard DP both
+predict (near-)exponential decay over the observation window, while this work predicts the
+Gaussian of eq.~\eqref{eq:tau_coh}. The shot budget of \S\ref{sec:predictions} therefore
+distinguishes the Gaussian profile from \emph{both} DP and dDP. Should a future platform
+reach the thermal-relaxation regime, the dDP profile would drift away from a pure
+exponential toward its steady state---a deformation distinct from the Gaussian's
+slow-then-sudden shape, sharpening rather than blurring the discrimination. This analysis
+is \textbf{(Sketch)}: it rests on the explicit assumption above and on the cited
+characterization of where the dDP non-Gaussian effects reside, not on a derived dDP
+coherence profile for the superposed-body geometry.
 
 \subsection{Material-dependent profile transition (conjectural)}
 \label{sec:material}
@@ -659,6 +726,18 @@ gravitational decoherence, \textit{New J.\ Phys.}\ \textbf{16}, 065020 (2014).
 \bibitem{marletto_classical} C.~Marletto, J.~Oppenheim, V.~Vedral, and E.~Wilson,
 Classical gravity cannot mediate entanglement,
 preprint arXiv:2511.07348 (2025).
+
+\bibitem{ddp_model} G.~Di Bartolomeo, M.~Carlesso, K.~Piscicchia, C.~Curceanu,
+M.~Derakhshani, and L.~Di\'osi, On the linear friction many-body equation for dissipative
+spontaneous wavefunction collapse, \textit{Phys.\ Rev.\ A}\ \textbf{108}, 012202 (2023).
+
+\bibitem{ddp_bounds} G.~Di Bartolomeo and M.~Carlesso, Experimental bounds on
+linear-friction dissipative collapse models from levitated optomechanics,
+\textit{New J.\ Phys.}\ \textbf{26}, 043006 (2024).
+
+\bibitem{melo_dissipative} P.~B.~Melo, P.~V.~Paraguass\'u, S.~Artini, G.~Lo Monaco,
+S.~Donadi, and M.~Paternostro, Non-equilibrium thermodynamics of collapse models in the
+strongly non-Gaussian regime, preprint arXiv:2606.06259 (2026).
 
 \bibitem{fixed_point} W.~Regelmann and Claude (Anthropic), Fixed-point existence of
 self-consistent semiclassical gravity (2026). Companion paper.

--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -503,7 +503,7 @@ $\sim 8{,}000$ experimental shots.
 \textbf{Invariance under the corrected platform parameters.} The discrimination metrics
 above---the maximum fractional difference $\approx 0.22$, the required visibility
 uncertainty $\sigma_V < 0.07$, and the shot budget $\sim 8{,}000$---depend only on the
-dimensionless ratio $\tau_{\text{coh}}/\tau_{DP} \approx 1.13$ (eq.~\ref{eq:tau_coh}), not
+dimensionless ratio $\tau_{\text{coh}}/\tau_{DP} \approx 1.13$ (eq.~\eqref{eq:tau_coh}), not
 on the absolute decoherence timescale. The errata correction to the BMV microdiamond row
 (real bulk density $3500$~kg/m$^3$, raising $\tau_{DP}$ from the pre-errata $1.2$~ms to
 $11.6$~ms; Table~\ref{tab:platforms}) rescales $\tau_{\text{coh}}$ in proportion
@@ -560,8 +560,10 @@ master equation for a rigid superposed body is not carried out here.
 \textbf{Consequence.} Under this assumption the three-way discrimination collapses to the
 two-way test already quantified in \S\ref{sec:predictions}: dDP and standard DP both
 predict (near-)exponential decay over the observation window, while this work predicts the
-Gaussian of eq.~\eqref{eq:tau_coh}. The shot budget of \S\ref{sec:predictions} therefore
-distinguishes the Gaussian profile from \emph{both} DP and dDP. Should a future platform
+Gaussian of eq.~\eqref{eq:tau_coh}. The shot budget of \S\ref{sec:predictions} (the BMV
+value, $r=1.13$; MAQRO's smaller separation $\approx 0.18$ at $r\approx 0.99$ requires a
+proportionately larger budget) therefore distinguishes the Gaussian profile from \emph{both}
+DP and dDP. Should a future platform
 reach the thermal-relaxation regime, the dDP profile would drift away from a pure
 exponential toward its steady state---a deformation distinct from the Gaussian's
 slow-then-sudden shape, sharpening rather than blurring the discrimination. This analysis
@@ -730,8 +732,8 @@ Classical gravity cannot mediate entanglement,
 preprint arXiv:2511.07348 (2025).
 
 \bibitem{ddp_model} G.~Di Bartolomeo, M.~Carlesso, K.~Piscicchia, C.~Curceanu,
-M.~Derakhshani, and L.~Di\'osi, On the linear friction many-body equation for dissipative
-spontaneous wavefunction collapse, \textit{Phys.\ Rev.\ A}\ \textbf{108}, 012202 (2023).
+M.~Derakhshani, and L.~Di\'osi, Linear-friction many-body equation for dissipative
+spontaneous wave-function collapse, \textit{Phys.\ Rev.\ A}\ \textbf{108}, 012202 (2023).
 
 \bibitem{ddp_bounds} G.~Di Bartolomeo and M.~Carlesso, Experimental bounds on
 linear-friction dissipative collapse models from levitated optomechanics,

--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -548,9 +548,11 @@ already constrain to be weak (collapse temperature $T \gtrsim 10^{-13}$~K for lo
 length $< 10^{-6}$~m)~\cite{ddp_bounds}.
 
 \textbf{Assumption (explicit).} We take the dDP friction over $t \lesssim 3\tau_{DP}$ to
-modify the position-coherence exponent by a fractional amount small compared to the $0.22$
-Gaussian--exponential separation of eq.~\eqref{eq:delta_V}---i.e.\ thermal relaxation is
-slow compared to decoherence on the BMV and MAQRO platforms. This is consistent with both
+modify the position-coherence exponent by a fractional amount small compared to the
+platform-specific Gaussian--exponential separation: $0.22$ for BMV ($r = \tau_{\text{coh}}/\tau_{DP} = 1.13$,
+eq.~\eqref{eq:delta_V}) and $\approx 0.18$ for MAQRO ($r \approx 0.99$,
+Table~\ref{tab:platforms})---i.e.\ thermal relaxation is slow compared to decoherence on
+both platforms. This is consistent with both
 the $T\to\infty$ reduction to DP and the steady-state location of the non-Gaussian
 effects~\cite{melo_dissipative}, but a derivation of the exponent correction from the dDP
 master equation for a rigid superposed body is not carried out here.


### PR DESCRIPTION
Closes #102.

## Summary

Implements GGD-2 (experimental discriminability) in `programs/gaussian-gravitational-decoherence/index.tex`, §5:

1. **Shot-count recomputation at corrected BMV τ_DP = 11.6 ms (§5.1).** The discrimination metrics — max fractional difference ≈ 0.22, required visibility uncertainty σ_V < 0.07, ~1000 shots/point (~8000 total) — depend **only** on the dimensionless ratio τ_coh/τ_DP ≈ 1.13, not on the absolute τ_DP. The errata (PR #73) rescales τ_coh in proportion (BMV: 11.6 ms → 13.1 ms; ratio 13.1/11.6 = 1.129), so all three metrics are **invariant**. Verified numerically (max fractional difference 0.216 at t ≈ 0.47 τ_DP). What changes is the absolute schedule: the eight sampling points now span t ∈ [1.2, 35] ms (max-discrimination at t ≈ 0.48 τ_DP ≈ 5.6 ms), millisecond-scale and experimentally favorable. Added an explicit invariance note rather than altering the (correct) numbers.

2. **Profile discrimination extended to dDP (§5.3, new, Sketch).** Outcome (a) of the issue: the dDP corrections are negligible at these sensitivities, with the argument stated explicitly. The dissipative-DP non-Gaussian effects flagged by #92 (arXiv:2606.06259) are **steady-state phase-space** properties — the state settles into a non-equilibrium steady state with non-Gaussian Wigner tails scaling as dissipation³ — *not* modifications of the position off-diagonal coherence at the decoherence timescale. Under an explicit weak-friction assumption (supported by the levitated-optomechanics bounds, T ≳ 10⁻¹³ K), the dDP coherence decay coincides with the standard DP exponential over t ≲ 3τ_DP. The GGD Gaussian is therefore discriminable from **both** DP and dDP by the same shape test; the three-way discrimination collapses to the two-way test of §5.1.

3. **Table 2** gains a dissipative-DP row; caption notes the non-Gaussian dynamics are steady-state effects, not coherence-profile modifications.

4. **Three new paper-grade citations**, all verified for existence (Crossref/arXiv) and content:
   - `ddp_model` — Di Bartolomeo, Carlesso, Piscicchia, Curceanu, Derakhshani, Diósi, *Phys. Rev. A* **108**, 012202 (2023) [arXiv:2301.07661] — dDP model definition.
   - `ddp_bounds` — Di Bartolomeo, Carlesso, *New J. Phys.* **26**, 043006 (2024) [arXiv:2401.04665] — weak-friction (collapse-temperature) bounds.
   - `melo_dissipative` — Melo, Paraguassú, Artini, Lo Monaco, Donadi, Paternostro, arXiv:2606.06259 (2026) — the #92 paper; non-Gaussian regime is steady-state/thermodynamic. (Note: #92's pointer listed only the first four authors; the paper has six — Donadi and Paternostro added.)

## Rigor level per result

- §5.1 invariance note: arithmetic restatement of existing **(Sketch)** results; no change in rigor.
- §5.3 dDP discrimination: **(Sketch)** — rests on an explicit weak-friction assumption and on the cited characterization of where the dDP non-Gaussian effects reside, not on a derived dDP coherence profile for the superposed-body geometry.
- No promotions. Results (1),(2) remain (Sketch); Conjecture 1 remains (Conjecture). Assumption 1 (Gaussian noise) is not lifted.

## Self-checks

- **Dimensional analysis.** No new dimensional formula is introduced. The discrimination metrics are dimensionless (ratios of decay factors); the absolute window [1.2, 35] ms and 5.6 ms point are τ_DP × dimensionless constants. dDP "temperature" T enters only as a qualitative scale (bound quoted in K from `ddp_bounds`). Consistent.
- **Limiting cases.** dDP → standard DP as friction → 0 (T → ∞), recovering the exponential of eq. (corr_diosi) — stated explicitly and used as the baseline. τ_coh/τ_DP → 1.13 limit and the e^{-1/4} − e^{-1/2} ≈ 0.17 simplification are unchanged.
- **Consistency.** The invariance argument is consistent with the errata: BMV τ_coh = 13.1 ms and τ_DP = 11.6 ms already in Table 1 give ratio 1.13, matching eq. (tau_coh). The dDP analysis is consistent with #92 (informs) and with the existing DP comparison in §6. No contradiction with merged results.
- **Order-of-magnitude sanity.** Numerically reproduced: max fractional difference 0.216 (paper: ~0.22); σ_V < 0.073 for 3σ resolution (paper: <0.07, conservative); N ≳ 818 → ~1000 shots at C = 0.5 (shot-noise σ_V = 1/(C√N)). Absolute window for τ_DP = 11.6 ms: [1.16, 34.8] ms, max-diff at 5.57 ms. All sane.

## Changed lines (§5)

- §5.1: added "Invariance under the corrected platform parameters" paragraph.
- §5.3: new subsection "Discrimination from the dissipative Diósi–Penrose model".
- Table 2 (tab:models): added dDP row + caption sentence.
- Bibliography: +3 bibitems.

**Discriminability outcome in one sentence:** at BMV and MAQRO sensitivities the GGD Gaussian profile is distinguishable from both standard DP and dissipative-DP by the same Gaussian-vs-exponential shape test (the dDP non-Gaussian corrections being steady-state phase-space effects negligible over the decoherence-timescale observation window), and the shot budget for that test is unchanged by the errata because it depends only on the preserved ratio τ_coh/τ_DP ≈ 1.13.

## Recommended adversarial review mode

**Verification** (check the invariance arithmetic, the dDP citations' content match, and that the weak-friction assumption is stated honestly as an assumption rather than a derived result). A light **stress test** of the claim that the dDP non-Gaussian effects cannot masquerade as a Gaussian profile within the observation window would be valuable but is not required (no rigor promotion).

## Relations

- **informs GGD-1** — bears on whether the GGD-vs-dDP distinction is practically accessible.
- **informs #92** — implements the GGD-2 extension #92 calls for; corrects the author list.

routine: worker · model: claude-opus-4-8