### PR TITLE
Fix nonexistent matplotlib>=3.11.0 pin blocking all PRs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest>=9.1.1
 
 # Used by the standalone exploration/plotting scripts in programs/*/tests/
 # (not required to run the pytest suite).
-matplotlib>=3.11.0
+matplotlib>=3.10.9


### PR DESCRIPTION
Dependabot's #112 bumped `matplotlib` to `>=3.11.0`, but that version isn't resolvable from the CI runner's package index right now (my local pip sees 3.11.0 as available, but the CI failure log from a few minutes ago listed only up to 3.10.9 -- looks like a just-released-version index-propagation lag rather than a real unavailability). Result: `pytest` fails installing dependencies on **every** open PR, regardless of what each PR actually touches -- currently blocking #153, #154, #155.

Fix: revert to the prior known-good floor, `>=3.10.9`, which is satisfied whether or not 3.11.0 has propagated yet.

Unrelated to the governance/identity work in #153/#155 -- pure infrastructure fix, flagged as its own PR for a clean diff.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QY1ecJtHBGCq3JM9PNNtu3