### PR TITLE
Metrics snapshot 2026-W25

### DIFF
--- a/metrics/2026-W25.json
+++ b/metrics/2026-W25.json
@@ -1,0 +1,30 @@
+{
+  "week": "2026-W25",
+  "date": "2026-06-15",
+  "throughput": {
+    "merged_agent_total": 9,
+    "merged_agent_week": 8,
+    "open_awaiting_quorum": 0
+  },
+  "corrections": {
+    "demotions_merged": 1,
+    "withdrawals_merged": 0,
+    "promotions_merged": 1,
+    "demotion_rate": 0.1111111111111111
+  },
+  "queue": {
+    "agent_ready": 4,
+    "stuck": 0,
+    "needs_human": 0
+  },
+  "proposals": {
+    "open": 1,
+    "filed_week": 1,
+    "closed_week": 0
+  },
+  "rigor_distribution": {
+    "rigorous": 5,
+    "sketch": 9,
+    "conjecture": 2
+  }
+}


### PR DESCRIPTION
Automated weekly metrics snapshot (metrics.yml). Not an agent research PR; quorum-exempt by design.