### PR TITLE
Red-team correction: Haar im_frac baseline does not converge to 1/√2 (CE-2); exact reduction verified Rigorous

### DIFF
--- a/programs/co-emergence/explorations/2026-06-18-imaginary-fraction-rank.md
+++ b/programs/co-emergence/explorations/2026-06-18-imaginary-fraction-rank.md
@@ -168,6 +168,15 @@ in `theta` for small `theta` (from `sin^2 ≈ (theta/2)^2 (·)^2`):
 
 ## Comparison with the Haar baseline
 
+> **Correction (2026-06-19, red-team audit).** An earlier version of this
+> section (and of `index.tex`) stated the max-alignment Haar `im_frac → 1/√2 ≈
+> 0.707` as `N → ∞`. **That limit is wrong** — the Haar value does not converge
+> to `1/√2`; it keeps rising past it (see the corrected table and the
+> mechanism below). The reduction (*) itself and its `(Rigorous)` label are
+> unaffected, and the qualitative conclusion — the fixed point carries far less
+> imaginary content than a Haar-random state at every accessible `N` — also
+> stands.
+
 Issue #33 asked whether the fixed point approaches the Haar value (maximal phase
 complexity). It does not. For a Haar-random pure state the Born weights are
 `p ~ Dirichlet(1, ..., 1)`; applying (*) (max alignment, `theta = 1`):
@@ -178,15 +187,35 @@ complexity). It does not. For a Haar-random pure state the Born weights are
 | 16 | 0.461 | 0.334 |
 | 64 | 0.563 | 0.382 |
 | 256 | 0.637 | ~0.39 |
-| → ∞ | 0.707 (`1/√2`) | 0.399 |
+| 4096 | 0.738 | ~0.40 |
+| 65536 | 0.800 | ~0.40 |
+| 262144 | 0.824 | ~0.40 |
 
-The Haar value diverges in log-spread and averages `sin^2 → 1/2`, giving
-`im_frac → 1/√2`. The fixed point saturates near `0.40` instead: the
-self-consistency map produces the *minimal* phase structure consistent with the
-moderate magnitude heterogeneity set by `h`, far below a generic random state.
-This is consistent with the entropy-excess exploration's finding that the
-fixed-point phases are narrowly distributed (std `~0.29` rad) and locked to the
-magnitudes, rather than random.
+Unlike the fixed point, the Haar value has **no clean large-`N` limit**. The
+naive argument "`sin^2 → 1/2`, so `im_frac → 1/√2`" fails because the
+max-magnitude reference `p_r = p_max` correlates the alignment phase with the
+Born weight, so the Born-weighted `⟨sin^2⟩` does *not* average to `1/2`. Writing
+the Haar weights as `p_σ ∝ E_σ` with `E_σ ~ Exp(1)`, the leading large-`N`
+behavior is
+
+```
+im_frac^2  ->  1/2  -  (1/2) * Re[ e^{i theta log E_max} * Gamma(2 - i theta) ],
+```
+
+an oscillation in `log E_max ~ log log N` whose amplitude
+`(1/2)|Gamma(2 ± i theta)| ≈ 0.369` at `theta = 1` does **not** vanish. This
+leading form matches the Monte-Carlo `im_frac` to `< 0.003` across `N = 256` to
+`2.6×10^5`; over that whole accessible range the value rises monotonically
+(`0.64 → 0.82`), always **above** the fixed point's `≈ 0.40` and well past
+`1/√2 ≈ 0.707`. (The clean `1/√2` would require a *centered* reference for which
+`⟨sin^2⟩ → 1/2`; the max-magnitude convention used here is not centered.)
+
+The fixed point, by contrast, saturates near `0.40` because the magnitude
+heterogeneity set by `h ~ U[0.5,1.5]` has bounded log-spread: the
+self-consistency map produces the *minimal* phase structure consistent with that
+heterogeneity, far below a generic random state. This is consistent with the
+entropy-excess exploration's finding that the fixed-point phases are narrowly
+distributed (std `~0.29` rad) and locked to the magnitudes, rather than random.
 
 ## What this changes
 

--- a/programs/co-emergence/index.tex
+++ b/programs/co-emergence/index.tex
@@ -676,9 +676,16 @@ the max-magnitude alignment, $\mathrm{im\_frac}$ rises with $N$ as
 $a - b\,N^{-c}$ ($a \approx 0.43$, $c \approx 0.55$) toward the analytic
 large-$N$ limit $\big(\mathbb{E}_p[\sin^2\theta(h-h_{\min})]\big)^{1/2}
 \approx 0.40$, where $p \propto e^{-2h}$; the optimal alignment converges
