### PR TITLE
Add /status-report and /research-report commands

### DIFF
--- a/.claude/commands/research-report.md
+++ b/.claude/commands/research-report.md
@@ -1,0 +1,75 @@
+---
+description: "Research report — plain-English narrative of what the research accomplished, tiered by significance"
+arguments:
+  - name: window
+    description: "Lookback window, e.g. '7d', '2w', '1mo'. Default 7d."
+    required: false
+  - name: program
+    description: "Optional: focus on one program (directory under programs/). If omitted, cover all four."
+    required: false
+---
+
+You are producing a **read-only research report** for the experimenter: a
+plain-English narrative of what the *research* accomplished in the window,
+tiered by significance. This is the on-demand twin of the automated weekly
+`digest.yml` (which emails the same kind of report and posts it to the
+"Breakthrough digest" issue) — keep the framing identical so the two never
+drift. It is the **research** counterpart to `/status-report`, which covers
+operational health (runs, tripwires, queue). Use this one to answer "what did
+we discover / overturn / advance?"; use `/status-report` for "is the machine
+healthy, what needs me?".
+
+Default the window to **7 days** unless $ARGUMENTS specifies one. Being
+interactive, you can go deeper than the headless digest: read the actual
+`index.tex` sections, explorations, and PR diffs to ground and explain claims,
+and follow up on any single result the experimenter asks about.
+
+## Step 1: Gather (run in parallel)
+
+Compute `SINCE` from the window, then:
+
+1. **Merged work:** `gh pr list --state merged --limit 50 --json number,title,mergedAt,labels,body` filtered to `mergedAt >= SINCE`. The labels `promotion-rigorous` / `demotion` / `withdrawn` / `governance` drive Tier A; the milestone IDs in titles (`CE-2`, `FPE-4`, …) map work to programs.
+2. **Queue health:** open `needs-human` (verbatim), `stuck`, and PRs awaiting quorum (`gh pr list --state open --label agent-pr`).
+3. **Rigor posture:** the rigor distribution from the latest metrics snapshot (Metrics dashboard issue / newest `metrics/*.json`), as the trend baseline.
+4. **Ground the claims:** for any Tier A/B item, read the relevant `programs/<p>/index.tex` section, exploration, or PR diff so the one-line description is accurate and at the correct rigor level — do not paraphrase the PR title. If `$program` is set, restrict to that program.
+
+## Step 2: Tier the work (significance, not activity)
+
+Mirror `digest.yml` exactly:
+
+- **Tier A — gate-certified events:** every merged PR labeled `promotion-rigorous`, `demotion`, or `withdrawn`, plus every `governance` merge touching an `OBJECTIVES.md`. Membership is mechanical — list ALL and nothing else here, each with one sentence on what was promoted/overturned and why it matters.
+- **Tier B — significant below the gate bar:** merged work meeting METHODOLOGY's significance test — *"would change a prediction or appear in the abstract"* — that is not Tier A: a new Sketch with a complete gap map, a negative result closing a direction, a notable exploration, a milestone advanced. Point at the specific labeled result or prediction; "interesting" is not a criterion.
+- **Tier C:** everything else merged, one line each.
+
+## Step 3: Write the report
+
+Lead with the outcome. Structure:
+
+```
+# Research report — <date>, <window> window
+
+## Headline
+<One paragraph, plain English a non-physicist could follow: what materially changed.>
+
+## Tier A — gate-certified events
+<Every promotion/demotion/withdrawal/OBJECTIVES merge, one sentence each. "None this window." if empty — the expected steady state, not a failure.>
+
+## Tier B — significant below the bar
+<Significant non-gate-certified work, each pointing at the affected result/prediction. "None this window." if empty.>
+
+## Tier C
+<Everything else merged, one line each.>
+
+## Per-program
+<One line per program (or just $program if focused): what advanced, current rigor posture, what's in flight.>
+
+## Queue health
+<needs-human verbatim; stuck; PRs awaiting quorum.>
+```
+
+## Calibration rules (binding — same as digest.yml)
+
+- **Do not inflate.** "None this window." is a valid and common Tier A line; it is the expected steady state, not a failure.
+- **Never state a result above its rigor label.** Call conjectures conjectures, sketches sketches, in plain English too.
+- **Demotions and withdrawals are progress**, not setbacks — report them that way (a counterexample found is a result).
+- **Read-only and informational.** No recommendations about labels, verdicts, or merges; no edits, no dispatches. If something needs action, that belongs in `/status-report`, not here.

