### PR TITLE
Migrate routine compute from Claude Code CLI to Copilot Agent Tasks API

### DIFF
--- a/.github/workflows/autonomy-governor.yml
+++ b/.github/workflows/autonomy-governor.yml
@@ -19,5 +19,5 @@ jobs:
     uses: ./.github/workflows/autonomy-routine.yml
     with:
       role: governor
-      model: ${{ vars.MODEL_GOVERNOR || 'claude-opus-4-8' }}
+      model: ${{ vars.MODEL_GOVERNOR || 'claude-opus-4.6' }}
     secrets: inherit

--- a/.github/workflows/autonomy-librarian.yml
+++ b/.github/workflows/autonomy-librarian.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/autonomy-routine.yml
     with:
       role: librarian
-      model: ${{ vars.MODEL_LIBRARIAN || 'claude-sonnet-4-6' }}
+      model: ${{ vars.MODEL_LIBRARIAN || 'claude-sonnet-5' }}
     secrets: inherit

--- a/.github/workflows/autonomy-red-team.yml
+++ b/.github/workflows/autonomy-red-team.yml
@@ -17,5 +17,5 @@ jobs:
     uses: ./.github/workflows/autonomy-routine.yml
     with:
       role: red-team
-      model: ${{ vars.MODEL_RED_TEAM || 'claude-opus-4-8' }}
+      model: ${{ vars.MODEL_RED_TEAM || 'claude-opus-4.6' }}
     secrets: inherit

--- a/.github/workflows/autonomy-responder.yml
+++ b/.github/workflows/autonomy-responder.yml
@@ -16,5 +16,5 @@ jobs:
     uses: ./.github/workflows/autonomy-routine.yml
     with:
       role: responder
-      model: ${{ vars.MODEL_RESPONDER || 'claude-sonnet-4-6' }}
+      model: ${{ vars.MODEL_RESPONDER || 'claude-sonnet-5' }}
     secrets: inherit

--- a/.github/workflows/autonomy-reviewer.yml
+++ b/.github/workflows/autonomy-reviewer.yml
@@ -18,5 +18,5 @@ jobs:
     uses: ./.github/workflows/autonomy-routine.yml
     with:
       role: reviewer
-      model: ${{ vars.MODEL_REVIEWER || 'claude-opus-4-8' }}
+      model: ${{ vars.MODEL_REVIEWER || 'claude-opus-4.6' }}
     secrets: inherit

--- a/.github/workflows/autonomy-routine.yml
+++ b/.github/workflows/autonomy-routine.yml
@@ -24,19 +24,25 @@ name: autonomy-routine
 # valid Copilot license"). Buying a seat for the machine account was
 # considered and deferred (cost); the accepted tradeoff is that Copilot
 # tasks are created and their content authored under the experimenter's own
-# account instead, via COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN — see
+# account instead, via COPILOT_TASK_API_PAT — see
 # EXPERIMENT.md log, 2026-07-12, and AUTONOMY.md's quorum-gate /
 # constitution-guard amendments the same day, which already removed the
 # gates that depended on a machine-account-only identity for authority
 # purposes. This workflow no longer checks out the repo or configures git
 # locally: the Copilot task clones and operates on the repo itself,
-# remotely, under COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN's identity. There
+# remotely, under COPILOT_TASK_API_PAT's identity. There
 # is no local git/gh operation left for AUTONOMY_BOT_PAT to authenticate, so
-# it is no longer used by this file. COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN
-# is an environment secret scoped to the "copilot" GitHub Environment (no
-# protection rules on it), not a plain repo secret, so this job declares
-# `environment: copilot` to read it -- confirmed necessary by a live test
-# that otherwise saw it as empty.
+# it is no longer used by this file.
+#
+# CREDENTIAL NOTE: the MCP-config page's "Agents secret"
+# (COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN, used to grant Copilot cloud
+# agent sessions write-tool access via MCP) turned out NOT to be a real
+# GitHub Actions secret -- it lives in a separate Copilot-internal store that
+# `secrets.*` in a workflow cannot read (confirmed empty even after trying
+# `environment: copilot`, which also turned out to hold zero actual secrets).
+# COPILOT_TASK_API_PAT is a second, genuine repo-level Actions secret
+# (same willregelmann identity, same license) created specifically so this
+# workflow can call the Agent Tasks API.
 #
 # Model IDs for the Agent Tasks API do not match the Claude Code CLI's IDs
 # (e.g. `claude-opus-4-8` 400s; the available ceiling is `claude-opus-4.6`).
