### PR TITLE
Demotion: Starobinsky cosmological coefficient H_0^2=180π/(G|a_2|) Rigorous→Sketch (citation does not cover the explicit coefficient)

### DIFF
--- a/programs/co-emergence/index.tex
+++ b/programs/co-emergence/index.tex
@@ -1443,8 +1443,12 @@ existence of solutions at three levels of rigor:
 \begin{enumerate}
 
 \item \emph{Exactly}, in the cosmological case via the Starobinsky
-(1980) trace anomaly solution~\cite{starobinsky}, with
-$H_0^2 = 180\pi/G|a_2|$ (Rigorous).
+(1980) trace anomaly solution~\cite{starobinsky}: the anomaly-driven
+de~Sitter fixed point \emph{exists} (Rigorous, by citation). Its
+explicit curvature scale $H_0^2 = 180\pi/G|a_2|$ is a
+convention-dependent reduction (Sketch); the coefficient and
+trace-anomaly normalization are not verbatim in the cited source
+(companion paper~\cite{fixed_point}, Section~3).
 
 \item \emph{Perturbatively}, near any classical solution, via a Banach
 contraction with constant $\kappa \sim (m/M_P)^2 \ll 1$ for massive

--- a/programs/fixed-point-existence/index.tex
+++ b/programs/fixed-point-existence/index.tex
@@ -29,7 +29,9 @@ The semiclassical Einstein equation $G_{\mu\nu}[g] = 8\pi G\langle\hat{T}_{\mu\n
 is a fixed-point condition: the geometry and quantum state must be mutually consistent.
 We address the question of whether such fixed points exist. We present three analyses:
 (1)~exact existence in the cosmological case via the trace anomaly
-(Starobinsky, 1980) (\textbf{Rigorous}, by citation); (2)~a perturbative argument near
+(Starobinsky, 1980) (existence \textbf{Rigorous}, by citation; the explicit fixed-point
+curvature scale $H_0^2 = 180\pi/(G|a_2|)$ is \textbf{Sketch} --- a convention-dependent
+reduction not verbatim in the cited sources, Section~\ref{sec:starobinsky}); (2)~a perturbative argument near
 classical solutions \emph{on globally hyperbolic spacetimes with compact Cauchy surfaces},
 via a Banach contraction whose target estimate is a contraction constant
 $\kappa \sim (m/M_P)^2 \ll 1$ for massive fields, developed via a Hadamard decomposition
@@ -127,6 +129,29 @@ the inflationary application this instability is the graceful-exit mechanism.
 reduces to $\langle\hat{T}^\mu{}_\mu\rangle = -a_2 H_0^4/120\pi^2$. The Friedmann
 equation yields $H_0$. The instability of the de~Sitter stage follows from the linearized
 equation for $\delta H$~\cite{starobinsky}. \hfill$\square$
+
+\smallskip\noindent\textbf{Rigor status (red-team demotion, June 2026).} The
+\emph{existence and instability} of the anomaly-driven de~Sitter fixed point are
+\textbf{Rigorous, by citation} to Starobinsky~\cite{starobinsky}. The \emph{explicit
+coefficient} $H_0^2 = 180\pi/(G|a_2|)$ is \textbf{Sketch}: the algebra is internally
+consistent (combining $\langle\hat{T}^\mu{}_\mu\rangle = -a_2 H_0^4/120\pi^2$ with the
+trace of the semiclassical equation, $-R = 8\pi G\langle\hat{T}^\mu{}_\mu\rangle$ and
+$R = 12H_0^2$ on de~Sitter, gives $H_0^2 = 180\pi/(Ga_2)$), but two steps are not closed
+by the cited sources. (i)~Starobinsky parametrizes the consistency condition through the
+effective action of $N$ conformal fields (a curvature-scale bound set by the field content),
+not as the closed form $180\pi/(G|a_2|)$ with ``$a_2 = $ Euler-density coefficient'';
+the $180\pi$ is a later reparametrization. (ii)~Capper--Duff~\cite{capper_duff} establishes
+the \emph{existence} of the conformal trace anomaly, but the de~Sitter-evaluated,
+field-content-summed normalization $\langle\hat{T}^\mu{}_\mu\rangle = -a_2 H_0^4/120\pi^2$
+requires fixing a field content and an anomaly-coefficient convention, neither of which that
+source supplies. Relative to the standard split $\langle\hat{T}^\mu{}_\mu\rangle =
+c\,C^2 - a\,E$ with $C^2 = 0$ and $E = 24H_0^4$ on de~Sitter, the factor $120\pi^2$ amounts
+to $a_2 = 2880\pi^2\,a$ --- a convention internal to this paper. Finally, the absolute value
+in $|a_2|$ silently encodes a positivity condition: $H_0^2 > 0$ requires $a_2 > 0$ (which
+holds for standard conformal matter, where the type-A coefficient $a > 0$, but is not free).
+Issue~\#133 tracks restoring this to Rigorous (fix the convention, cite a modern
+anomaly-induced-inflation reference for the explicit coefficient, state the $a_2 > 0$
+condition).
 
 \smallskip\noindent\emph{Remark (correction).} An earlier draft of this paper asserted
 that the de~Sitter solution is a stable attractor with exponentially damped perturbations.

