### PR TITLE
CE-10 follow-on: state θ↔signature identification as derived-up-to-polarization (Sketch)

### DIFF
--- a/programs/co-emergence/index.tex
+++ b/programs/co-emergence/index.tex
@@ -53,6 +53,10 @@ entirely a phase effect.
 We propose that this mechanism extends to a co-emergence of mass,
 Lorentzian signature, local time, and local Hilbert space: four aspects
 of a single self-consistent structure, none existing without the others.
+The complex weight that drives the mechanism is itself derived from
+hyperbolic temporal mode structure---not stipulated by analogy with the
+path integral---at Sketch level, up to a residual polarization choice
+(complex versus signed-real amplitudes) that signature alone does not fix.
 Physical mass requires hyperbolicity (Wigner 1939); hyperbolicity
 provides local proper time along timelike geodesics; local proper time
 enables a local Hilbert space via the Page--Wootters mechanism; and the
@@ -266,27 +270,76 @@ of marginalization or coarse-graining can generate complex amplitudes
 from real-valued weights. If $\mu^*$ is real, the framework produces
 statistical mechanics, not quantum mechanics.
 
-Quantum statistics require complex weights that can cancel. In the path
-integral, this structure comes from the Lorentzian action: the weight
-$e^{iS/\hbar}$ is a complex phase whose oscillations produce the
-interference that distinguishes quantum from classical. On a Riemannian
-manifold, the corresponding weight $e^{-S_E/\hbar}$ is real and positive.
-
-This observation connects the phase structure of $\mu^*$ directly to
-signature selection. If the smooth-structure measure inherits its weight
-from the action functional on each smooth structure, then:
+Quantum statistics require weights that can cancel; classical statistics
+arise from real, positive weights that cannot. Within the framework this
+distinction is \emph{derived} from signature rather than imported from the
+path integral. Treating each configuration's self-consistency weight as
+the amplitude of a free scalar's temporal mode accumulated over that
+configuration's temporal extent---using the operator dichotomy across the
+degenerate surface established in the companion signature-change note
+(oscillatory on the Lorentzian side, exponentially decaying on the
+Euclidean side, at the same rate constants)---yields the following chain,
+recorded in
+\texttt{explorations/2026-06-10-derived-weight-from-signature.md}:
 \begin{itemize}
-\item On a Lorentzian manifold, $\mu^*$ carries complex phases $\to$
-marginalization can produce quantum statistics $\to$ Level~3 is
-nontrivial.
-\item On a Riemannian manifold, $\mu^*$ is real-valued $\to$
-marginalization produces only classical correlations $\to$ Level~3
-collapses to classical statistics.
+\item \textbf{(Rigorous.)} \emph{Cancellation capacity
+$\Leftrightarrow$ hyperbolicity.} The elliptic (Euclidean) temporal
+operator has a unique bounded branch, which is real and strictly
+positive, so a weight built from it can never cancel. Every solution of
+the hyperbolic (Lorentzian) operator satisfies
+$\varphi(u + \pi/\omega) = -\varphi(u)$: weights at temporal extents a
+half-period apart cancel exactly, for \emph{every} polarization. The
+structural difference between $e^{iS}$ and $e^{-S_E}$ that this argument
+uses---oscillation versus positivity---is thus a theorem about operator
+type (hyperbolic versus elliptic), with no polarization choice involved.
+\item \textbf{(Sketch.)} \emph{The complex weight is fixed up to a
+polarization fork.} Under the complex (positive-frequency / Wick)
+polarization of the two-dimensional hyperbolic solution space, the
+accumulated-phase weight reproduces the toy model's $e^{(-1+i\theta)R}$
+exactly, the damping part $(-1)$ identified as a Euclidean admixture over
+a fraction $\varepsilon = 1/(1+\theta)$ of the extent, and phase locking
+$\varphi_\sigma = c\,R_\sigma$ is then derived rather than read off the
+stipulated exponent.
 \end{itemize}
-This is a sharper mechanism for Level~3 signature selectivity than the
-absence of timelike geodesics alone. The Riemannian fixed point fails
-not only because there are no local clocks, but because the measure
-itself lacks the phase structure required for quantum interference.
+The $\theta\leftrightarrow$signature identification is therefore
+\textbf{derived from hyperbolic temporal mode structure (Sketch)}, not
+stipulated. The path-integral comparison---$e^{iS/\hbar}$ a complex,
+oscillating Lorentzian weight versus the real, positive Riemannian
+$e^{-S_E/\hbar}$---now serves as a consistency check on this derivation
+rather than as its support.
+
+\medskip\noindent\textbf{Open: the polarization choice (gap (c)).} What
+signature alone does \emph{not} fix is the \emph{complex} form of the
+cancellation, as opposed to a signed-real one. Transporting the Euclidean
+boundedness selection across the degenerate surface by the
+no-surface-layer junction conditions yields a \emph{real} oscillatory
+mode ($\cos\omega u - \sin\omega u$, with equal-modulus coefficients on
+$e^{\pm i\omega u}$); the complex line $e^{i\omega u}$ requires a separate
+contour / positive-frequency choice not fixed by local data at the
+degenerate surface. The signed-real sector is a genuine self-consistent
+alternative that cancels---interference in the sense this argument
+requires---but has \emph{real} subsystem density matrices
+(real-amplitude quantum theory). Whether any cross-level requirement of
+the framework excludes it, thereby deriving \emph{complex} quantum
+structure from self-consistency, is open; it is pursued as
+thread-proposal~\#104. The identification above is thus derived \emph{up
+to} this polarization fork.
+
+\medskip
+With this derivation in hand, the connection to signature selection
+sharpens. On a Riemannian manifold the weight is real and positive
+(the Rigorous cancellation result above), so $\mu^*$ admits no
+cancellation,
+marginalization produces only classical correlations, and Level~3
+collapses to classical statistics. On a Lorentzian manifold the weight
+oscillates and $\mu^*$ can cancel, so marginalization can produce
+quantum statistics and Level~3 is nontrivial---with the complex (as
+opposed to signed-real) character of those statistics resting on the
+open polarization choice above. This is a sharper mechanism for Level~3
+signature selectivity than the absence of timelike geodesics alone: the
+Riemannian fixed point fails not only because there are no local clocks,
+but because the measure itself lacks the structure required for
+interference.
 
 %----------------------------------------------------------------------
 \subsection{Phase structure of the fixed point}


