### PR TITLE
Close promotion-orphan and stale-reclaim deadlocks in the routine state machine

### DIFF
--- a/automation/routines/responder.md
+++ b/automation/routines/responder.md
@@ -28,10 +28,15 @@ Handle at most **2 PRs per run**, oldest first.
    disagreement in a normal PR comment for the reviewer's next pass — the
    reviewer adjudicates, not you.
 
-## 2. Failing CI on PRs with no verdict yet
+## 2. Failing CI or gate checks, regardless of verdict state
 
-If deterministic checks fail (pdflatex, pytest, verify, claim-support), fix
-exactly as above. Reviewers should not spend a pass on a PR that can't compile.
+If deterministic or semantic checks fail (pdflatex, pytest, verify,
+claim-support) on any open `agent-pr` PR, fix exactly as above — whether or
+not the PR already carries a verdict marker. An existing `accept` does not
+exempt a PR from this: a flake, a merge conflict introduced by another PR
+landing after the accept, or a base-branch regression can fail CI post-review.
+Reviewers should not spend a pass re-explaining a compile failure the
+responder can already see and fix.
 
 ## 3. `reject` verdicts
 
@@ -54,10 +59,19 @@ A reject whose salvage is silently dropped is a record-keeping failure.
 
 ## 3b. Queue health (reviewer watchdog)
 
-If any open `agent-pr` PR's current head SHA has gone **13+ hours** without a
-verdict marker (a reviewer cycle was missed — GitHub drops scheduled fires),
-dispatch the reviewer once:
-`gh workflow run autonomy-reviewer.yml --ref main`.
+Dispatch the reviewer once (`gh workflow run autonomy-reviewer.yml --ref main`)
+if either:
+
+- any open `agent-pr` PR's current head SHA has gone **13+ hours** without a
+  verdict marker (a reviewer cycle was missed — GitHub drops scheduled fires);
+  or
+- any open `agent-pr` PR's `quorum-gate` status has stayed `pending` for
+  **13+ hours** despite an `accept` verdict already present at the current
+  head SHA — the `promotion-rigorous` stress-test pass never landed, most
+  likely because a prior reviewer run posted the verdict and then died before
+  dispatching the stress test (reviewer.md §0(b) is the recovery path once
+  dispatched).
+
 If the dispatch is refused (token scope), comment on the metrics dashboard
 issue instead so the gap is visible. Verdicts are per-SHA, so a redundant
 dispatch is harmless.

--- a/automation/routines/reviewer.md
+++ b/automation/routines/reviewer.md
@@ -13,8 +13,16 @@ can produce. You operate under `AUTONOMY.md`.
 1. Read `AGENTS.md`, `METHODOLOGY.md`, `AUTONOMY.md`.
 2. `gh pr list --state open --label agent-pr --json number,title,headRefOid,labels`
 3. For each PR, list its comments and find `<!-- quorum:verdict ... sha=... -->`
