### PR TITLE
Demotion: CE-3 item-1 inference Rigorous → Sketch (raw action vs. scale-invariant distillate)

### DIFF
--- a/programs/co-emergence/explorations/2026-06-19-einstein-hilbert-action-smooth-structures.md
+++ b/programs/co-emergence/explorations/2026-06-19-einstein-hilbert-action-smooth-structures.md
@@ -11,6 +11,22 @@ homeomorphic, non-diffeomorphic compact 4-manifolds. Transferring this to the
 framework's actual setting — *non-compact* (exotic $\mathbb{R}^4$) and
 *Lorentzian* metrics — is open and is the residual gap.
 
+> **Demotion note (red-team, 2026-06-22).** The summary inference in
+> "What this means" item 1 was demoted **Rigorous → Sketch**. Its
+> Rigorous-labeled core (Claims 1–3, Parts I–II) is unaffected and survives
+> stress-testing. The defect was in the *translation* of Parts I–II into a
+> claim about the toy model's actual external field $h_{rc}$: (i) the
+> universal "the action varies *whenever* Seiberg–Witten invariants do" is the
+> wrong direction — the scale-invariant distillates $\mathcal{Y},
+> \mathcal{I}_s$ are *lossy* functions of the SW basic-class set, so distinct
+> SW data need not yield distinct distillates; the true implication runs only
+> "differing distillates ⇒ distinct smooth structures"; and (ii) $h_{rc}$ is
+> the **raw** action $S_{\mathrm{EH}}[g^*_\sigma]$, which is scale-dependent
+> (Claim 1a) and is not $\mathcal{Y}$/$\mathcal{I}_s$ — the bridge needs the
+> self-consistent metric to track a scale-invariant extremizer, which is not
+> established. All three LeBrun citations were re-verified clean (existence and
+> content). Gap-filling follow-up: issue #124.
+
 ---
 
 ## The question (from the toy model)
@@ -96,9 +112,11 @@ $\mathrm{Sm}(\mathcal{M})$. The framework clears its lowest bar rigorously.
 ## Part II — Branch (1), rigorously, in the compact Riemannian case
 
 Because $S_{\mathrm{EH}}$ is scale-dependent (Claim 1a), the sharp question is
-not about the *raw* action — which the self-consistent dynamics will scale-fix
-anyway — but about a **scale-invariant** distillate of it, where one can ask
-cleanly whether smooth structure changes the value. There are two canonical
+not about the *raw* action — which the self-consistent dynamics is
+*conjectured* to scale-fix (see the demotion note below; that the
+self-consistent metric $g^*_\sigma$ tracks a scale-invariant extremizer is
+**not** established here) — but about a **scale-invariant** distillate of it,
+where one can ask cleanly whether smooth structure changes the value. There are two canonical
 scale-invariant functionals built from $s$, and Seiberg–Witten theory shows
 **both distinguish smooth structures**.
 
@@ -228,11 +246,37 @@ anything stronger would violate the rigor discipline.
 ## What this means for the toy model and the paper
 
 1. **The toy model's non-uniform $h_{rc}$ is structurally justified, not
-   merely a parameter choice — in the compact Riemannian category (Rigorous).**
-   The exploration's own caveat #2 ("the external field $h$ is not derived")
-   is partially discharged: a scale-fixed action *does* vary across smooth
-   structures whenever Seiberg–Witten invariants do. What remains undischarged
-   is the transfer to Lorentzian signature and to the non-compact candidate.
+   merely a parameter choice — in the compact Riemannian category (Sketch;
+   demoted from Rigorous 2026-06-22, see note).** What is *Rigorous* (Claims
+   2–3) is narrower than this sentence originally stated: scale-invariant
+   scalar-curvature distillates ($\mathcal{Y}$, $\mathcal{I}_s$) take
+   **different** values on some homeomorphic, non-diffeomorphic compact
+   Riemannian 4-manifolds. The exploration's caveat #2 ("the external field
+   $h$ is not derived") is therefore *partially* discharged, but two omitted
+   steps keep the discharge at Sketch:
+   - **Direction.** The supported implication is one-directional: *differing
+     $\mathcal{Y}$ or $\mathcal{I}_s$ certifies distinct smooth structures.*
+     The converse — that the distillates differ *whenever* the
+     Seiberg–Witten invariants differ — is **false in general**:
+     $\mathcal{I}_s = 32\pi^2\beta^2$ and (negative-case)
+     $\mathcal{Y} = -4\pi\sqrt{2c_1^2(X_{\min})}$ depend only on the
+     convex-hull extremum of the monopole classes / the minimal model's
+     $c_1^2$, which are *lossy* functions of the full basic-class set. Two
+     smooth structures with different SW data can share the same
+     $\mathcal{Y}$, $\mathcal{I}_s$.
+   - **Raw action vs. distillate.** The toy model's $h_{rc}$ is the **raw**
+     action $S_{\mathrm{EH}}[g^*_\sigma]$ at the *specific* self-consistent
+     metric, which is scale-dependent (Claim 1a) and is **not**
+     $\mathcal{Y}$ or $\mathcal{I}_s$. Nothing rigorous here connects the
+     self-consistent metric to a scale-invariant extremizer (it solves the
+     SCE, not a Yamabe/SW variational problem). Bridging "distillates differ"
+     to "$h_{rc}$ is non-uniform" needs that connection — the
+     scale-fixing clause flagged at the start of Part~II — which is itself
+     unestablished.
+
+   What remains undischarged is therefore not only the transfer to Lorentzian
+   signature and to the non-compact candidate, but also — already inside the
+   compact Riemannian category — the two steps above. Follow-up: issue #124.
 
 2. **No paper text should be promoted on this yet.** The honest, citable
    statement is the *negative* one (Part I, Rigorous): the EH action is not a