@@ -65,10 +71,9 @@ jobs:
     name: ${{ inputs.role }}
     if: ${{ vars.AUTONOMY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
-    environment: copilot
     timeout-minutes: 45
     env:
-      GH_TOKEN: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}
+      GH_TOKEN: ${{ secrets.COPILOT_TASK_API_PAT }}
       ROLE: ${{ inputs.role }}
       MODEL: ${{ inputs.model }}
       REPO: ${{ github.repository }}
@@ -77,7 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::Missing COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN(secret) — cannot run the ${ROLE} routine."
+            echo "::error::Missing COPILOT_TASK_API_PAT(secret) — cannot run the ${ROLE} routine."
             exit 1
           fi
           ACTUAL=$(gh api user --jq .login)

--- a/.github/workflows/autonomy-routine.yml
+++ b/.github/workflows/autonomy-routine.yml
@@ -2,40 +2,42 @@ name: autonomy-routine
 
 # Reusable runner for the seven autonomous routines (AUTONOMY.md). Each role's
 # scheduled caller (autonomy-<role>.yml) invokes this with its role + model.
-# Behavior lives in automation/routines/<role>.md; this file only establishes
-# the machine-account identity and starts a Copilot cloud agent task on the
-# role's pointer prompt via the Agent Tasks REST API.
+# Behavior lives in automation/routines/<role>.md; this file only starts a
+# Copilot cloud agent task on the role's pointer prompt via the Agent Tasks
+# REST API and waits for it to finish.
 #
-# WHY THIS EXISTS: the original deployment ran the routines as claude.ai
-# scheduled remote agents, which authenticate GitHub with the *account's*
-# global connector — i.e. the experimenter's admin login. That voided every
-# authority boundary in AUTONOMY.md (write-not-admin, no self-verdict, no
-# protected-path self-approval). A GitHub Actions runner authenticates with a
-# credential we control (AUTONOMY_BOT_PAT), restoring the machine-account
-# identity by construction. See EXPERIMENT.md log (2026-06-09).
+# WHY THE MACHINE-ACCOUNT DESIGN EXISTS: the original deployment ran the
+# routines as claude.ai scheduled remote agents, which authenticate GitHub
+# with the *account's* global connector — i.e. the experimenter's admin
+# login. That voided every authority boundary in AUTONOMY.md (write-not-
+# admin, no self-verdict, no protected-path self-approval). Moving to GitHub
+# Actions with a credential we control (AUTONOMY_BOT_PAT, machine account
+# will-physagent) restored that identity by construction. See EXPERIMENT.md
+# log (2026-06-09).
 #
 # COMPUTE MIGRATION (2026-07-12): the actual reasoning step moved from a
-# headless Claude Code CLI session to a GitHub Copilot cloud agent task,
-# started and polled via the Agent Tasks REST API
-# (agents/repos/{owner}/{repo}/tasks). Everything else about the identity and
-# kill-switch model is unchanged. Two things specific to this API, learned by
-# direct testing before this migration:
-#   - The agent tasks API only accepts user-to-server tokens (PATs, OAuth
-#     tokens) — NOT the default GITHUB_TOKEN. AUTONOMY_BOT_PAT already
-#     satisfies this, so no new credential was introduced.
-#   - Model IDs for this API do not match the Claude Code CLI's IDs (e.g.
-#     `claude-opus-4-8` 400s; the available ID is `claude-opus-4.6`). Model
-#     defaults in each autonomy-<role>.yml caller were updated accordingly.
+# headless Claude Code CLI session to a GitHub Copilot cloud agent task.
+# THIS CHANGED WHICH IDENTITY AUTHORS ROUTINE CONTENT, DELIBERATELY AND
+# LOGGED — not an accident of the kind the 2026-06-05 incident was. Copilot
+# licenses are per-user; the machine account (will-physagent) does not have
+# one, confirmed by testing (the Agent Tasks API 403s: "This API requires a
+# valid Copilot license"). Buying a seat for the machine account was
+# considered and deferred (cost); the accepted tradeoff is that Copilot
+# tasks are created and their content authored under the experimenter's own
+# account instead, via COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN — see
+# EXPERIMENT.md log, 2026-07-12, and AUTONOMY.md's quorum-gate /
+# constitution-guard amendments the same day, which already removed the
+# gates that depended on a machine-account-only identity for authority
+# purposes. This workflow no longer checks out the repo or configures git
+# locally: the Copilot task clones and operates on the repo itself,
+# remotely, under COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN's identity. There
+# is no local git/gh operation left for AUTONOMY_BOT_PAT to authenticate, so
+# it is no longer used by this file.
 #
-# IDENTITY: every git/gh operation, including the task-creation call itself,
-# authenticates as the machine account via AUTONOMY_BOT_PAT, NOT the default
-# GITHUB_TOKEN (whose actor is github-actions[bot] — neither the machine
-# account nor the experimenter, and whose PRs would not trigger the
-# required-check workflows). checkout runs with persist-credentials:false so
-# the default token's git credential cannot shadow the PAT. A hard identity
-# guard refuses to run the routine if the effective login is not the
-# AUTONOMY_BOT variable value — the exact check whose absence caused the
-# 2026-06-05 incident.
+# Model IDs for the Agent Tasks API do not match the Claude Code CLI's IDs
+# (e.g. `claude-opus-4-8` 400s; the available ceiling is `claude-opus-4.6`).
+# Model defaults in each autonomy-<role>.yml caller are being updated to
+# Agent-Tasks-API-compatible IDs role by role as each is migrated.
 #
 # KILL SWITCH: the job is gated on the repo variable AUTONOMY_ENABLED == 'true'.
 # Unset or any other value => every routine run skips. Flip that one variable to
@@ -61,42 +63,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      GH_TOKEN: ${{ secrets.AUTONOMY_BOT_PAT }}
+      GH_TOKEN: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}
       ROLE: ${{ inputs.role }}
       MODEL: ${{ inputs.model }}
