### PR TITLE
GGD-4: resolve Remark 2 ensemble-dephasing caveat (per-realization coherence; §5 observable re-scoped)

### DIFF
--- a/programs/gaussian-gravitational-decoherence/README.md
+++ b/programs/gaussian-gravitational-decoherence/README.md
@@ -16,8 +16,15 @@ to within about 13%, but the *shape* of the decay differs — something an
 experiment could check, distinguishing this account from its rivals. The shape
 prediction is a sketch, not a finished proof: it relies on modeling gravity's
 noise as "Gaussian noise", which is an assumption of the framework used, not
-something derived — and on reading an ensemble-averaged fading of coherence
-as genuine decoherence, which is an open interpretational question. A further
+something derived. A second worry — whether an ensemble-averaged fading of
+coherence counts as genuine decoherence — is now settled at the level that
+matters for experiment: within any single run the superposition's coherence is
+exactly preserved and only its phase shifts, and the predicted fading is exactly
+what an ordinary many-shot interferometer measures, so the prediction is
+well-defined. Whether to *call* that ensemble fading "decoherence" is a question
+of words, not of what the experiment sees; and because the fading is in
+principle reversible, a spin-echo control run could even tell it apart from a
+truly irreversible collapse. A further
 idea — that rigid crystals would decay Gaussian while soft materials would
 drift back toward exponential — is a conjecture: the mechanism has not been
 worked out, and it is not yet known whether any realistic laboratory object
@@ -27,7 +34,7 @@ experiment.
 ## Results
 
 1. **(Sketch)** The decoherence timescale is tau_coh = (4sqrt(2)/5) hbar/E_Delta ~ 1.13 tau_DP, determined by the same gravitational self-energy as the Diosi-Penrose prediction.
-2. **(Sketch)** The temporal profile is Gaussian, not exponential -- a consequence of the noise kernel for stationary matter being time-independent in the Newtonian limit. Both results rest on the Einstein-Langevin framework's Gaussian-noise assumption (made explicit as Assumption 1 in the paper, not derived) and on an unresolved ensemble-dephasing caveat (Remark 2 in the paper).
+2. **(Sketch)** The temporal profile is Gaussian, not exponential -- a consequence of the noise kernel for stationary matter being time-independent in the Newtonian limit. Both results rest on the Einstein-Langevin framework's Gaussian-noise assumption (made explicit as Assumption 1 in the paper, not derived); this is now the *only* source of the Sketch ceiling, since the ensemble-dephasing caveat (Remark 2) is resolved at the operational level (paper §4.3): the per-realization coherence magnitude is exactly conserved and the Gaussian suppression is an echo-reversible inhomogeneous-dephasing effect recovered only on averaging, so the predicted quantity is the free-evolution ensemble visibility a many-shot interferometer measures.
 3. **(Conjecture)** The profile is material-dependent: rigid crystalline bodies give Gaussian decoherence, while bodies whose acoustic modes approach the gravitational coherence frequency would transition toward exponential. The crossover mechanism is asserted, not derived, and whether any experimentally realistic platform reaches the crossover regime is open.
 
 ## Relationship to other programs

--- a/programs/gaussian-gravitational-decoherence/README.md
+++ b/programs/gaussian-gravitational-decoherence/README.md
@@ -20,9 +20,12 @@ something derived. A second worry — whether an ensemble-averaged fading of
 coherence counts as genuine decoherence — is now settled at the level that
 matters for experiment: within any single run the superposition's coherence is
 exactly preserved and only its phase shifts, and the predicted fading is exactly
-what an ordinary many-shot interferometer measures, so the prediction is
-well-defined. Whether to *call* that ensemble fading "decoherence" is a question
-of words, not of what the experiment sees; and because the fading is in
+what an ordinary many-shot interferometer measures (each new run creates the
+superposition anew, redrawing the noise from the superposition's own mass
+distribution rather than from a fixed external field, so each shot is an
+independent sample), so the prediction is well-defined. Whether to *call* that
+ensemble fading "decoherence" is a question of words, not of what the experiment
+sees; and because the fading is in
 principle reversible, a spin-echo control run could even tell it apart from a
 truly irreversible collapse. A further
 idea — that rigid crystals would decay Gaussian while soft materials would