-to $\approx 0.25$. This is far \emph{below} the Haar-random baseline
-($\mathrm{im\_frac} \to 1/\sqrt{2} \approx 0.707$ as $N \to \infty$): the
-self-consistency map produces minimal, not maximal, phase complexity.
+to $\approx 0.25$. This is far \emph{below} the Haar-random baseline at every
+size tested. For Haar-random Born weights the max-magnitude $\mathrm{im\_frac}$
+has \emph{no} clean $N \to \infty$ limit, and in particular does \emph{not}
+approach $1/\sqrt{2}$: because the max-magnitude reference component correlates
+the alignment phase with the Born weight, the weighted $\langle\sin^2\rangle$
+does not tend to $\tfrac12$, and the value instead rises monotonically across
+all accessible sizes (from $\approx 0.64$ at $N = 256$ to $\approx 0.82$ at
+$N \approx 2.6\times10^{5}$), staying well above the fixed point's
+$\approx 0.40$. The self-consistency map therefore produces minimal, not
+maximal, phase complexity.
 The Riemannian $\psi^*$ is exactly real. Since the curvature map depends
 on $\psi$ only through $|\psi_\sigma|^2$, both fixed points satisfy the
 same magnitude equation: stripping phases from the Lorentzian $\psi^*$

--- a/programs/co-emergence/tests/imaginary_fraction.py
+++ b/programs/co-emergence/tests/imaginary_fraction.py
@@ -33,9 +33,14 @@ Consequences, all checked below:
   - im_frac rises with N toward an analytic large-N limit set by theta and the
     spread of h; for max alignment, theta = 1, h ~ U[0.5, 1.5] the limit is
     ~0.40 (and ~0.25 for the optimal alignment).
