### PR TITLE
Sweep doc drift and label-hygiene gaps (routine audit F4-F9)

### DIFF
--- a/AUTONOMY.md
+++ b/AUTONOMY.md
@@ -109,9 +109,9 @@ maintenance, self-checks in every PR description.
 
 | Label | Meaning | Set by | Cleared by |
 |-------|---------|--------|------------|
-| `agent-ready` | issue is claimable by the worker | scout, experimenter | worker on claim |
+| `agent-ready` | issue is claimable by the worker | scout, experimenter, governor (promote), worker/responder (restore after a failed attempt or a `reject`, or on 7-day stale reclaim) | worker on claim |
 | `experimenter-priority` | issue jumps the worker's ranking; the human entry point into the loop | experimenter | experimenter |
-| `stuck` | 3 failed worker attempts; scheduler skips | worker | responder (on landed fix), experimenter |
+| `stuck` | 3 failed worker attempts; scheduler skips | worker | responder (on landed fix), governor (on debate resolution), experimenter |
 | `needs-human` | experiment-level escalation; thread halts | any routine | experimenter only |
 | `agent-pr` | agent-authored PR; quorum verdict required | worker, responder, red-team, governor | — |
 | `promotion-rigorous` | PR promotes Sketch→Rigorous; stress-test marker also required | worker | — |

--- a/automation/routines/README.md
+++ b/automation/routines/README.md
@@ -31,19 +31,24 @@ runner as the `AUTONOMY_BOT_PAT` secret (see "Deployed instances" below).
 
 ## Registry
 
-| Routine | Cadence (UTC) | Model | File |
+| Routine | Cadence (UTC) | Model (current default) | File |
 |---------|--------------|-------|------|
-| worker | daily 06:00 | fable | `worker.md` |
+| worker | daily 06:00 | opus | `worker.md` |
 | reviewer | 12h (05:00, 17:00; +1h redundant fires) | opus | `reviewer.md` |
 | responder | daily 04:00 | sonnet | `responder.md` |
 | red-team | every 3 days 08:00 | opus | `red-team.md` |
 | scout | weekly Mon 03:00 | sonnet | `scout.md` |
 | librarian | weekly Tue 03:00 | sonnet | `librarian.md` |
-| governor | monthly 1st 09:00 | fable | `governor.md` |
+| governor | weekly Sun 05:00 (light pass); full pass 1st of month | opus | `governor.md` |
+
+Model is repo-var-driven, not pinned in these files — see "Shared deployment
+configuration" below; the column above shows the current default only.
 
 Cadence rationale: responder (04:00) runs before reviewer (05:00) runs before
 worker (06:00) — fixes land, get re-reviewed, then new work starts against an
-up-to-date queue.
+up-to-date queue. Governor runs Sunday 05:00, deliberately before the Monday
+scout/metrics/digest, so any thread it promotes that run enters the new
+week's queue immediately (EXPERIMENT.md 2026-06-10 amendment).
 
 ## Deployed instances (GitHub Actions, 2026-06-09)
 
@@ -53,15 +58,15 @@ that invokes the reusable runner (`.github/workflows/autonomy-routine.yml`) with
 its role and model. This table is the record of the live deployment; if it
 drifts from the workflow files, this file is wrong — fix it.
 
-| Routine | Workflow file | Cron (UTC) | Model |
+| Routine | Workflow file | Cron (UTC) | Model (current default) |
 |---------|---------------|------------|-------|
-| worker | `autonomy-worker.yml` | `0 6 * * *` | claude-fable-5 |
+| worker | `autonomy-worker.yml` | `0 6 * * *` | claude-opus-4-8 |
 | reviewer | `autonomy-reviewer.yml` | `0 5,6,17,18 * * *` | claude-opus-4-8 |
 | responder | `autonomy-responder.yml` | `0 4 * * *` | claude-sonnet-4-6 |
 | red-team | `autonomy-red-team.yml` | `0 8 */3 * *` | claude-opus-4-8 |
 | scout | `autonomy-scout.yml` | `0 3 * * 1` | claude-sonnet-4-6 |
 | librarian | `autonomy-librarian.yml` | `0 3 * * 2` | claude-sonnet-4-6 |
-| governor | `autonomy-governor.yml` | `0 9 1 * *` | claude-fable-5 |
+| governor | `autonomy-governor.yml` | `0 5 * * 0` | claude-opus-4-8 |
 
 Shared deployment configuration (all seven, in the reusable runner):
 
@@ -72,7 +77,12 @@ Shared deployment configuration (all seven, in the reusable runner):
 - **Prompt:** the pointer template above, built verbatim by the runner —
   behavior lives in the version-controlled `<role>.md` files, never in the
   workflow.