--- a/.claude/commands/status-report.md
+++ b/.claude/commands/status-report.md
@@ -23,9 +23,9 @@ Compute `SINCE` from the window (e.g. `date -u -d '7 days ago' +%FT%TZ`), then:
    - Open PRs: `gh pr list --state open --json number,title,labels,headRefOid,createdAt`
    - Per label count, open issues: `agent-ready`, `stuck`, `needs-human`, `thread-proposal` (`gh issue list --state open --label <L> --json number,title`)
 3. **Throughput (window):** `gh pr list --state merged --limit 50 --json number,title,mergedAt,labels` then filter `mergedAt >= SINCE`.
-4. **Metrics:** latest comment on the **Metrics dashboard** issue (`gh issue list --state open --search 'in:title "Metrics dashboard"'` → newest comment) and the most recent two `metrics/*.json` files.
-5. **Quorum verdicts (for T3):** scan recent merged + open agent-PR comments for `<!-- quorum:verdict <accept|revise|reject> -->` markers over the trailing 20.
-6. **Per program:** for each of `co-emergence`, `fixed-point-existence`, `gaussian-gravitational-decoherence`, `signature-change-boundary`, read `programs/<p>/OBJECTIVES.md` (milestone statuses) and the merged PRs in the window touching `programs/<p>/`.
+4. **Metrics (last recorded, NOT current):** read the newest comment on the **Metrics dashboard** issue (`gh issue list --state open --search 'in:title "Metrics dashboard"'` → newest comment) and the latest `metrics/*.json`. This is the last *weekly* snapshot and may be up to 6 days stale — note its date. Do **not** quote its PR counts as current: compute current totals (merged agent-PRs, demotions, promotions, demotion rate) from the live merge list in Step 1.3, and use the snapshot only for the rigor distribution and as a trend baseline.
+5. **Quorum verdicts (for T3):** collect markers across the last ~10 merged agent-PRs plus all open agent-PRs, then take the trailing 20. Per-PR query that works (`scan` returns empty — use `capture`): `gh pr view <N> --json comments --jq '[.comments[].body | capture("quorum:verdict (?<v>accept|revise|reject)")?.v] | map(select(.!=null))'`. Tally accept vs revise/reject.
+6. **Per program** (`co-emergence`, `fixed-point-existence`, `gaussian-gravitational-decoherence`, `signature-change-boundary`): infer movement from the window's merged-PR **titles** first — they carry milestone IDs (`CE-2`, `FPE-4`, `GGD-2`, `SCB-6`). Read a `programs/<p>/OBJECTIVES.md` only to resolve a status the titles leave unclear; do not read all four by default.
 
 ## Step 2: Diagnose failures (do not just count them)
 

