### PR TITLE
quorum-gate: anchor verdict marker matching (gate-workflow amendment)

### DIFF
--- a/.github/workflows/quorum-gate.yml
+++ b/.github/workflows/quorum-gate.yml
@@ -79,16 +79,25 @@ jobs:
               exit 0 ;;
           esac
 
-          # Markers count only from the machine account or the experimenter.
+          # Markers count only from the machine account or the experimenter,
+          # must be the sole content of a line, and fenced code blocks are
+          # stripped first -- so quoting the marker format in prose or in a
+          # ```example``` (e.g. a responder comment explaining what the
+          # reviewer should post) can't be mistaken for a live verdict. All
+          # routines share the machine-account identity, so this isn't a
+          # spoofing defense against outsiders (logins are already gated
+          # above) -- it closes the narrower gap where a routine's own
+          # comment accidentally contains the marker string.
           COMMENTS=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
             | jq -r --arg bot "${BOT:-__unset__}" --arg exp "$EXPERIMENTER" \
-              '.[] | select(.user.login == $bot or .user.login == $exp) | .body')
+              '.[] | select(.user.login == $bot or .user.login == $exp) | .body
+               | gsub("```[\\s\\S]*?```"; "")')
 
           VERDICT=$(echo "$COMMENTS" \
-            | grep -oE "<!-- quorum:verdict (accept|revise|reject) sha=$SHA -->" \
+            | grep -oE "^[[:space:]]*<!-- quorum:verdict (accept|revise|reject) sha=$SHA -->[[:space:]]*$" \
             | tail -1 | grep -oE 'accept|revise|reject' || true)
           STRESS=$(echo "$COMMENTS" \
-            | grep -oE "<!-- quorum:stress-test (pass|fail) sha=$SHA -->" \
+            | grep -oE "^[[:space:]]*<!-- quorum:stress-test (pass|fail) sha=$SHA -->[[:space:]]*$" \
             | tail -1 | grep -oE 'pass|fail' || true)
 
           if [ -z "$VERDICT" ]; then


### PR DESCRIPTION
## Summary

Fixes a loose-parsing gap in `quorum-gate.yml` found during a workflow audit (F2): the verdict-marker regex matched anywhere in any machine-account/experimenter comment body, unanchored, with no exclusion for quoted or fenced text.

Because worker, reviewer, responder, and governor all authenticate as the same machine account (`AUTONOMY_BOT` = `will-physagent`), any routine's comment that merely *quotes* the marker format at the live head SHA -- e.g. a responder writing "the reviewer should post `` `<!-- quorum:verdict accept sha=... -->` ``" -- would flip quorum-gate to accept with no actual review having occurred. This isn't outside spoofing (login filtering already prevents that); it's a self-inflicted gap given the shared identity, and compounds the residual author≠reviewer trust dependency AUTONOMY.md already documents as enforced by discipline rather than construction.

## Change

- Strip ` ```fenced``` ` code blocks from each comment body before matching (via `jq gsub`).
- Anchor the marker regex to require it be the sole content of a line (`^...$`, whitespace-tolerant) rather than a substring anywhere in the body.

## Verification

- Confirmed the jq `gsub("```[\s\S]*?```"; "")` pattern correctly strips multi-line fenced blocks (tested standalone).
- Confirmed the anchored regex still matches the real accept marker on live data: pulled PR #141's actual comment thread, ran both the old unanchored pattern and the new anchored pattern against it -- **identical match**, so this change does not affect any legitimate verdict already posted.
- Constructed the exact exploit text ("the reviewer should post `` `<!-- quorum:verdict accept sha=X -->` `` as an example") and confirmed the new anchored pattern does *not* match it, while the old pattern would have.

## Self-checks

- **Scope**: touches only `.github/workflows/quorum-gate.yml`; no other gate behavior changed.
- **Consistency**: preserves every existing sound property from the audit (per-SHA invalidation, login-gated authorship, research-content guard, promotion-rigorous double-marker requirement) -- verified by re-reading the full post-edit file.
- **Backward compatibility**: does not require rewriting any historical verdict comment; only matching logic for future evaluation changes.

## Process note

Per `AUTONOMY.md`'s amendment procedure, gate-workflow changes have no agent path (the machine account's PAT lacks `workflow` scope) and are experimenter-authored, merged via `gh pr merge --admin`, with the merge recorded in `EXPERIMENT.md`'s log. This PR was drafted by Claude in an interactive session under Will's direction, for his review and admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)