-      AUTONOMY_BOT: ${{ vars.AUTONOMY_BOT }}
       REPO: ${{ github.repository }}
     steps:
-      - name: Preflight — required secrets and variables present
+      - name: Preflight — required secret present; log the effective identity
         run: |
           set -euo pipefail
-          missing=
-          [ -z "${GH_TOKEN:-}" ] && missing="$missing AUTONOMY_BOT_PAT(secret)"
-          [ -z "${AUTONOMY_BOT:-}" ] && missing="$missing AUTONOMY_BOT(var)"
-          if [ -n "$missing" ]; then
-            echo "::error::Missing required configuration:$missing — cannot run the ${ROLE} routine."
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Missing COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN(secret) — cannot run the ${ROLE} routine."
             exit 1
           fi
-
-      - name: Check out repo (do not persist the default-token credential)
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Configure git/gh as the machine account, and GUARD the identity
-        run: |
-          set -euo pipefail
-          gh auth setup-git
-          git config --global user.name "${AUTONOMY_BOT}"
-          git config --global user.email "${AUTONOMY_BOT}@users.noreply.github.com"
           ACTUAL=$(gh api user --jq .login)
-          echo "Effective GitHub identity: ${ACTUAL} (expected: ${AUTONOMY_BOT})"
-          if [ "${ACTUAL}" != "${AUTONOMY_BOT}" ]; then
-            echo "::error::Routine would run as '${ACTUAL}', not the machine account '${AUTONOMY_BOT}'."
-            echo "::error::Refusing to act. This is the identity guard the claude.ai deployment lacked (2026-06-05 incident)."
-            exit 1
-          fi
+          echo "${ROLE}: this run's Copilot task will be created and its content authored as GitHub identity '${ACTUAL}'. This is the deliberate, logged 2026-07-12 tradeoff (see AUTONOMY.md and EXPERIMENT.md) — not an unguarded accident. It is expected to be the experimenter's own account, not a dedicated machine account, until the machine account has its own Copilot seat."
 
       - name: Start Copilot cloud agent task and wait for completion
         run: |

