### PR TITLE
Note Mermaid diagram support in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ Read `METHODOLOGY.md` before contributing. It defines:
   English too. Updated in the same PR as any headline rigor change; the
   governor freshness-sweeps monthly.
 
+## Documentation
+
+Markdown files in this repo (READMEs, explorations, this file) can include
+Mermaid diagrams — GitHub renders them natively in-browser, no separate image
+export needed.
+
 ## Before starting work
 
 1. Read `METHODOLOGY.md` — understand the contribution workflow and rigor requirements.


### PR DESCRIPTION
Small docs note: we're full GitHub, so Markdown files in this repo (READMEs, explorations, AGENTS.md itself) can use Mermaid diagrams natively -- GitHub renders them in-browser, no separate image export needed.

Added under a new "## Documentation" section in AGENTS.md, right after the LaTeX-focused "## Conventions" section (kept separate since that section is specifically about the paper, not general Markdown docs).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QY1ecJtHBGCq3JM9PNNtu3