@@ -34,7 +37,7 @@ experiment.
 ## Results
 
 1. **(Sketch)** The decoherence timescale is tau_coh = (4sqrt(2)/5) hbar/E_Delta ~ 1.13 tau_DP, determined by the same gravitational self-energy as the Diosi-Penrose prediction.
-2. **(Sketch)** The temporal profile is Gaussian, not exponential -- a consequence of the noise kernel for stationary matter being time-independent in the Newtonian limit. Both results rest on the Einstein-Langevin framework's Gaussian-noise assumption (made explicit as Assumption 1 in the paper, not derived); this is now the *only* source of the Sketch ceiling, since the ensemble-dephasing caveat (Remark 2) is resolved at the operational level (paper §4.3): the per-realization coherence magnitude is exactly conserved and the Gaussian suppression is an echo-reversible inhomogeneous-dephasing effect recovered only on averaging, so the predicted quantity is the free-evolution ensemble visibility a many-shot interferometer measures.
+2. **(Sketch)** The temporal profile is Gaussian, not exponential -- a consequence of the noise kernel for stationary matter being time-independent in the Newtonian limit. Both results rest on the Einstein-Langevin framework's Gaussian-noise assumption (made explicit as Assumption 1 in the paper, not derived); this is now the *only* source of the Sketch ceiling, since the ensemble-dephasing caveat (Remark 2) is resolved at the operational level (paper §4.3): the per-realization coherence magnitude is exactly conserved and the Gaussian suppression is an echo-reversible inhomogeneous-dephasing effect recovered only on averaging, so the predicted quantity is the free-evolution ensemble visibility a many-shot interferometer measures (the identification holds because the framework locates the noise source in the superposition's own mass distribution, so each fresh preparation redraws the noise; a frozen external field is a distinct model the framework does not adopt).
 3. **(Conjecture)** The profile is material-dependent: rigid crystalline bodies give Gaussian decoherence, while bodies whose acoustic modes approach the gravitational coherence frequency would transition toward exponential. The crossover mechanism is asserted, not derived, and whether any experimentally realistic platform reaches the crossover regime is open.
 
 ## Relationship to other programs

--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -305,19 +305,95 @@ yields exponential decoherence at rate $\Gamma = C_V(0)\tau_c/\hbar^2$. In the
 static limit ($\tau_c\to\infty$ for stationary matter), the exponential rate vanishes and
 the profile is Gaussian with timescale $\tau_{\text{coh}} = \hbar\sqrt{2}/\sqrt{C_V(0)}$.
 
-\begin{remark}[Ensemble dephasing versus single-system decoherence]
+\begin{remark}[Ensemble dephasing versus single-system decoherence: operationally resolved]
 \label{rem:dephasing}
 Equation~\eqref{eq:gaussian_suppression} is an average over realizations of a
 \emph{static} Gaussian random variable. In any single realization the branch-differential
 potential $\delta V_\Delta$ is a constant, and the accumulated phase is deterministic and
 in principle recoverable (e.g.\ by echo protocols); the Gaussian decay describes
-dephasing of an ensemble. Di\'osi's white noise, by contrast, produces irreversible
-decoherence realization by realization. Whether the ensemble-averaged Gaussian suppression
-constitutes genuine single-system decoherence---and what, physically, the ensemble of
-realizations of the superposition's own stress-energy variance refers to---is an open
-interpretational question of the Einstein-Langevin framework that we flag here and do not
-resolve.
+\emph{inhomogeneous} dephasing of an ensemble, whereas Di\'osi's white noise produces
+irreversible decoherence realization by realization. Section~\ref{sec:per_realization}
+resolves the operational content of this distinction: the coherence magnitude is exactly
+conserved per realization (eq.~\eqref{eq:single_realization}), and the Gaussian $t^2$
+suppression is recovered only on averaging (eq.~\eqref{eq:ensemble_recovers}). The
+predicted observable is therefore well-defined---it is the free-evolution fringe
+visibility a standard many-shot interferometer measures (\S\ref{sec:predictions})---and its
+refocusability under a branch-swap echo is an additional discriminant from
+Di\'osi--Penrose. What remains genuinely open is only the metaphysical question of whether
+ensemble-averaged dephasing ``is'' single-system decoherence; the predicted observable does
+not depend on that choice, so no postulate beyond the framework's axioms is required.
 \end{remark}