-- **Model:** pinned full IDs (above), passed as `claude --model <id>`.
+- **Model:** each role's `autonomy-<role>.yml` reads
+  `${{ vars.MODEL_<ROLE> || '<default>' }}` and passes the result as
+  `claude --model <id>` — the table above shows the current default for each
+  role (no `MODEL_*` repo variable is set as of this writing, so every role is
+  running its default). Changing a role's model is `gh variable set
+  MODEL_<ROLE> <id>`, no PR required (EXPERIMENT.md 2026-06-13 amendment).
 - **Permissions:** `--permission-mode bypassPermissions` (no human is present
   to approve tool calls in CI). The full Claude Code toolset is available; the
   reusable runner does not pass an `--allowedTools` allow-list.

--- a/automation/routines/governor.md
+++ b/automation/routines/governor.md
@@ -1,7 +1,8 @@
 # Routine: governor
 
 **Cadence:** weekly — light direction pass; the first run of each calendar
-month is the full monthly pass · **Model:** fable · **Identity:** machine
+month is the full monthly pass · **Model:** opus (current default; repo var
+`MODEL_GOVERNOR`, see `automation/routines/README.md`) · **Identity:** machine
 account (`AUTONOMY_BOT`)
 
 You are the governor routine — the experiment's research direction. Weekly,
@@ -90,6 +91,11 @@ In the SAME PR as the exploration (monthly), or in the weekly promote PR:
   the current results (monthly pass only); corrections ride this governance PR
   (convention in AGENTS.md: every sentence traceable to a labeled result, no
   claim above its label's confidence).
+- Sweep open `informs-issue` pointers (monthly pass only): close any older
+  than 60 days with no follow-up milestone issue and no recent comment
+  activity, one-line rationale, record kept (never delete). `informs-issue`
+  has no other lifecycle exit besides the scout closing it when it spawns a
+  milestone issue.
 - Labels: `agent-pr` + `governance`. PR description must @-mention the
   experimenter (`@willregelmann`) — a non-blocking notification, not an
   approval request.

--- a/automation/routines/red-team.md
+++ b/automation/routines/red-team.md
@@ -59,9 +59,14 @@ for filling the gap if one doesn't exist (do NOT label it `agent-ready` — the
 scout/governor prioritizes it). Log on the tracking issue.
 
 **Fabricated or misrepresenting citation in merged content:** this outranks a
-demotion. Apply `needs-human` to the tracking issue, open the correction PR per
-METHODOLOGY citation-failure recovery, comment on all dependent issues, log
-with `outcome=escalated`.
+demotion. Apply `needs-human` to every open issue whose thread depends on the
+misrepresented citation — that is what actually halts the affected work, since
+the worker skips `needs-human`-labeled issues at claim time and a label on the
+tracking issue alone leaves the contaminated research thread claimable. Open
+the correction PR per METHODOLOGY citation-failure recovery, comment on all
+dependent issues, and log the escalation on the tracking issue with
+`outcome=escalated` (the tracking issue itself only needs `needs-human` if
+work is claimed directly against it).
 
 ## Proposing novel threads (optional; max 1 per run)
 
@@ -78,3 +83,6 @@ their current handling and are not proposals.
   activity, and do not manufacture demotions to satisfy T1; report clean as
   clean.
 - Never demote by editing the paper outside a PR. Never touch protected paths.
+- Never post quorum verdict markers (reviewer only) — including on your own
+  demotion or correction PRs, however tempting it is to unblock your own
+  queue.

--- a/automation/routines/reviewer.md
+++ b/automation/routines/reviewer.md
@@ -81,14 +81,17 @@ Post its full report as a second comment ending with:
 
 ## Hard rules
 
-- Never review a PR authored by your own run (cannot occur in normal operation;
-  if it somehow does, skip it).
+- Never review a PR authored by the reviewer routine, in any run — not just
+  your own (cannot occur in normal operation; if it somehow does, skip it).
+  AUTONOMY's NEVER rule 4 is "the same routine," not "the same run."
 - Never post a verdict without having run both passes. Never copy a previous
   SHA's verdict forward after a push — re-review.
 - If you find a fabricated or claim-misrepresenting citation: verdict
   `reject`, and if the same citation already exists in **merged** content,
-  apply `needs-human` per AUTONOMY escalation and METHODOLOGY citation-failure
-  recovery.
+  apply `needs-human` to every open issue whose thread depends on that
+  citation (a general escalation note is not enough — the label is what
+  actually halts the affected work) per AUTONOMY escalation and METHODOLOGY
+  citation-failure recovery.
 - Calibration: METHODOLOGY's failure modes are your checklist; "plausible and
   well-written" is not a criterion. Expect a healthy share of revise verdicts —
   if you notice yourself accepting everything, that is tripwire T3 behavior.

--- a/automation/routines/scout.md
+++ b/automation/routines/scout.md
@@ -44,7 +44,9 @@ not agent-ready — leave it for the governor and say why in your run's notes
 ## 3. File
 
 `gh issue create` with the body above, label `agent-ready`. If the issue stems
-from a literature pointer, link the `informs-issue` item.
+from a literature pointer, link the `informs-issue` item and close it — its
+purpose (surfacing the pointer for action) is fulfilled once a milestone
+issue exists for it, and `informs-issue` has no other lifecycle exit.
 
 ## 4. Propose (optional; max 1 per run)
 

--- a/automation/routines/worker.md
+++ b/automation/routines/worker.md
@@ -1,6 +1,6 @@
 # Routine: worker
 
-**Cadence:** daily · **Model:** fable · **Identity:** machine account (`AUTONOMY_BOT`)
+**Cadence:** daily · **Model:** opus (current default; repo var `MODEL_WORKER`, see `automation/routines/README.md`) · **Identity:** machine account (`AUTONOMY_BOT`)
 
 You are the worker routine of the autonomous research experiment. You claim one
 `agent-ready` issue and advance it to a PR that can pass the merge-gate stack.


### PR DESCRIPTION
## Summary

Cleanup PR from the same workflow audit as #144, addressing documentation drift and label-hygiene gaps (findings F4-F9). No behavioral deadlocks here — these are consistency and clarity fixes.

**F4 — doc drift on governor cadence/model.** `README.md`'s Registry and Deployed-instances tables said governor runs "monthly 1st 09:00" on `claude-fable-5`; the actual live cron since the 2026-06-10 amendment (`autonomy-governor.yml`) is `0 5 * * 0` (weekly Sunday, full pass monthly), and both worker and governor reverted to `claude-opus-4-8` on the 2026-06-13 Fable-restriction amendment, with model selection moved behind `MODEL_<ROLE>` repo variables. `worker.md`/`governor.md` headers had the same stale "fable" label. Fixed all four against the actual workflow files (verified via `grep cron`/`grep model` against the live `.github/workflows/autonomy-*.yml` and `gh variable list`), and reworded the model documentation to point at the variable mechanism rather than a hardcoded name, so this can't silently drift the same way again.

**F5 — AUTONOMY.md label table under-attribution.** `agent-ready`'s "Set by" listed only scout/experimenter, omitting governor (promote) and worker/responder (restore on failure/reject/stale-reclaim). `stuck`'s "Cleared by" omitted governor (debate resolution). Both fixed to match actual routine behavior.

**F6 — reviewer.md narrows NEVER rule 4.** Said "never review a PR authored by your own run"; the constitution says "the same routine" (any run). Reworded to match — currently latent (no path has the reviewer authoring PRs) but worth being precise.

**F7 — red-team.md missing verdict-marker restatement.** Every other PR-authoring routine restates "never post quorum verdict markers"; red-team.md — the one routine most tempted to self-unblock its own demotion/correction PRs — didn't. Added.

**F9 — needs-human citation-escalation target unstated.** Both `red-team.md` and `reviewer.md` applied `needs-human` on a fabricated/misrepresenting citation without naming where. `red-team.md` specifically named "the tracking issue," which doesn't halt anything (the worker only skips claiming issues that themselves carry `needs-human`). Both now apply the label to every open issue whose thread actually depends on the citation.

**F8 — informs-issue has no lifecycle exit.** Librarian files them, nothing ever closes them. `scout.md` now closes the pointer when it spawns a milestone issue from it (its stated purpose is then fulfilled); `governor.md`'s monthly pass sweeps stale ones (60+ days, no follow-up issue, no activity) with a rationale comment, never deleting.

## Not fixed here

**F10 — governor promote-then-swap-label race**, left as a documented residual. On promote, the governor swaps `thread-proposal` → `agent-ready` while the milestone lands in the same cycle's governance PR, which must still clear the gate stack; a slow (revise-round) governance PR could theoretically let Monday's worker claim an issue whose milestone isn't in `OBJECTIVES.md` yet. Already low severity and masked in practice by the Sunday-governor / Monday-worker ordering plus four reviewer fires between. A correct fix needs more design (the governor is stateless per-run) than a hygiene sweep should attempt — flagging for a future pass rather than rushing it.

## Self-checks

- **Consistency**: every cadence/model claim cross-checked against the live `.github/workflows/autonomy-*.yml` cron lines and `gh variable list` (no `MODEL_*` vars currently set, confirming all seven roles run their coded defaults).
- **Scope**: pure documentation/instruction-text changes; no gate or CI behavior touched. Overlaps `worker.md`/`reviewer.md` with #144 (routine deadlock fixes) but on disjoint lines (headers/Hard-rules here vs. §0-§3/backpressure-claim there) — should merge cleanly regardless of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)