--- a/programs/fixed-point-existence/index.tex
+++ b/programs/fixed-point-existence/index.tex
@@ -123,6 +123,10 @@ H_0^2 = \frac{180\pi}{G|a_2|}
 where $a_2$ is the coefficient of the Euler density in the trace anomaly. The de~Sitter
 solution is \emph{unstable}: the quasi-de~Sitter stage is long-lived but decays, and in
 the inflationary application this instability is the graceful-exit mechanism.
+
+\emph{(Existence and instability of the de~Sitter fixed point: \textbf{Rigorous}, by
+citation to Starobinsky~\cite{starobinsky}. Explicit coefficient
+$H_0^2 = 180\pi/(G|a_2|)$: \textbf{Sketch} --- see Rigor status note below.)}
 \end{theorem}
 
 \noindent\emph{Proof sketch.} For constant $H$, the trace anomaly~\cite{capper_duff}


### PR DESCRIPTION
**Red-team demotion.** Closes the gap audited in Red-team log #75 (audit dated 2026-06-25). Opens follow-up #133 for restoring Rigorous.

## What is demoted

The **explicit closed-form coefficient** of the cosmological fixed point,
`H_0^2 = 180π/(G|a_2|)` (`programs/fixed-point-existence/index.tex`, Cosmological-fixed-point theorem; and the companion assertion at `programs/co-emergence/index.tex:1447`), is demoted from **Rigorous (by citation) → Sketch**.

## What is NOT demoted

The **existence and instability** of the anomaly-driven de Sitter fixed point remain **Rigorous, by citation** to Starobinsky (1980). The FPE README already scoped its Rigorous claim to existence only ("only existence is used here"); that claim is untouched and correct. No downstream result uses the explicit coefficient as a lemma (the companion paper uses only *existence* of the exact fixed point).

## The gap (precise)

The coefficient algebra is **internally consistent** — combining `⟨T^μ_μ⟩ = −a_2 H_0^4/120π²` with the trace of the semiclassical equation (`−R = 8πG⟨T^μ_μ⟩`, `R = 12H_0²` on de Sitter) reproduces `H_0² = 180π/(G a_2)`, and an independent re-derivation via the Euler density (`E|_dS = 24H_0^4`, `C²=0`) agrees. So this is a **Sketch, not a withdrawal**. But the **"Rigorous, by citation"** label is not defensible, because two steps are not covered by the cited sources:

1. **Starobinsky (1980), Phys. Lett. B 91, 99** parametrizes the consistency condition through the one-loop effective action of `N` conformal fields — a curvature-scale bound set by the field content — **not** the closed form `180π/(G|a_2|)` with "`a_2` = Euler-density coefficient." The `180π` form is a later reparametrization, not Starobinsky's statement.
2. **Capper–Duff (1974), Nuovo Cimento A 23, 173** establishes the *existence* of the conformal trace anomaly in dim-reg. It does **not** supply the de-Sitter-evaluated, field-content-summed normalization `⟨T^μ_μ⟩ = −a_2 H_0^4/120π²`; reaching it needs a field content + an anomaly-coefficient convention + `E|_dS = 24H_0^4`, none of which is in that paper. Relative to the standard split `⟨T^μ_μ⟩ = c C² − a E`, the `120π²` amounts to `a_2 = 2880π² a` — a convention internal to this paper.

Secondary: the `|a_2|` silently launders a positivity condition — `H_0² > 0` requires `a_2 > 0` (true for standard conformal matter, but not free).

**Both bibliographic entries are real, correctly cited, and on-topic** — so this is a demotion (citation supports *less* than claimed), not a `needs-human` fabrication/misrepresentation escalation.

## Changes

- `programs/fixed-point-existence/index.tex`: added a "Rigor status (red-team demotion)" note after the cosmological theorem precisely separating Rigorous (existence/instability) from Sketch (explicit coefficient), with the two uncovered steps, the `a_2 = 2880π² a` convention, and the positivity condition; refined the §1 overview line to label the explicit curvature scale Sketch.
- `programs/co-emergence/index.tex`: cite-site at line 1447 reworded — existence Rigorous-by-citation, explicit coefficient Sketch.

## Self-checks

- **Dimensional analysis:** `[180π/(G|a_2|)] = 1/G = mass²` in ħ=c=1 (a_2 dimensionless) ✓ — unchanged, no new equation introduced.
- **Limiting / consistency:** independent re-derivation via the Euler density agrees with the trace-equation route (`180π` both ways); order of magnitude `H_0 ~ M_P/√(field count)` is the expected Starobinsky scale ✓. No contradiction introduced; the demoted claim is *narrowed*, so consistency with the rest of both papers strictly improves.
- **Citation content:** the reworded text at the `starobinsky` cite-site claims only what Starobinsky/Capper–Duff support (existence of the anomaly / of the de Sitter fixed point), so the diff-scoped `claim-support` assertion should pass more cleanly than before.
- **Hidden-assumption check:** existence relies on the de-Sitter-invariant conformal (Bunch–Davies) vacuum, so no foliation/observer is smuggled; the claim is existence not stability (de Sitter is explicitly unstable), so no time-evolution/attractor conflation; "conformal matter" (classical `T^μ_μ = 0`) is the load-bearing restriction and is stated.

Labels: `agent-pr`, `demotion`. No open issue uses the explicit coefficient as a lemma, so no dependent-issue comments are required.

routine: red-team · model: claude-opus-4-8