+
+\subsection{Per-realization coherence and the ensemble observable}
+\label{sec:per_realization}
+
+We separate the single-realization content of eq.~\eqref{eq:gaussian_suppression} from its
+ensemble content explicitly, resolving the interpretational question flagged in
+Remark~\ref{rem:dephasing} at the operational level.
+
+\textbf{Single realization.} Fix one realization of the noise field $\xi_{00}$. For a
+stationary superposition the kernel is static (eq.~\eqref{eq:N0000_static}), so the realized
+branch-differential force is a single time-independent constant,
+\begin{equation}
+\delta V_\Delta(t) = v, \qquad
+v \equiv m\!\left[\delta\Phi(\mathbf{x}_L) - \delta\Phi(\mathbf{x}_R)\right],
+\label{eq:single_v}
+\end{equation}
+drawn once per realization from a zero-mean Gaussian with variance
+$\langle v^2\rangle_s = C_V(0)$ (eq.~\eqref{eq:CV0} below). The off-diagonal element then
+evolves by a pure phase,
+\begin{equation}
+\rho_{LR}(t) = \rho_{LR}(0)\,e^{-i v t/\hbar}, \qquad
+\bigl|\rho_{LR}(t)\bigr| = \bigl|\rho_{LR}(0)\bigr|,
+\label{eq:single_realization}
+\end{equation}
+so \emph{within a single realization the coherence magnitude is exactly conserved}: no decay
+occurs, and the deterministic phase $vt/\hbar$ is in principle recoverable. This step is
+\textbf{(Rigorous)} within the Einstein--Langevin model given the static
+kernel~\eqref{eq:N0000_static}; the Assumption~\ref{ass:gaussian} ceiling on its status as a
+claim about nature is unchanged.
+
+\textbf{Ensemble.} Averaging eq.~\eqref{eq:single_realization} over the Gaussian
+distribution of $v$ reproduces eq.~\eqref{eq:gaussian_suppression} exactly:
+\begin{equation}
+\overline{\rho_{LR}(t)}
+= \rho_{LR}(0)\,\bigl\langle e^{-i v t/\hbar}\bigr\rangle_s
+= \rho_{LR}(0)\,e^{-\langle v^2\rangle_s\, t^2/2\hbar^2}
+= \rho_{LR}(0)\,e^{-C_V(0)\,t^2/2\hbar^2}.
+\label{eq:ensemble_recovers}
+\end{equation}
+The Gaussian $t^2$ suppression \emph{arises only after averaging}; it does not survive per
+realization. This is the structural signature of \emph{inhomogeneous} dephasing---a static
+spread of phase-accumulation rates across the ensemble, the analogue of $T_2^\ast$---not the
+irreversible, realization-by-realization decoherence ($T_2$) produced by Di\'osi's white
+noise. In particular a mid-point branch-swap (Hahn) echo, which flips the sign of
+$\delta V_\Delta$ for the second half of the evolution, refocuses
+eq.~\eqref{eq:single_realization} completely (the phase
+$\int_0^{t/2}\!v\,dt' - \int_{t/2}^{t}\!v\,dt' = 0$ because $v$ is constant), whereas it
+cannot refocus white-noise decoherence, whose second-half phase is statistically
+independent of the first.
+
+\textbf{The observable this predicts.} A standard free-evolution (Ramsey-type, no echo)
+interferometer estimates the fringe visibility by averaging over many shots, each an
+independent preparation of the superposition and hence an independent draw of $v$. For that
+protocol the measured visibility equals the ensemble average~\eqref{eq:ensemble_recovers},
+so the profile discriminant of \S\ref{sec:predictions} (maximum fractional-coherence
+difference $0.22$) is the quantity a real free-evolution interferometer measures: the
+predicted observable is well-defined. The identification of the shot ensemble with the
+stochastic ensemble is the operational reading already built into
+eq.~\eqref{eq:decoherence_integral} (an average over realizations); it introduces no
+postulate beyond the framework's axioms. Because the suppression is refocusable, a control
+run with a branch-swap echo furnishes an \emph{additional}, sign-definite discriminant from
+Di\'osi--Penrose---it restores the Einstein--Langevin coherence but leaves genuine
+Di\'osi--Penrose decoherence suppressed---subject to the caveat that an echo also refocuses
+any other static or inhomogeneous dephasing, so it isolates the reversible-versus-irreversible
+distinction rather than gravity specifically.
+
+This subsection is the resolution required by milestone GGD-4: the outcome is a
+\emph{re-scoping}, not a demotion. Result~2 remains \textbf{(Sketch)}---the
+Assumption~\ref{ass:gaussian} Gaussian-noise ceiling is untouched---but the predicted
+quantity is now identified precisely as the free-evolution ensemble visibility, and the
+\S\ref{sec:predictions} discriminant stands as a statement about that observable.
 
 \subsection{Evaluation of $C_V(0)$ for a uniform sphere}
 