--- a/.github/workflows/autonomy-routine.yml
+++ b/.github/workflows/autonomy-routine.yml
@@ -3,8 +3,8 @@ name: autonomy-routine
 # Reusable runner for the seven autonomous routines (AUTONOMY.md). Each role's
 # scheduled caller (autonomy-<role>.yml) invokes this with its role + model.
 # Behavior lives in automation/routines/<role>.md; this file only establishes
-# the machine-account identity and runs a headless Claude Code session on the
-# role's pointer prompt.
+# the machine-account identity and starts a Copilot cloud agent task on the
+# role's pointer prompt via the Agent Tasks REST API.
 #
 # WHY THIS EXISTS: the original deployment ran the routines as claude.ai
 # scheduled remote agents, which authenticate GitHub with the *account's*
@@ -14,14 +14,28 @@ name: autonomy-routine
 # credential we control (AUTONOMY_BOT_PAT), restoring the machine-account
 # identity by construction. See EXPERIMENT.md log (2026-06-09).
 #
-# IDENTITY: every git/gh operation authenticates as the machine account via
-# AUTONOMY_BOT_PAT, NOT the default GITHUB_TOKEN (whose actor is
-# github-actions[bot] — neither the machine account nor the experimenter, and
-# whose PRs would not trigger the required-check workflows). checkout runs with
-# persist-credentials:false so the default token's git credential cannot shadow
-# the PAT. A hard identity guard refuses to run the routine if the effective
-# login is not the AUTONOMY_BOT variable value — the exact check whose absence
-# caused the 2026-06-05 incident.
+# COMPUTE MIGRATION (2026-07-12): the actual reasoning step moved from a
+# headless Claude Code CLI session to a GitHub Copilot cloud agent task,
+# started and polled via the Agent Tasks REST API
+# (agents/repos/{owner}/{repo}/tasks). Everything else about the identity and
+# kill-switch model is unchanged. Two things specific to this API, learned by
+# direct testing before this migration:
+#   - The agent tasks API only accepts user-to-server tokens (PATs, OAuth
+#     tokens) — NOT the default GITHUB_TOKEN. AUTONOMY_BOT_PAT already
+#     satisfies this, so no new credential was introduced.
+#   - Model IDs for this API do not match the Claude Code CLI's IDs (e.g.
+#     `claude-opus-4-8` 400s; the available ID is `claude-opus-4.6`). Model
+#     defaults in each autonomy-<role>.yml caller were updated accordingly.
+#
+# IDENTITY: every git/gh operation, including the task-creation call itself,
+# authenticates as the machine account via AUTONOMY_BOT_PAT, NOT the default
+# GITHUB_TOKEN (whose actor is github-actions[bot] — neither the machine
+# account nor the experimenter, and whose PRs would not trigger the
+# required-check workflows). checkout runs with persist-credentials:false so
+# the default token's git credential cannot shadow the PAT. A hard identity
+# guard refuses to run the routine if the effective login is not the
+# AUTONOMY_BOT variable value — the exact check whose absence caused the
+# 2026-06-05 incident.
 #
 # KILL SWITCH: the job is gated on the repo variable AUTONOMY_ENABLED == 'true'.
 # Unset or any other value => every routine run skips. Flip that one variable to
@@ -36,7 +50,7 @@ on:
         required: true
         type: string
       model:
-        description: Full Claude model ID to run this routine on
+        description: Agent Tasks API model ID to run this routine on (e.g. claude-opus-4.6, claude-sonnet-5 -- NOT the Claude Code CLI's dashed IDs)
         required: true
         type: string
 
@@ -45,19 +59,19 @@ jobs:
     name: ${{ inputs.role }}
     if: ${{ vars.AUTONOMY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       GH_TOKEN: ${{ secrets.AUTONOMY_BOT_PAT }}
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ROLE: ${{ inputs.role }}
       MODEL: ${{ inputs.model }}
       AUTONOMY_BOT: ${{ vars.AUTONOMY_BOT }}
+      REPO: ${{ github.repository }}
     steps:
       - name: Preflight — required secrets and variables present
         run: |
           set -euo pipefail
           missing=
           [ -z "${GH_TOKEN:-}" ] && missing="$missing AUTONOMY_BOT_PAT(secret)"
-          [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && missing="$missing CLAUDE_CODE_OAUTH_TOKEN(secret)"
           [ -z "${AUTONOMY_BOT:-}" ] && missing="$missing AUTONOMY_BOT(var)"
           if [ -n "$missing" ]; then
             echo "::error::Missing required configuration:$missing — cannot run the ${ROLE} routine."
@@ -84,84 +98,56 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-
-      - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
-
-      - name: Run the ${{ inputs.role }} routine
+      - name: Start Copilot cloud agent task and wait for completion
         run: |
           set -euo pipefail
           PROMPT="You are the ${ROLE} routine of the self-consistency autonomous research experiment. Read AUTONOMY.md at the repository root first, then read automation/routines/${ROLE}.md and execute it exactly. If automation/routines/${ROLE}.md does not exist on this branch, the experiment infrastructure has not landed yet — exit immediately without taking any action. For the metrics record: you are running as model ${MODEL}; end every PR body, issue body, and review/verdict comment you post with the line 'routine: ${ROLE} · model: ${MODEL}'."
 
-          # Retry wrapper for two distinct, non-bug failure modes (EXPERIMENT.md
-          # log, 2026-06-11 and 2026-06-20):
-          #
-          #   (A) Session limit: the CLI exits nonzero with "You've hit your
-          #       session limit · resets H:MMam/pm (UTC)" when the account's
-          #       rolling budget is exhausted. If the reset is <= 90 min away,
-          #       sleep through it and retry once; otherwise fail and defer to
-          #       the next scheduled fire.
-          #   (B) Transient API error: "API Error: 529 Overloaded" (or 5xx/429/
-          #       rate-limit) — a server-side hiccup. Seen 4× on the reviewer
-          #       (2026-06-17/20); each self-healed on the next cron, but the run
-          #       failed and polluted the failure signal. Retry in place with
-          #       short exponential backoff (30s/60s/120s) before deferring.
-          #
-          # Any other nonzero exit is a real error and is surfaced immediately.
-          session_retry_used=0
-          transient_attempt=0
-          MAX_TRANSIENT=3
+          RESPONSE=$(gh api "agents/repos/${REPO}/tasks" --method POST \
+            -f prompt="$PROMPT" \
+            -f base_ref="main" \
+            -f model="$MODEL")
+          TASK_ID=$(echo "$RESPONSE" | jq -r .id)
+          if [ -z "$TASK_ID" ] || [ "$TASK_ID" = "null" ]; then
+            echo "::error::${ROLE}: task creation did not return an id. Response: $RESPONSE"
+            exit 1
+          fi
+          echo "${ROLE}: started task $TASK_ID (model $MODEL). https://github.com/${REPO}/tasks/${TASK_ID}"
+
+          # Poll to a terminal state. Docs list: queued, in_progress, completed,
+          # failed, idle, waiting_for_user, timed_out, cancelled. Every terminal
+          # state except "completed" is treated as a failure here -- in
+          # particular waiting_for_user (the task paused for a plan-approval
+          # click, observed firsthand in interactive testing before this
+          # migration) has no one present to click it in an unattended run, so
+          # it must fail rather than hang. This retry/failure-mode classification
+          # is a first cut, not battle-tested: the CLI-based runner's own
+          # session-limit and transient-API-error handling (see git history)
+          # was itself built up incrementally from real incidents in
+          # EXPERIMENT.md's log (2026-06-11, 2026-06-20). Expect this block to
+          # need the same kind of amendment once real Copilot-specific failure
+          # modes are observed in production.
+          MAX_POLLS=120   # 120 * 20s = 40 minutes, under the job's 45-minute timeout
+          poll=0
           while :; do
-            set +e
-            claude -p "$PROMPT" \
-              --model "$MODEL" \
-              --permission-mode bypassPermissions 2>&1 | tee /tmp/routine-output.txt
-            status=${PIPESTATUS[0]}
-            set -e
-            [ "$status" -eq 0 ] && exit 0
-
-            # (A) Session-limit branch
-            if grep -q "hit your session limit" /tmp/routine-output.txt; then
-              if [ "$session_retry_used" -ge 1 ]; then
-                echo "::error::${ROLE} hit the Claude session limit on the retry as well — giving up; the next scheduled fire covers this."
-                exit "$status"
-              fi
-              reset_str=$(grep -o "resets [0-9:]*[ap]m" /tmp/routine-output.txt | head -1 | sed 's/^resets //')
-              wait_s=""
-              if [ -n "$reset_str" ]; then
-                reset_epoch=$(date -u -d "today ${reset_str}" +%s 2>/dev/null || echo "")
-                if [ -n "$reset_epoch" ]; then
-                  now_epoch=$(date -u +%s)
-                  [ "$reset_epoch" -le "$now_epoch" ] && reset_epoch=$((reset_epoch + 86400))
-                  wait_s=$((reset_epoch - now_epoch + 120))
-                fi
-              fi
-              if [ -z "$wait_s" ] || [ "$wait_s" -gt 5400 ]; then
-                echo "::error::${ROLE} hit the Claude session limit; reset ('${reset_str:-unparseable}') is over 90 minutes away or unparseable — failing now rather than holding a runner. The next scheduled fire covers this."
-                exit "$status"
-              fi
-              echo "::warning::${ROLE} hit the Claude session limit; sleeping $((wait_s / 60)) minutes until the reset (${reset_str} UTC), then retrying once."
-              sleep "$wait_s"
-              session_retry_used=1
-              continue
+            poll=$((poll + 1))
+            if [ "$poll" -gt "$MAX_POLLS" ]; then
+              echo "::error::${ROLE}: task $TASK_ID did not reach a terminal state within the poll budget; failing so the next scheduled fire covers this."
+              exit 1
             fi
-
-            # (B) Transient API-error branch (529 Overloaded / 5xx / 429 / rate limit)
-            if grep -qiE "API Error: (5[0-9][0-9]|429)|Overloaded|rate.?limit" /tmp/routine-output.txt; then
-              if [ "$transient_attempt" -ge "$MAX_TRANSIENT" ]; then
-                echo "::error::${ROLE} hit a transient API error ${MAX_TRANSIENT}× in a row (last exit $status); giving up — the next scheduled fire covers this."
-                exit "$status"
-              fi
-              transient_attempt=$((transient_attempt + 1))
-              backoff=$((30 * 2 ** (transient_attempt - 1)))
-              echo "::warning::${ROLE} hit a transient API error (attempt ${transient_attempt}/${MAX_TRANSIENT}); backing off ${backoff}s then retrying."
-              sleep "$backoff"
-              continue
-            fi
-
-            # Any other nonzero exit is a real error.
-            exit "$status"
+            sleep 20
+            STATE=$(gh api "agents/repos/${REPO}/tasks/${TASK_ID}" --jq .state)
+            case "$STATE" in
+              completed)
+                echo "${ROLE}: task $TASK_ID completed."
+                exit 0 ;;
+              queued|in_progress|idle)
+                continue ;;
+              failed|timed_out|cancelled|waiting_for_user)
+                echo "::error::${ROLE}: task $TASK_ID ended in state '$STATE' -- the next scheduled fire covers this."
+                exit 1 ;;
+              *)
+                echo "::warning::${ROLE}: task $TASK_ID returned unrecognized state '$STATE'; continuing to poll."
+                continue ;;
+            esac
           done