-  - The fixed point sits far BELOW the Haar-random baseline (im_frac -> 1/sqrt2
-    ~ 0.707 as N -> infinity): the self-consistency map produces minimal, not
-    maximal, phase complexity.
+  - The fixed point sits far BELOW the Haar-random baseline at every accessible
+    N: the self-consistency map produces minimal, not maximal, phase complexity.
+    NOTE: the Haar baseline does NOT converge to 1/sqrt2 -- under the
+    max-magnitude reference the Born-weighted <sin^2> is modulated by
+    Gamma(2 +- i*theta) and the value keeps rising with N (0.64 at N=256 to
+    0.82 at N~2.6e5), staying above the fixed point's ~0.40 throughout. (An
+    earlier version of this script and of index.tex wrongly claimed a 1/sqrt2
+    limit; corrected by the 2026-06-19 red-team audit.)
 
 Reference: programs/co-emergence/index.tex, Section 3.1 (sec:toy_model).
 """
@@ -191,11 +196,14 @@ def main():
     print("4. HAAR BASELINE  (max alignment, theta=1)")
     print("=" * 74)
     print(f"   fixed-point asymptote (analytic) : {limit_max_align():.4f}")
-    print(f"   Haar asymptote (1/sqrt2)         : {1 / np.sqrt(2):.4f}")
-    for N in [4, 16, 64, 256, 1024]:
-        print(f"   N={N:5d}:  im_frac_Haar = {haar_im_frac(N):.4f}")
-    print("   --> the fixed point carries far LESS imaginary content than a")
-    print("       Haar-random state: minimal, not maximal, phase complexity.")
+    print("   Haar baseline (max-align) does NOT converge to 1/sqrt2; it keeps")
+    print("   rising with N (Gamma(2 +- i*theta) modulation -- see exploration):")
+    for N in [4, 16, 64, 256, 1024, 16384, 262144]:
+        tr = 4000 if N <= 16384 else 800
+        print(f"   N={N:7d}:  im_frac_Haar = {haar_im_frac(N, trials=tr):.4f}")
+    print("   --> the fixed point (~0.40) carries far LESS imaginary content")
+    print("       than a Haar-random state at every N: minimal, not maximal,")
+    print("       phase complexity.")
 
     print("\n" + "=" * 74)
     print("5. THETA DEPENDENCE  (dims=(4,4); small-theta linear in theta)")


### PR DESCRIPTION
## Red-team audit → correction

Target (per the red-team routine ranking): **`eq:im_frac_reduction`**, the imaginary-fraction **exact reduction** labeled **(Rigorous)** in `programs/co-emergence/index.tex` §3.1, merged during the experiment in **PR #114** (CE-2, closes #33), never previously audited. Prior four red-team targets are all inside the 30-day exclusion window.

Method: fresh-context stress-test subagent (line-by-line re-derivation + independent reimplementation of the self-consistency map, no import of the paper's formula) **plus** my own independent algebra and numerics from a different direction (analytic + Monte-Carlo).

## The Rigorous result HELD — no demotion of `eq:im_frac_reduction`

The exact reduction
```
im_frac^2 = sum_sigma p_sigma sin^2( (theta/2) log(p_r / p_sigma) )
```
is correct and its derivation is rigorous. Independently verified:

- **Identity exact to 2.78e-16** (independent reimplementation vs. direct `||Im psi||/||psi||`, dims 2–16, multiple seeds).
- **Load-bearing premise holds exactly.** `R_sigma` is **exactly real** at the fixed point (`max|Im R| = 0`; structural — `curvature()` depends on `psi` only through `|psi|^2` and `h ∈ ℝ`), the phase is locked to the magnitude (`arg psi*_sigma = theta R_sigma`, residual 5e-13), and the Lorentzian/Riemannian magnitudes coincide (2.8e-13) so phase-stripping recovers the Riemannian state.
- **Fixed-point large-N limit ≈ 0.40** confirmed (`E_p[sin^2 theta(h-h_min)]^{1/2} = 0.3988`).
- Hidden-assumption sweep passed: no time evolution (static fixed-point condition), no smuggled background beyond the disclosed external field `h`, the global-phase alignment is an acknowledged gauge choice (the result is convention-dependent and says so).

**The `(Rigorous)` label on `eq:im_frac_reduction` is justified and is retained.** Demoting it would be a manufactured demotion.

## The defect: a false asymptotic in the same bullet

The adjacent claim — the **Haar-random baseline** `im_frac → 1/√2 ≈ 0.707 as N → ∞` (max-magnitude alignment) — is **wrong**.

The "`sin^2 → 1/2` ⇒ `im_frac → 1/√2`" argument fails: under the **max-magnitude reference** `p_r = p_max`, the alignment phase is correlated with the Born weight, so the Born-weighted `⟨sin^2⟩` does **not** average to `1/2`. For Haar weights `p_sigma ∝ E_sigma`, `E_sigma ~ Exp(1)`, the leading large-N behavior is
```
im_frac^2 -> 1/2 - (1/2) Re[ e^{i theta log E_max} Gamma(2 - i theta) ],
```
an oscillation in `log E_max ~ log log N` of amplitude `(1/2)|Gamma(2 ± i theta)| ≈ 0.369` at `theta=1` — **nonzero**, so there is no `1/√2` limit. Monte-Carlo confirms (matches the leading form to `< 0.003`):

| N | 256 | 1024 | 4096 | 16384 | 65536 | 262144 |
|---|-----|------|------|-------|-------|--------|
| max-align Haar `im_frac` | 0.637 | 0.695 | 0.738 | 0.773 | 0.800 | **0.824** |

The value rises monotonically **through** 0.707 with no sign of converging to it. The script/paper extrapolated the `N ≤ 256` trend to `1/√2`; the trend does not hold.

The **qualitative** conclusion is unaffected: the Haar value is ≥ 0.637 and rising at every accessible `N`, always well above the fixed point's ≈ 0.40, so "the self-consistency map produces minimal, not maximal, phase complexity" still stands.

(The subagent's secondary flag — that the *optimal*-alignment value is not reproducible by `eq:(*)` with a single data-point reference — is **not** a paper error: `index.tex` only states both figures are convention-dependent functionals of `{p_sigma}, theta`, which is true. No change made on that account.)

## Changes

- `index.tex` §3.1 — replace the false `→ 1/√2` Haar limit with the verified non-convergent behaviour; keep `eq:im_frac_reduction` **(Rigorous)** and the qualitative "below Haar / minimal phase complexity" conclusion.
- `explorations/2026-06-18-imaginary-fraction-rank.md` — dated **Correction** note, corrected table (extended to `N = 2.6×10^5`), and the corrected `Gamma(2 ± i theta)` mechanism.
- `tests/imaginary_fraction.py` — docstring + script output corrected (the `haar_im_frac` Monte-Carlo function itself was already correct; only the `1/√2` *interpretation* was wrong).

## Self-checks

- **Dimensional analysis.** `im_frac` is a dimensionless norm ratio; unchanged.
- **Limiting cases.** Riemannian (`theta=0`) `im_frac = 0` exactly (retained); fixed-point large-N limit ≈ 0.40 (retained, verified 0.3988).
- **Consistency.** The corrected Haar statement is consistent with the (correct, untouched) `haar_im_frac` Monte-Carlo and with the `TestBelowHaar` assertions (which compare against the Monte-Carlo baseline, not `1/√2`, and remain green).
- **Order-of-magnitude / numerics.** Leading asymptotic matches Monte-Carlo to `< 0.003` over `N = 256 … 2.6×10^5`; tests pass (20 passed).

## Rigor level

- `eq:im_frac_reduction`: **(Rigorous)** — unchanged (verified, not demoted).
- Haar-baseline asymptote: previously stated `→ 1/√2` (numerical claim) is **corrected/withdrawn**; replaced by the verified non-convergent behaviour.

Closes nothing; corrects merged content from #114. Relation: **corrects #114** (the CE-2 PR), **informs #33** (the originating issue, closed).

routine: red-team · model: claude-opus-4-8