--- a/.claude/commands/status-report.md
+++ b/.claude/commands/status-report.md
@@ -1,0 +1,94 @@
+---
+description: "Status report — workflow-run health, autonomy-loop flow, tripwires, and per-program progress"
+arguments:
+  - name: window
+    description: "Lookback window for throughput/failures, e.g. '7d', '48h', '2w'. Default 7d."
+    required: false
+---
+
+You are producing a **read-only status report** of this autonomous research
+system (see `docs/ARCHITECTURE.md`) for the experimenter. This command
+reports and assesses; it never sets labels, merges, dispatches routines, or
+modifies the repo. Default the lookback window to **7 days** unless $ARGUMENTS
+specifies one (e.g. `48h`, `2w`).
+
+## Step 1: Gather data (run in parallel)
+
+Compute `SINCE` from the window (e.g. `date -u -d '7 days ago' +%FT%TZ`), then:
+
+1. **Recent runs + failures:**
+   - `gh run list --limit 25 --json workflowName,status,conclusion,createdAt,event,databaseId`
+   - `gh run list --limit 80 --json conclusion,workflowName,createdAt,databaseId --jq '[.[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="startup_failure")]'`
+2. **Queue & flow:**
+   - Open PRs: `gh pr list --state open --json number,title,labels,headRefOid,createdAt`
+   - Per label count, open issues: `agent-ready`, `stuck`, `needs-human`, `thread-proposal` (`gh issue list --state open --label <L> --json number,title`)
+3. **Throughput (window):** `gh pr list --state merged --limit 50 --json number,title,mergedAt,labels` then filter `mergedAt >= SINCE`.
+4. **Metrics:** latest comment on the **Metrics dashboard** issue (`gh issue list --state open --search 'in:title "Metrics dashboard"'` → newest comment) and the most recent two `metrics/*.json` files.
+5. **Quorum verdicts (for T3):** scan recent merged + open agent-PR comments for `<!-- quorum:verdict <accept|revise|reject> -->` markers over the trailing 20.
+6. **Per program:** for each of `co-emergence`, `fixed-point-existence`, `gaussian-gravitational-decoherence`, `signature-change-boundary`, read `programs/<p>/OBJECTIVES.md` (milestone statuses) and the merged PRs in the window touching `programs/<p>/`.
+
+## Step 2: Diagnose failures (do not just count them)
+
+For each failed run in the window, classify — don't report a raw failure count:
+
+- **Self-healed** — a transient API error (529/5xx/429) or session limit that a
+  later scheduled fire covered (per-SHA verdicts mean nothing was lost). Confirm
+  by checking that no open agent-PR is missing a current-SHA verdict and a
+  subsequent run of the same workflow succeeded. Report as "absorbed", not as an
+  outage.
+- **Real** — a non-transient failure, or one that left a PR stranded (open
+  agent-PR whose head SHA has no verdict and no in-flight reviewer), or a
+  repeated pattern. These go in "Needs attention".
+
+Pull the failing step's log tail when unsure (`gh run view <id> --log-failed`
+or the jobs API) and quote the actual error.
+
+## Step 3: Evaluate tripwires (EXPERIMENT.md T1–T5)
+
+State each as ✅ / ⚠️ near-threshold / 🔴 fired:
+
+- **T1** — zero demotions+withdrawals after 20 merged agent result-PRs. Report the running counts and how close.
+- **T2** — fabricated/misrepresenting citation in merged content. Mechanically uncheckable here; flag as "manual — no automated signal", note any citation-related demotions seen.
+- **T3** — quorum accept rate > 95% over trailing 20 verdicts. Compute from Step 1.5; a healthy system shows revises/rejects.
+- **T4** — > 50% of merged PR volume (trailing 4 weeks) outside any OBJECTIVES milestone. Estimate from labels/titles vs. OBJECTIVES; mark as estimate.
+- **T5** — two consecutive weekly metrics runs failed or empty. Check the last two `metrics/*.json` exist and carry non-zero PR-derived numbers.
+
+## Step 4: Write the report
+
+Lead with the outcome. Use this structure:
+
+```
+# Status — <date>, <window> window
+
+**<One-line verdict>** — healthy / healthy-with-noise / needs attention, and the single most important fact.
+
+## Workflow health
+<Runs green? Failures classified as absorbed vs real. Is the event-driven loop firing (workflow_dispatch reviewers/responders)?>
+
+## Flow & queue
+<Open agent-PRs and whether they hold current-SHA verdicts; agent-ready depth; stuck; needs-human; thread-proposals (and whether the governor has adjudicated them).>
+
+## Throughput (<window>)
+<Merged PRs grouped by program; demotions/promotions; anything that closed a long-standing issue.>
+
+## Tripwires
+<T1–T5, one line each, with the number that matters.>
+
+## Per-program
+<One line per program: latest milestone movement, rigor posture, what's in flight.>
+
+## Needs your attention
+<Only genuine items: needs-human, stuck, real (non-absorbed) failures, thread-proposals awaiting adjudication, any tripwire ⚠️/🔴. If none, say "Nothing — system is running itself.">
+```
+
+## Constraints
+
+- **Read-only.** Never merge, label, dispatch, or edit. If you spot something
+  that needs action, put it under "Needs your attention" — do not act on it.
+- **Classify, don't alarm.** A self-healed transient failure is noise, not an
+  incident; say so explicitly so the failure signal stays meaningful. Conversely,
+  do not bury a real stranded PR under a green headline.
+- **Numbers that matter, not data dumps.** Quote the demotion rate, the accept
+  rate, the queue depths — not every run.
+- **Be honest about estimates.** T2 and T4 are partly judgment; label them as
+  such rather than asserting a clean pass.


### PR DESCRIPTION
Two parallel read-only report commands, split by audience question rather than merged into one output:

| | `/status-report` | `/research-report` |
|---|---|---|
| Answers | "is the machine healthy, what needs me?" | "what did the research accomplish / overturn / advance?" |
| Content | run-failure classification (absorbed vs. real), queue/flow, tripwires T1–T5 | plain-English narrative tiered by significance (Tier A gate-certified / B significant-below-bar / C) |
| Twin of | — | the automated weekly `digest.yml` |

Both are read-only (report, never act), take an optional `window` arg (default 7d), and match the existing `.claude/commands/` house style.

**`/status-report`** also incorporates three fixes from its first live run: treat the metrics snapshot as a possibly-stale weekly datapoint and recompute current counts from the live merge list; use the working `capture` verdict query for T3; infer per-program movement from milestone IDs in PR titles instead of reading all four OBJECTIVES files.

**`/research-report`** mirrors `digest.yml`'s tiering and calibration rules verbatim, so the on-demand and automated research narratives stay consistent. Being interactive, it can read `index.tex`/explorations/diffs to ground claims rather than paraphrasing PR titles, and takes an optional `program` focus arg.

Deliberately **not** consolidated into one report: the operational and research views serve different moments, and a single output would bloat each. The sensible shared-logic follow-up (a `scripts/collect_status.sh` collector feeding the two commands *and* the digest, plus a health line in the weekly email) is noted for a separate PR.

Protected path (`.claude/`) → experimenter-authored, admin-merge per the documented procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)