--- a/.github/workflows/autonomy-routine.yml
+++ b/.github/workflows/autonomy-routine.yml
@@ -32,7 +32,11 @@ name: autonomy-routine
 # locally: the Copilot task clones and operates on the repo itself,
 # remotely, under COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN's identity. There
 # is no local git/gh operation left for AUTONOMY_BOT_PAT to authenticate, so
-# it is no longer used by this file.
+# it is no longer used by this file. COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN
+# is an environment secret scoped to the "copilot" GitHub Environment (no
+# protection rules on it), not a plain repo secret, so this job declares
+# `environment: copilot` to read it -- confirmed necessary by a live test
+# that otherwise saw it as empty.
 #
 # Model IDs for the Agent Tasks API do not match the Claude Code CLI's IDs
 # (e.g. `claude-opus-4-8` 400s; the available ceiling is `claude-opus-4.6`).
@@ -61,6 +65,7 @@ jobs:
     name: ${{ inputs.role }}
     if: ${{ vars.AUTONOMY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
+    environment: copilot
     timeout-minutes: 45
     env:
       GH_TOKEN: ${{ secrets.COPILOT_MCP_GITHUB_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/autonomy-scout.yml
+++ b/.github/workflows/autonomy-scout.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/autonomy-routine.yml
     with:
       role: scout
-      model: ${{ vars.MODEL_SCOUT || 'claude-sonnet-4-6' }}
+      model: ${{ vars.MODEL_SCOUT || 'claude-sonnet-5' }}
     secrets: inherit

--- a/.github/workflows/autonomy-worker.yml
+++ b/.github/workflows/autonomy-worker.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/autonomy-routine.yml
     with:
       role: worker
-      model: ${{ vars.MODEL_WORKER || 'claude-opus-4-8' }}
+      model: ${{ vars.MODEL_WORKER || 'claude-opus-4.6' }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Replaces the reusable runner's compute step: instead of a headless Claude Code CLI session (`claude -p ...`), `autonomy-routine.yml` now starts a GitHub Copilot cloud agent task via the Agent Tasks REST API (`POST agents/repos/{owner}/{repo}/tasks`) and polls it to a terminal state. Behavior still lives entirely in `automation/routines/<role>.md` -- the pointer-prompt pattern is unchanged.

## Why

Consolidates the routine fleet's compute onto GitHub's own product rather than a separately-managed Claude subscription credential (`CLAUDE_CODE_OAUTH_TOKEN`, no longer used by this file).

## What changed, concretely

- **Identity**: Copilot licenses are per-user; the machine account (`will-physagent`) doesn't have one (confirmed by a live 403: "This API requires a valid Copilot license"). Buying it a seat was considered and deferred (cost). Accepted tradeoff: routine content is now authored under the experimenter's own account (`willregelmann`), via a new dedicated Actions secret `COPILOT_TASK_API_PAT`. This workflow no longer does any local git/gh operation (the Copilot task clones and works on the repo remotely under its own identity), so `AUTONOMY_BOT_PAT`, checkout, and the old identity guard are all removed from this file. A preflight step now logs the effective identity every run instead, for transparency.
- **Model IDs**: the Agent Tasks API's catalog doesn't match the CLI's IDs. `claude-opus-4-8` 400s; `claude-opus-4.6` is the available ceiling. `claude-sonnet-5` is available and newer than the prior `claude-sonnet-4-6` default. All seven `autonomy-<role>.yml` callers' model defaults updated accordingly (opus-tier: worker/reviewer/red-team/governor; sonnet-tier: responder/scout/librarian).
- **Failure-mode handling**: the old CLI-based retry logic (session-limit sleep-retry, transient-API-error backoff) doesn't map cleanly onto the API's task states (`queued`/`in_progress`/`completed`/`failed`/`idle`/`waiting_for_user`/`timed_out`/`cancelled`). First cut: any terminal state except `completed` fails the run, deferring to the next scheduled fire -- including `waiting_for_user`, which I saw firsthand in interactive testing (a "plan ready for review, approve to continue" state with no one present to click it in an unattended run). Flagged in the workflow's own comments as needing the same kind of incremental refinement the CLI-based retry logic got from real incidents (EXPERIMENT.md log, 2026-06-11/06-20).

## Validation

Real, unattended, end-to-end test via `workflow_dispatch` against the actual production secrets on this branch (not a local/manual session): librarian ran the full pipeline -- arXiv sweep across all four programs, correct milestone-relevance filtering, correctly noticed the signature-change-boundary program is halted under `needs-human` #75 and explicitly declined to authorize any work there, filed a correctly-labeled `informs-issue` with the required `routine: librarian · model: claude-sonnet-5` stamp, flagged its citation as unverified-abstract-only per METHODOLOGY discipline. Result: **#157**. ~74 AI credits for the complete run.

**Not yet individually live-tested**: worker, reviewer, red-team, and governor carry real merge authority (PRs, verdicts, demotions) -- meaningfully higher stakes than librarian's issue-only output. Only the model-default swap was applied to them, on the strength of the shared reusable-runner mechanism being validated, not a live per-role test. Flagging this explicitly rather than claiming more validation than actually happened.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QY1ecJtHBGCq3JM9PNNtu3