### PR DESCRIPTION
Closes #121.

## Summary

CE-10 follow-on (framing clause). The derivation half of CE-10 landed in PR #89 (exploration `programs/co-emergence/explorations/2026-06-10-derived-weight-from-signature.md`, outcome (a)). This PR completes the milestone's remaining done-condition clause: update §3 framing and the abstract to state the θ↔signature identification as **derived-up-to-polarization (Sketch)**, not stipulated by path-integral analogy.

**Changes to `programs/co-emergence/index.tex`:**

1. **§3 preamble (`sec:phase`).** Replaced the path-integral-analogy paragraph + bullets with the Lemma 1–3 derivation chain from the exploration:
   - **Cancellation capacity ⟺ hyperbolicity** stated as derived (**Rigorous**): elliptic operator → unique bounded real-positive branch (no cancellation); hyperbolic operator → `φ(u+π/ω) = −φ(u)` (exact cancellation, every polarization). Oscillation-vs-positivity is a theorem about operator type, not an analogy.
   - The complex weight reproducing `e^{(-1+iθ)R}` is fixed **up to the polarization fork** (**Sketch**), with phase locking derived.
   - **Gap (c)** named explicitly: signature fixes cancellation but not its *complex* (vs signed-real) form; the signed-real sector is a genuine self-consistent real-amplitude alternative. Referenced thread-proposal #104 as the channel pursuing whether cross-level constraints exclude it.
   - Path-integral comparison **repositioned as a consistency check**, not the support.
   - Preserved the Level-3 signature-selectivity conclusion, restated so the Riemannian→classical collapse is the Rigorous part and the Lorentzian→quantum nontriviality carries the polarization caveat.
   - Exploration referenced by relative path `explorations/2026-06-10-derived-weight-from-signature.md` (matching existing `\texttt{...}` style).

2. **Abstract (co-emergence thesis paragraph).** Added a sentence: the complex weight driving the mechanism is derived from hyperbolic temporal mode structure — not stipulated by path-integral analogy — at Sketch level, up to the residual polarization choice. No claim stated above its rigor label.

No new equations, no new numerics, no new citations. The pre-existing cosmetic `m^{1+iθ}`/`m^{1−iθ}` label slip at `rem:entropy_application` (exploration §7 item 5) is a separate maintenance issue against `main` and is **not** touched here.

## Rigor level

Framing/labeling update only. The result it documents is **(Sketch)** (derived-up-to-polarization); the embedded cancellation⟺hyperbolicity statement is **(Rigorous)**. No rigor *promotion* — the milestone status was already Sketch in the merged exploration; this PR brings the paper text into line with it. The headline §3 framing changes, so the README "In plain English" abstract was reviewed for consistency (see below).

## Self-checks

- **Dimensional analysis.** No new equations; `θ` dimensionless, `ωτ = cR` dimensionless (ℏ = 1); no units introduced. ✓
- **Limiting cases.** Riemannian / `θ = 0`: elliptic mode real → weight real and positive → consistent with the retained "real measure → classical statistics" statement. The `θ → 0 ⟹ (ε,c) → (1,1)` continuity established in the exploration §6 underlies this. ✓
- **Consistency.** Text draws on the SCB fixed-background note strictly within its stated scope (test-field, single-mode); the framing does not overstate to the full coupled problem — the single-mode/`k`-sum and action-identification gaps (a),(b) remain named in the exploration and are not claimed closed. Gap (c) is presented as open, matching the exploration and thread-proposal #104. No contradiction with `lem:entropy_excess` (depends on magnitudes only). ✓
- **Order-of-magnitude sanity.** No numerical predictions added or changed. ✓

## Verification

- `pdflatex` not available in this worker environment; brace balance (1155/1155) and `\begin`/`\end` environment matching verified programmatically. The CI `pdflatex (co-emergence)` gate is authoritative.
- No `.bib`/`thebibliography` change → no citation verification needed; the only new reference is the in-repo exploration path.

## README "In plain English" check

The change keeps the identification at Sketch and explicitly *adds* the open polarization caveat (does not raise confidence), so the README abstract is not over-claimed by this PR. Reviewer should confirm the README line on the complex-phase origin, if any, is not now under-stated; no headline rigor *level* changed (Sketch → Sketch), so no README rigor edit is required by the worker routine's same-PR rule.

## Recommended adversarial review mode

**Verification.** No new derivation is introduced; the review should confirm (1) the text faithfully represents the exploration's rigor levels (Rigorous for Lemmas 1–2 / cancellation⟺hyperbolicity; Sketch for the complex-form identification), (2) gap (c) is not understated, (3) scope is not overstated beyond the test-field single-mode model, and (4) the Riemannian θ=0 limit statement is preserved.

routine: worker · model: claude-opus-4-8