@@ -386,7 +462,9 @@ Assumption~\ref{ass:gaussian} (Gaussian noise, not derived, and maximally violat
 actual bimodal stress-energy distribution of the state), on the decoherence
 formula~\eqref{eq:decoherence_integral}, which is exact only for Gaussian noise and is
 imported from the stochastic-gravity literature~\cite{hu_verdaguer} rather than derived
-here, and on the interpretational caveat of Remark~\ref{rem:dephasing}. Numerical values
+here. (The interpretational caveat of Remark~\ref{rem:dephasing} is now resolved
+operationally in \S\ref{sec:per_realization} and no longer contributes to the Sketch
+ceiling---which rests on Assumption~\ref{ass:gaussian} alone.) Numerical values
 for three experimental platforms are given in Table~\ref{tab:platforms}.
 
 \begin{table}[h]
@@ -519,6 +597,20 @@ The profile discrimination requires that environmental decoherence $\Gamma_{\tex
 be characterized to within a factor of $\sim 2$ (so that $\delta\Gamma_{\text{env}}\cdot
 \tau_{\text{coh}} \lesssim 0.1$). This is achievable by comparing data at different masses
 or between materials with the same environmental coupling but different $E_\Delta$.
+
+\textbf{Which observable, and an echo cross-check.} The discriminant above is a statement
+about the \emph{free-evolution} (no-echo) fringe visibility, which equals the ensemble
+average of the per-realization coherence
+(\S\ref{sec:per_realization}, eq.~\eqref{eq:ensemble_recovers})---exactly what a standard
+BMV/MAQRO shot average measures, so the predicted quantity is well-defined
+(Remark~\ref{rem:dephasing}). Because the Einstein--Langevin suppression is inhomogeneous
+dephasing rather than irreversible decoherence, a control run with a mid-point branch-swap
+echo should \emph{restore} the Einstein--Langevin coherence while leaving genuine
+Di\'osi--Penrose decoherence suppressed---a sign-definite, second discriminant independent
+of resolving the $0.22$ profile difference. The echo also refocuses other static or
+inhomogeneous dephasing, so it tests the reversible-versus-irreversible character of the
+suppression rather than its gravitational origin; it is a complement to, not a replacement
+for, the profile measurement.
 
 \subsection{Discrimination from the dissipative Di\'osi--Penrose model}
 \label{sec:ddp}
@@ -668,7 +760,13 @@ corrections are $\mathcal{O}(v^2/c^2)$. The material-dependent crossover
 (Conjecture~\ref{conj:material}) requires a more detailed model of the phonon-spectrum
 contribution to the noise kernel, and a quantitative assessment of whether any
 experimentally realistic platform reaches the crossover regime; both are open problems.
-The ensemble-dephasing caveat of Remark~\ref{rem:dephasing} is unresolved. The BMV null
+The ensemble-dephasing caveat of Remark~\ref{rem:dephasing} is resolved at the operational
+level (\S\ref{sec:per_realization}): the coherence magnitude is exactly conserved per
+realization and the Gaussian $t^2$ suppression is an echo-reversible inhomogeneous-dephasing
+effect recovered only on averaging, so the predicted observable is the free-evolution
+ensemble visibility a many-shot interferometer measures; only the metaphysical
+identification of ensemble dephasing with single-system decoherence remains a matter of
+interpretation, and the predictions do not depend on it. The BMV null
 prediction is necessary but not sufficient; the discriminating positive prediction is the
 temporal profile and, conditionally on Conjecture~\ref{conj:material}, its material
 dependence.

--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -237,6 +237,7 @@ two-point function as the complete specification of a Gaussian noise source
 (Assumption~\ref{ass:gaussian}).
 
 \subsection{Physical interpretation}
+\label{sec:physical_interpretation}
 
 The noise is not a quantum vacuum fluctuation of matter fields. It is the statistical
 variance of the mass distribution arising from the superposition: the mass is in two
@@ -281,7 +282,7 @@ The stochastic Newtonian potential at branch location $\mathbf{x}_{L,R}$ is:
 \begin{equation}
 \delta\Phi(\mathbf{x}) = -\frac{G}{c^2}\int \frac{\xi_{00}(\mathbf{x}')}{|\mathbf{x}-\mathbf{x}'|}\,d^3x'
 \end{equation}
-The branch-differential stochastic force $\delta V_\Delta(t) \equiv m[\delta\Phi(\mathbf{x}_L,t) - \delta\Phi(\mathbf{x}_R,t)]$ dephases the off-diagonal element of the density matrix. Averaging over stochastic realizations~\cite{hu_verdaguer}:
+The branch-differential stochastic potential-energy difference $\delta V_\Delta(t) \equiv m[\delta\Phi(\mathbf{x}_L,t) - \delta\Phi(\mathbf{x}_R,t)]$ dephases the off-diagonal element of the density matrix. Averaging over stochastic realizations~\cite{hu_verdaguer}:
 \begin{equation}
 |\rho_{LR}(t)| = |\rho_{LR}(0)|\exp\!\left(-\frac{1}{2\hbar^2}\int_0^t\!\!\int_0^t
 C_V(t'-t'')\,dt'\,dt''\right)
@@ -321,7 +322,9 @@ visibility a standard many-shot interferometer measures (\S\ref{sec:predictions}
 refocusability under a branch-swap echo is an additional discriminant from
 Di\'osi--Penrose. What remains genuinely open is only the metaphysical question of whether
 ensemble-averaged dephasing ``is'' single-system decoherence; the predicted observable does
-not depend on that choice, so no postulate beyond the framework's axioms is required.
+not depend on that choice, so no postulate beyond the framework's physical identification
+of the noise with the superposition's own mass distribution
+(\S\ref{sec:physical_interpretation}) is required.
 \end{remark}
 
 \subsection{Per-realization coherence and the ensemble observable}
@@ -333,7 +336,7 @@ Remark~\ref{rem:dephasing} at the operational level.
 
 \textbf{Single realization.} Fix one realization of the noise field $\xi_{00}$. For a
 stationary superposition the kernel is static (eq.~\eqref{eq:N0000_static}), so the realized
-branch-differential force is a single time-independent constant,
+branch-differential potential-energy difference is a single time-independent constant,
 \begin{equation}
 \delta V_\Delta(t) = v, \qquad
 v \equiv m\!\left[\delta\Phi(\mathbf{x}_L) - \delta\Phi(\mathbf{x}_R)\right],
@@ -375,14 +378,21 @@ independent of the first.
 
 \textbf{The observable this predicts.} A standard free-evolution (Ramsey-type, no echo)
 interferometer estimates the fringe visibility by averaging over many shots, each an
-independent preparation of the superposition and hence an independent draw of $v$. For that
-protocol the measured visibility equals the ensemble average~\eqref{eq:ensemble_recovers},
-so the profile discriminant of \S\ref{sec:predictions} (maximum fractional-coherence
-difference $0.22$) is the quantity a real free-evolution interferometer measures: the
-predicted observable is well-defined. The identification of the shot ensemble with the
-stochastic ensemble is the operational reading already built into
-eq.~\eqref{eq:decoherence_integral} (an average over realizations); it introduces no
-postulate beyond the framework's axioms. Because the suppression is refocusable, a control
+independent preparation of the superposition and hence an independent draw of $v$. Each
+preparation creates the superposition anew; because $v$ is the branch-differential
+potential-energy difference sourced by the superposition's own mass distribution
+(\S\ref{sec:physical_interpretation}; eq.~\eqref{eq:N0000}), each fresh preparation
+redraws $v$ from its Gaussian distribution---in contrast to a frozen external field, which
+would fix $v$ identically across shots and is a distinct model the framework does not
+adopt. For that protocol the measured visibility equals the ensemble
+average~\eqref{eq:ensemble_recovers}, so the profile discriminant of
+\S\ref{sec:predictions} (maximum fractional-coherence difference $0.22$) is the quantity a
+real free-evolution interferometer measures: the predicted observable is well-defined. The
+identification of the shot ensemble with the stochastic ensemble is the operational reading
+already built into eq.~\eqref{eq:decoherence_integral} (an average over realizations); it
+rests on the framework's physical identification of the noise as the statistical variance of
+the superposition's own mass distribution (\S\ref{sec:physical_interpretation}), not on a
+new axiom. Because the suppression is refocusable, a control
 run with a branch-swap echo furnishes an \emph{additional}, sign-definite discriminant from
 Di\'osi--Penrose---it restores the Einstein--Langevin coherence but leaves genuine
 Di\'osi--Penrose decoherence suppressed---subject to the caveat that an echo also refocuses


### PR DESCRIPTION
Closes #149.

## Summary

Milestone **GGD-4** (Result 2 observable integrity). The GGD headline — the coherence decay is Gaussian, not Diósi–Penrose exponential — rested on **Remark 2**, which flagged as an *open interpretational question* whether the ensemble-averaged dephasing the paper computes equals genuine single-system decoherence, and therefore whether the §5 discriminant (0.22 fractional-coherence difference, PR #105) predicts what a single interferometer run measures.

This PR does the postulate-free calculation the milestone specifies (new **§4.3, "Per-realization coherence and the ensemble observable"**) and **resolves Remark 2 at the operational level — outcome (ii), a re-scoping, not a demotion, not a `needs-human` escalation.**

**The calculation.** Because the stationary noise kernel `eq:N0000_static` is *static*, in any single realization the branch-differential force is a single time-independent constant $v$ (drawn once from a zero-mean Gaussian of variance $C_V(0)$). The off-diagonal element then evolves by a pure phase:
$$\rho_{LR}(t)=\rho_{LR}(0)\,e^{-ivt/\hbar},\qquad |\rho_{LR}(t)|=|\rho_{LR}(0)|,$$
so **the coherence magnitude is exactly conserved per realization** — no decay, only a deterministic (recoverable) phase (`eq:single_realization`, **Rigorous** within the E–L model). Averaging over the Gaussian of $v$ recovers the paper's `eq:gaussian_suppression` exactly:
$$\overline{\rho_{LR}(t)}=\rho_{LR}(0)\,\langle e^{-ivt/\hbar}\rangle=\rho_{LR}(0)\,e^{-C_V(0)t^2/2\hbar^2}\quad(\texttt{eq:ensemble\_recovers}).$$
**The Gaussian $t^2$ suppression therefore arises only after averaging.** It is inhomogeneous ($T_2^\ast$-type) dephasing — refocusable by a mid-point branch-swap (Hahn) echo because $v$ is constant in time — not the irreversible, realization-by-realization ($T_2$) decoherence of Diósi's white noise.

**Why re-scope, not demote.** For a standard *free-evolution* (Ramsey, no-echo) interferometer, the visibility is estimated by averaging over many shots, each an independent preparation and hence an independent draw of $v$; the measured visibility equals the ensemble average `eq:ensemble_recovers`. So the §5 discriminant (0.22) **is** the quantity a real free-evolution interferometer measures — the predicted observable is well-defined and the merged §5 number stands. Identifying the shot ensemble with the stochastic ensemble is the operational reading already built into `eq:decoherence_integral` (an average over realizations); **no postulate beyond the framework's axioms is introduced.** The echo-reversibility is a *bonus*: a branch-swap-echo control run restores the E–L coherence while leaving genuine DP decoherence suppressed — a sign-definite second discriminant (with the honest caveat, stated in-text, that an echo also refocuses other static dephasing, so it tests reversible-vs-irreversible rather than gravitational origin).

**Why not (iii)/`needs-human`.** The only thing left genuinely open is the *metaphysical* question of whether ensemble dephasing "is" single-system decoherence. The predictions do not depend on that choice, so it is not a postulate that changes any prediction — no escalation is warranted. The milestone's escalation branch is for the case where resolving the observable *requires* a new axiom; here it does not.

**Rigor.** Result 2 remains **(Sketch)** — the Assumption 1 (Gaussian-noise) ceiling is untouched; this PR removes only the *second*, ensemble-dephasing caveat from that ceiling. The per-realization/ensemble decomposition itself is **(Rigorous)** within the Einstein–Langevin model. **No promotion** (no `promotion-rigorous` label; no stress-test marker required).

## Changes
- `index.tex` §4.3 (new): per-realization vs. ensemble derivation, echo argument, observable identification, explicit re-scope statement.
- `index.tex` Remark 2: restated from "open ... do not resolve" → operationally resolved, pointing to §4.3.
- `index.tex` §5 Profile discrimination: new "Which observable, and an echo cross-check" paragraph scoping the discriminant to the free-evolution ensemble visibility and adding the echo discriminant.
- `index.tex` §4.5 rigor-status note and §6 Discussion limitation line: caveat marked resolved; Sketch ceiling attributed to Assumption 1 alone.
- `README.md`: "In plain English" and Results item 2 updated to reflect the resolved caveat (Result 2 still Sketch).

## Self-checks
- **Dimensional consistency.** $v=m\,\Delta(\delta\Phi)$ has units of energy; $vt/\hbar$ is dimensionless (phase); $\langle v^2\rangle t^2/\hbar^2 = C_V(0)t^2/\hbar^2$ is dimensionless, matching the existing `eq:gaussian_suppression` exponent — same $C_V(0)$, same prefactor $1/2\hbar^2$. ✓
- **Limiting cases.** (a) $t\to 0$: per-realization $|\rho_{LR}|\to|\rho_{LR}(0)|$ and ensemble $\overline{\rho_{LR}}\to\rho_{LR}(0)$ — both reduce to full coherence. ✓ (b) Ensemble-average limit `eq:ensemble_recovers` reproduces the paper's existing `eq:gaussian_suppression` identically (same $C_V(0)$, same $t^2$). ✓ (c) Gaussian characteristic-function identity $\langle e^{-ivt/\hbar}\rangle=e^{-\langle v^2\rangle t^2/2\hbar^2}$ for zero-mean Gaussian $v$ — standard. ✓
- **Consistency.** No merged number changes: §5 discriminant 0.22, $\sigma_V<0.07$, ~8000 shots, $\tau_{\rm coh}/\tau_{DP}=1.13$ all stand — the PR re-interprets the observable they describe (free-evolution ensemble visibility), it does not alter them. Result 2 label unchanged (Sketch). ✓
- **Order-of-magnitude sanity.** No new numerical prediction; the echo claim is qualitative (static phase refocuses exactly; white-noise variance grows monotonically and does not). Consistent with the standard NMR $T_2^\ast$ vs $T_2$ distinction. ✓

**Compilation:** `pdflatex index.tex` compiles clean twice (13 pages, no undefined references or citation warnings). Bibliography untouched (no citation-verification impact).

## Relations
- **informs** GGD-2 (#102, closed) — confirms the merged §5 discriminant predicts the measured free-evolution observable.
- **informs** GGD-3 — GGD-3 hardens the *shape* (vs. Assumption 1); this fixes *what quantity* the shape describes. Complementary.
- The potential block on promoting Result 2 above Sketch now rests on Assumption 1 alone (the ensemble-dephasing half of the old obstruction is cleared).

## Recommended adversarial review mode
**Verification mode** (check the per-realization algebra, the Gaussian-average identity, and that no merged §5 number is disturbed). A **stress-test** lens on one point is welcome but not required for merge: whether the "shot ensemble = stochastic ensemble" identification could smuggle in a hidden assumption — the PR argues it is already implicit in `eq:decoherence_integral`, but an adversary should test whether a preparation that does *not* redraw $v$ (a correlated-shot scenario) breaks the observable identification, and whether that scenario is physical.

routine: worker · model: claude-opus-4-8
