### PR TITLE
Allowlist markus: pre-DOI 1955 Annals of Math paper blocking verify gate

### DIFF
--- a/tools/citation-allowlist.yml
+++ b/tools/citation-allowlist.yml
@@ -17,3 +17,4 @@ smale: "Smale, On the structure of manifolds, Amer. J. Math. 84, 387 (1962). Ver
 radzikowski: "Radzikowski, Micro-local approach to the Hadamard condition, Commun. Math. Phys. 179, 529 (1996). Verified real; bib title is abbreviated relative to Crossref record."
 choquet_bruhat: "Choquet-Bruhat, Acta Math. 88, 141 (1952). Verified real; French title, accents stripped during parsing reduce match score."
 schauder: "Schauder, Der Fixpunktsatz in Funktionalraeumen, Studia Math. 2, 171 (1930). Verified real; German title not indexed by Crossref title search."
+markus: "Markus, Line element fields and Lorentz structures on differentiable manifolds, Ann. Math. (2) 62, 411 (1955). Verified real; pre-DOI paper, below Crossref fuzzy-match threshold."


### PR DESCRIPTION
## Summary
- `verify-citations` was failing (0.67 score, below threshold) on the `markus` bibitem in `programs/co-emergence/index.tex`: L. Markus, "Line element fields and Lorentz structures on differentiable manifolds," *Ann. Math.* (2) 62, 411–417 (1955).
- Verified real via web search (nLab/ResearchGate cross-references confirm the title, journal, volume, pages, year). Pre-DOI, so Crossref title-match falls below threshold — same failure mode as the existing `schauder`, `choquet_bruhat`, and `radzikowski` allowlist entries.
- Confirmed the citation is used correctly at both call sites (`index.tex:102`, `:1348`): Markus's classical result that a compact manifold admits a Lorentz(ian) structure iff its Euler characteristic vanishes, which is exactly the claim attributed to it.
- This is a protected-path (`tools/`) change per `AUTONOMY.md`, drafted as the interactive assistant under the experimenter's direction, following the same allowlist-only pattern as #142.

## Test plan
- [x] `python3 tools/verify_citations.py` locally: `0 unresolved` (was `1 unresolved`), all other counts unchanged.
- [x] No `.tex` content changed — only the allowlist justification file.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01WR68zKQsioBhwTGTDsy8vq