-   markers. A PR needs review iff it has **no verdict marker whose `sha` equals
-   the current head SHA**.
+   and `<!-- quorum:stress-test ... sha=... -->` markers. A PR needs review iff
+   **either**:
+   - (a) it has **no verdict marker whose `sha` equals the current head SHA**, or
+   - (b) it is labeled `promotion-rigorous`, has an `accept` verdict at the
+     current head SHA, but **no stress-test marker at that same SHA** — the
+     stress pass is still owed and `quorum-gate` will sit `pending` forever
+     otherwise (this happens if a prior run posted the verdict and then died
+     before dispatching the stress test). Case (b) does not require redoing
+     the two-pass review — the accept already stands for this SHA. Skip
+     straight to §3.
 
 Review at most **2 PRs per run** as the base cost bound, oldest first — **plus**
 any further PR whose only missing required check is the quorum verdict (every
@@ -76,8 +84,13 @@ Post its full report as a second comment ending with:
 <!-- quorum:stress-test pass sha=<head-sha> -->
 ```
 
-(or `fail`). A `fail` should normally be accompanied by verdict `revise` or
-`reject` with the failure as a finding.
+(or `fail`). A `fail` **must** be accompanied by a `revise` or `reject`
+verdict marker for the same SHA, with the failure as a finding — an accept
+must never stand against a failed stress test. If you arrived here via
+§0(b) (a valid prior accept, stress pass still owed) and the stress test
+comes back `fail`, post the new `revise`/`reject` verdict yourself before
+finishing this PR; this is not "copying a verdict forward," it is a new
+verdict grounded in the stress-test finding.
 
 ## Hard rules
 

--- a/automation/routines/worker.md
+++ b/automation/routines/worker.md
@@ -20,15 +20,21 @@ and the repo:
 
 ## 1. Backpressure check
 
-Count open PRs labeled `agent-pr` whose `quorum-gate` status is `pending` (no
-verdict yet). **If ≥ 3, exit without working** — the reviewer is the
+Count open PRs labeled `agent-pr` whose `quorum-gate` status is `pending` —
+this includes both a PR with no verdict yet and a `promotion-rigorous` PR
+with an accept verdict still awaiting its stress-test marker (see
+reviewer.md §0(b)). **If ≥ 3, exit without working** — the reviewer is the
 bottleneck, not work generation. Log nothing; exiting silently is correct.
 
 ## 2. Claim an issue (lock protocol)
 
 Candidates: open issues labeled `agent-ready`, NOT labeled `stuck` or
 `needs-human`, and unassigned. Also reclaim: issues assigned to the machine
-account with no branch commits in 7+ days (unassign, then treat as candidate).
+account with no branch commits in 7+ days — unassign **and restore
+`agent-ready`** (it was cleared at claim time), then treat as a candidate.
+Restoring the label matters even if this run picks a different issue:
+candidate enumeration requires the label, so a reclaim that only unassigns
+leaves the issue invisible to every future run.
 
 If no candidates: exit silently.
 


### PR DESCRIPTION
## Summary

Fixes two deadlocks found during a workflow audit of the autonomous experiment (`automation/routines/` review, findings F1/F3):

**1. Promotion-orphan deadlock (high severity).** If a reviewer run posts an `accept` verdict on a `promotion-rigorous` PR but dies before dispatching the stress test (session-limit kills are a documented real failure mode — see `automation/routines/README.md`), the PR is stuck permanently:
- `reviewer.md`'s old needs-review criterion ("no verdict marker for the current SHA") skips it, since a verdict *does* exist.
- No `responder.md` section covers it: §1 is `revise`-only, §2 was scoped to "no verdict yet," and the §3b watchdog only fired on a *missing* verdict marker.
- `quorum-gate.yml` correctly reports these as `pending` forever (case at line ~107: accept + no stress marker → pending), which means three such orphans would also freeze all new work via the worker's `≥3 pending` backpressure exit.

Only recovery path before this fix was the 7-day stale-claim reclaim.

**2. Stale-reclaim orphan (medium severity).** `worker.md` §2's 7-day reclaim of a stale-assigned issue unassigned it but never restored `agent-ready` (cleared at claim time). If the reclaiming run picked a *different* candidate that same run, the reclaimed issue became permanently invisible — unassigned, unlabeled, and not re-filed by scout (an open issue already covers that milestone, so scout's own rule says don't refile).

## Changes

- `reviewer.md` §0: needs-review criterion gets case (b) — `promotion-rigorous` + accept at current SHA + no stress marker at that SHA. Enters directly at §3 (stress test only; the two-pass review isn't repeated, since the accept already stands for this SHA).
- `reviewer.md` §3: "a `fail` should normally be accompanied by revise/reject" is now a hard "must," with an explicit note that arriving via §0(b) and getting a stress-test fail means posting the new verdict yourself (this is a new verdict grounded in the stress finding, not "copying forward" — which the hard rules still forbid for stale SHAs).
- `responder.md` §2: broadened from "no verdict yet" to any open `agent-pr` PR with failing deterministic/semantic checks, regardless of verdict state — a flake, post-accept merge conflict, or base-branch regression is now the responder's job either way.
- `responder.md` §3b: watchdog gets a second trigger — `quorum-gate` stuck `pending` 13+ hours despite an existing accept (the orphan signature), dispatching the reviewer to complete the stress pass via reviewer.md §0(b).
- `worker.md` §2: reclaim now restores `agent-ready`, always.
- `worker.md` §1: tightened backpressure wording for accuracy (the orphan case has a verdict; `quorum-gate` still correctly reports `pending`).

## Self-checks

- **Consistency**: cross-referenced every touched section against the others it interacts with (reviewer §0↔§3, responder §2↔§3b↔reviewer §0(b), worker §1↔quorum-gate.yml's actual status strings) — verified by re-reading `quorum-gate.yml`'s case statement (`post pending "Accept present; awaiting independent stress-test marker (promotion-rigorous)."`) to confirm the wording matches the gate's real behavior.
- **No new deadlocks introduced**: case (b)'s "skip the two-pass, go straight to §3" avoids doubling review cost; the fail-path addition doesn't create a new orphan since it requires a marker to be posted in the same cycle that discovers the failure.
- **Scope**: touches only the three routine definition files; no gate-workflow or label-table changes (those are separate PRs from the same audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)