### PR DESCRIPTION
Red-team stress-test of the CE-3 exploration `programs/co-emergence/explorations/2026-06-19-einstein-hilbert-action-smooth-structures.md` (merged PR #115, issue #29). Audited under METHODOLOGY stress-testing mode with a fresh-context attack subagent.

## What was attacked

The three **(Rigorous)** claims (Claim 1: $S_{\mathrm{EH}}$ not a topological invariant; Claim 2: Yamabe invariant separates smooth structures, LeBrun 1999; Claim 3: the $32\pi^2(\mathfrak{a}^+)^2$ SW scalar-curvature bound, LeBrun 2001), the **(Rigorous)** summary inference in "What this means" item 1, all three LeBrun citations (existence **and** content), and every hidden-assumption warning (time/foliation, smuggled background, the Gap A/B firewall).

## What held (no change)

- **Claims 1–3 survive at Rigorous.** Scaling arithmetic ($S_{\mathrm{EH}}[\lambda^2 g]=\lambda^{n-2}S_{\mathrm{EH}}[g]$, $n{=}4\Rightarrow\lambda^2$), the $\chi/\tau$-independence argument, the Kodaira-dimension sign rule, $\mathcal{Y}=-4\pi\sqrt{2c_1^2}$, the $32\pi^2 c_1^2$ sharp value, the blow-up shift, and the internal consistency $\mathcal{I}_s=\mathcal{Y}^2$ (negative case) all check out.
- **All three LeBrun citations are clean** — exist and say what is attributed (re-verified via the 1999 and 2001 papers). No citation action.
- **Gap A/B firewall is sound** — no Rigorous-labeled sentence depends on bridging the Lorentzian or non-compact gaps; those are correctly quarantined in Conjecture Claim 4.

## The gap (demotion)

The **(Rigorous)** label on "What this means" **item 1** is overstated on two counts, both in the *translation* of Parts I–II into a claim about the toy model's actual external field $h_{rc}$:

1. **Reversed implication.** Item 1 asserted the action varies "*whenever* Seiberg–Witten invariants do." This is the wrong direction. $\mathcal{I}_s = 32\pi^2\beta^2$ and $\mathcal{Y} = -4\pi\sqrt{2c_1^2(X_{\min})}$ depend only on the convex-hull extremum of the monopole classes / the minimal model's $c_1^2$ — *lossy* functions of the full basic-class set — so distinct SW data can give identical distillates. Only "differing $\mathcal{Y}/\mathcal{I}_s$ ⇒ distinct smooth structures" is rigorous.
2. **Raw action vs. distillate.** $h_{rc}$ is the **raw** $S_{\mathrm{EH}}[g^*_\sigma]$, which is scale-dependent (Claim 1a) and is *not* $\mathcal{Y}$ or $\mathcal{I}_s$. The self-consistent metric solves the SCE, not a Yamabe/SW variational problem, so the Rigorous separation of the distillates does not rigorously transfer to the raw action the toy model uses. The bridge rests on the "the dynamics will scale-fix anyway" clause (Part II opener) — a smuggled assumption.

Both defects sit on the single sentence that carries Parts I–II into the framework. **Item 1 demoted Rigorous → Sketch**: the argument structure is sound and compelling (smooth structures *are* distinguished by curvature functionals), but two steps are omitted.

## Changes

- Item 1: `(Rigorous)` → `(Sketch; demoted ...)`, rewritten to state the one-directional implication and the raw-action-vs-distillate gap explicitly.
- Part II opener: hedged the "will scale-fix anyway" clause (smuggled-assumption removal); no label change.
- Added a dated demotion note below the Outcome header.
- Opened gap-filling follow-up **#124** (not `agent-ready`).

## Self-checks

- **Scope:** only the `.md` exploration changes; no `index.tex`, no `thebibliography`, no headline rigor-status change → no README "In plain English" update required, no new/changed citation (`verify`/`claim-support` untouched).
- **Consistency:** Parts I–II and Claim 4 (Conjecture) unchanged; the demotion only *lowers* a claim, introduces no new postulate, and contradicts no merged result. Issues #27 and #29 (the only issues this exploration informed) are closed — no open lemma dependents to notify.
- **No over-reach:** Claims 1–3 explicitly left Rigorous; this is not a manufactured demotion (citations and core math all held).

Labels: `agent-pr`, `demotion`.

routine: red-team · model: claude-opus-4-8