### PR TITLE
Full documentation sweep: sync docs to 2026-07-12 changes, add Mermaid diagrams

### DIFF
--- a/automation/routines/README.md
+++ b/automation/routines/README.md
@@ -16,18 +16,42 @@ Register each routine with this pointer prompt (replace `<role>`):
 > experiment infrastructure has not landed yet — exit immediately without
 > taking any action.
 
-Source: this repository, branch `main`. Git identity / GitHub auth: the
-machine account recorded in the repo variable `AUTONOMY_BOT`, supplied to the
-runner as the `AUTONOMY_BOT_PAT` secret (see "Deployed instances" below).
+Source: this repository, branch `main`. GitHub identity for routine-created
+content: the experimenter's own account (`willregelmann`), via the
+`COPILOT_TASK_API_PAT` secret (see "Deployed instances" below) — **not** the
+machine account, as of the 2026-07-12 compute migration described below.
 
 > **Runner note (2026-06-09).** The routines were originally registered as
 > claude.ai scheduled remote agents. That runner authenticates GitHub with the
 > account's *global* connector — i.e. the experimenter's admin login — which
 > voided the machine-account identity the whole authority model depends on
-> (EXPERIMENT.md log). The routines now run as **GitHub Actions scheduled
-> workflows** instead, which authenticate with a credential we control
-> (`AUTONOMY_BOT_PAT`). The pointer prompt above is unchanged — it is what the
-> reusable workflow feeds to a headless Claude Code session.
+> (EXPERIMENT.md log). The routines then ran as **GitHub Actions scheduled
+> workflows** instead, authenticating with a credential under our control
+> (`AUTONOMY_BOT_PAT`, machine account `will-physagent`). The pointer prompt
+> above was unchanged throughout — it's what the reusable workflow feeds to
+> whatever's doing the actual reasoning.
+
+> **Compute migration (2026-07-12).** The reusable workflow no longer runs a
+> headless Claude Code CLI session. It starts a GitHub Copilot cloud agent
+> task via the Agent Tasks REST API and polls it to completion — the pointer
+> prompt is unchanged, only the compute substrate underneath it. This also
+> changed *which identity* authors routine content: Copilot licenses are
+> per-user, the machine account doesn't have one, and buying it a seat was
+> deferred (cost). Routine content is now created and authored under the
+> experimenter's own account instead — a deliberate, logged tradeoff (see
+> `EXPERIMENT.md` log and `docs/ARCHITECTURE.md`'s Identity and authority
+> section for why this is not a repeat of the 2026-06-05 incident). Dispatch
+> flow:
+
+```mermaid
+flowchart LR
+    Cron["autonomy-&lt;role&gt;.yml<br/>cron / workflow_dispatch"] --> Runner["autonomy-routine.yml<br/>reusable runner"]
+    Runner -->|"POST /agents/repos/.../tasks<br/>COPILOT_TASK_API_PAT (willregelmann)"| API[Agent Tasks API]
+    API --> Task["Copilot cloud agent task<br/>own remote environment,<br/>clones the repo itself"]
+    Task -->|reads| Files["AUTONOMY.md +<br/>automation/routines/&lt;role&gt;.md"]
+    Task -->|"writes as willregelmann"| GH["Issues / PRs / comments"]
+    Runner -.->|polls to a terminal state| API
+```
 
 ## Registry
 
@@ -50,7 +74,7 @@ up-to-date queue. Governor runs Sunday 05:00, deliberately before the Monday
 scout/metrics/digest, so any thread it promotes that run enters the new
 week's queue immediately (EXPERIMENT.md 2026-06-10 amendment).
 
-## Deployed instances (GitHub Actions, 2026-06-09)
+## Deployed instances (GitHub Actions, 2026-06-09; compute migrated 2026-07-12)
 
 The routines run as **GitHub Actions scheduled workflows** in this repository.
 Each role has a thin scheduled caller (`.github/workflows/autonomy-<role>.yml`)
@@ -58,45 +82,61 @@ that invokes the reusable runner (`.github/workflows/autonomy-routine.yml`) with
 its role and model. This table is the record of the live deployment; if it
 drifts from the workflow files, this file is wrong — fix it.
 
-| Routine | Workflow file | Cron (UTC) | Model (current default) |
+| Routine | Workflow file | Cron (UTC) | Model (current default, Agent Tasks API ID) |
 |---------|---------------|------------|-------|
-| worker | `autonomy-worker.yml` | `0 6 * * *` | claude-opus-4-8 |
-| reviewer | `autonomy-reviewer.yml` | `0 5,6,17,18 * * *` | claude-opus-4-8 |
-| responder | `autonomy-responder.yml` | `0 4 * * *` | claude-sonnet-4-6 |
-| red-team | `autonomy-red-team.yml` | `0 8 */3 * *` | claude-opus-4-8 |
-| scout | `autonomy-scout.yml` | `0 3 * * 1` | claude-sonnet-4-6 |
-| librarian | `autonomy-librarian.yml` | `0 3 * * 2` | claude-sonnet-4-6 |
-| governor | `autonomy-governor.yml` | `0 5 * * 0` | claude-opus-4-8 |
+| worker | `autonomy-worker.yml` | `0 6 * * *` | claude-opus-4.6 |
+| reviewer | `autonomy-reviewer.yml` | `0 5,6,17,18 * * *` | claude-opus-4.6 |
+| responder | `autonomy-responder.yml` | `0 4 * * *` | claude-sonnet-5 |
+| red-team | `autonomy-red-team.yml` | `0 8 */3 * *` | claude-opus-4.6 |
+| scout | `autonomy-scout.yml` | `0 3 * * 1` | claude-sonnet-5 |
+| librarian | `autonomy-librarian.yml` | `0 3 * * 2` | claude-sonnet-5 |
+| governor | `autonomy-governor.yml` | `0 5 * * 0` | claude-opus-4.6 |
+
+Model IDs for the Agent Tasks API do not match the old Claude Code CLI's IDs
+(confirmed by direct testing: `claude-opus-4-8` 400s — "model not found";
+`claude-opus-4.6` is the available ceiling; `claude-sonnet-5` is available and
+newer than the prior `claude-sonnet-4-6` default).
 
 Shared deployment configuration (all seven, in the reusable runner):
 
-- **Runner:** `ubuntu-latest`; each run is a fresh checkout of this repo, a
-  global `npm install -g @anthropic-ai/claude-code`, and one headless
-  `claude -p "<pointer prompt>"` session. Stateless — every run reconstructs
-  from GitHub, which suits ephemeral CI.
-- **Prompt:** the pointer template above, built verbatim by the runner —
-  behavior lives in the version-controlled `<role>.md` files, never in the
-  workflow.
+- **Runner:** `ubuntu-latest`; each run POSTs to the Agent Tasks API and polls
+  the resulting task to a terminal state (`queued` → `in_progress` →
+  `completed`, or a failure state). No local checkout, no CLI install — the
+  Copilot cloud agent task clones and works on the repo itself, remotely, in
+  its own environment. This is a bigger change than it sounds: through
+  2026-07-12 the runner *was* the compute (a headless CLI session executing
+  on the Actions runner itself); since then the runner is just a thin
+  dispatcher, and the actual reasoning happens entirely off-runner.
+- **Prompt:** the pointer template above, unchanged — behavior lives in the
+  version-controlled `<role>.md` files, never in the workflow, exactly as
+  before the compute migration.
 - **Model:** each role's `autonomy-<role>.yml` reads
-  `${{ vars.MODEL_<ROLE> || '<default>' }}` and passes the result as
-  `claude --model <id>` — the table above shows the current default for each
-  role (no `MODEL_*` repo variable is set as of this writing, so every role is
-  running its default). Changing a role's model is `gh variable set
-  MODEL_<ROLE> <id>`, no PR required (EXPERIMENT.md 2026-06-13 amendment).
-- **Permissions:** `--permission-mode bypassPermissions` (no human is present
-  to approve tool calls in CI). The full Claude Code toolset is available; the
-  reusable runner does not pass an `--allowedTools` allow-list.
-- **Claude auth:** the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (shared with the
-  `semantic-review` gate).
-- **GitHub identity:** the `AUTONOMY_BOT_PAT` repo secret (the machine
-  account's PAT, `public_repo` scope, deliberately NO `workflow` scope). The
-  runner uses it for every git/gh operation — NOT the default `GITHUB_TOKEN`,
-  whose actor `github-actions[bot]` is neither the machine account nor the
-  experimenter and whose PRs would not trigger the required checks. `checkout`
-  runs with `persist-credentials: false` so the default token cannot shadow the
-  PAT. A hard identity guard in the runner refuses to act unless the effective
-  login equals `AUTONOMY_BOT` — the check whose absence caused the 2026-06-05
-  incident.
+  `${{ vars.MODEL_<ROLE> || '<default>' }}` and passes the result as the
+  Agent Tasks API's `model` parameter — the table above shows the current
+  default for each role. Changing a role's model is still `gh variable set
+  MODEL_<ROLE> <id>`, no PR required (EXPERIMENT.md 2026-06-13 amendment) —
+  just make sure the ID is one the Agent Tasks API recognizes, not a CLI ID.
+- **Permissions:** N/A to this runner directly — the Copilot cloud agent task
+  runs in its own sandboxed environment under GitHub's control, with its own
+  tool/network policy (see the repo's Settings → Copilot pages), not this
+  workflow's.
+- **Claude auth:** `CLAUDE_CODE_OAUTH_TOKEN` is **no longer used by this
+  runner** (it's still used elsewhere: `semantic-review`'s claim-support
+  evaluator, `digest.yml`'s significance pass).
+- **GitHub identity:** `COPILOT_TASK_API_PAT`, a personal access token under
+  the experimenter's own account (`willregelmann`) — **not** the machine
+  account. Copilot licenses are per-user and the machine account
+  (`will-physagent`) doesn't have one (confirmed by a live 403: "This API
+  requires a valid Copilot license"); buying it a seat was considered and
+  deferred as a cost decision. This is a deliberate, logged tradeoff, not an
+  unguarded accident — see `docs/ARCHITECTURE.md`'s Identity and authority
+  section for why this specifically does not repeat the 2026-06-05 incident
+  (the two gates whose safety property depended on machine-account-only
+  identity were retired the same day, before this migration landed). The
+  runner logs the effective identity every run instead of guarding against
+  it. `AUTONOMY_BOT_PAT` (the machine account's PAT) still exists and is
+  still used by `metrics.yml` and `autonomy-identity-probe.yml` — just not by
+  this file any more.
 
 ### Kill switch
 
@@ -104,16 +144,25 @@ Step 1 of the kill switch is the repo variable **`AUTONOMY_ENABLED`**: the
 reusable runner skips every routine unless it is exactly `true`. Set it to
 `false` (or unset it) to halt the whole fleet in one action; individual roles
 can also be disabled from the Actions tab. (The full kill switch — budget, PAT
-revocation — is in `EXPERIMENT.md`.)
+revocation — is in `EXPERIMENT.md`, which as of 2026-07-12 needs to revoke
+both `AUTONOMY_BOT_PAT` and `COPILOT_TASK_API_PAT` for a hard stop.)
 
 ### Enablement runbook
 
-1. Set the `AUTONOMY_BOT_PAT` secret to the machine account's PAT.
+1. Set the `COPILOT_TASK_API_PAT` secret to a personal access token under the
+   identity routine content should be authored as (currently the
+   experimenter's own account — see "GitHub identity" above).
 2. Merge these workflows to `main` (scheduled/dispatch workflows only run from
-   the default branch). Protected-path PR → experimenter admin-merge.
-3. Run `gh workflow run autonomy-identity-probe.yml` and confirm it is green
-   (authenticates as `AUTONOMY_BOT`, write-not-admin).
+   the default branch).
+3. Manually `gh workflow run` one low-stakes role (e.g. `autonomy-librarian.yml`)
+   via `workflow_dispatch` and confirm it completes and produces correctly
+   labeled, correctly attributed output before trusting the cron cadence.
 4. Set `AUTONOMY_ENABLED=true` and record the start date in `EXPERIMENT.md`.
+
+`autonomy-identity-probe.yml` still exists and still checks `AUTONOMY_BOT_PAT`
+resolves to `will-physagent`, write-not-admin — that remains true and useful
+for the credential's other uses (`metrics.yml`), but it no longer gates
+whether the routine fleet itself can run.
 
 Note on red-team cadence: `0 8 */3 * *` is day-of-month based, so the
 interval compresses at month boundaries (e.g. the 31st → the 1st). Harmless;
@@ -131,8 +180,10 @@ non-issue during an active run).
 - **Marker comments** are HTML comments, found by prefix and edited in place:
   `<!-- quorum:verdict ... sha=... -->`, `<!-- quorum:stress-test ... sha=... -->`
   (reviewer only), `<!-- worker:attempts n=K -->`, `<!-- red-team:audit ... -->`.
-  Verdict markers are only honored by the gate when authored by the machine
-  account or the experimenter.
+  Verdict markers are honored by the gate from **any** commenter as of
+  2026-07-12 — the machine-account-only trust check was removed the same day
+  as the compute migration (an accepted, logged risk; see `AUTONOMY.md`'s
+  quorum tier bullet and the `EXPERIMENT.md` log for the reasoning).
 - **Labels** are the state machine — normative table in `AUTONOMY.md`.
 - **No routine merges manually.** GitHub auto-merge + the required-check stack
   is the only merge path.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,22 +18,43 @@ those win.
 
 | Application concept | Implementation |
 |---|---|
-| Compute / runtime | GitHub Actions runners executing headless Claude Code sessions ([`autonomy-routine.yml`](../.github/workflows/autonomy-routine.yml)) |
+| Compute / runtime | GitHub Actions runners that start and poll GitHub Copilot cloud agent tasks via the Agent Tasks REST API ([`autonomy-routine.yml`](../.github/workflows/autonomy-routine.yml)); the actual reasoning happens remotely in Copilot's own environment, not on the runner. Compute migrated 2026-07-12 from a headless Claude Code CLI session — see the mapping's Service account row and `EXPERIMENT.md` log |
 | Processes | Seven routines — durable *roles* ([`automation/routines/`](../automation/routines/)), ephemeral *invocations* (one Actions run each) |
 | Scheduler | cron triggers per role (`autonomy-<role>.yml`), with deliberate redundancy (reviewer double-fire) |
 | Event bus | GitHub events: a quorum verdict comment dispatches the responder; an agent-PR push dispatches the reviewer ([`autonomy-event-dispatch.yml`](../.github/workflows/autonomy-event-dispatch.yml)). Cron remains the guaranteed backstop |
 | State machine | The label system: `agent-ready` → claim (assignee lock) → `agent-pr` → per-SHA verdict → merged / `stuck` / `needs-human`. Transitions table in [`AUTONOMY.md`](../AUTONOMY.md) |
 | Database | Issues, PRs, and the repository tree. Durable, queryable (`gh` is the query language), transactional (a merge is a commit, in both senses) |
 | Schema | METHODOLOGY's rigor system: every result typed **Rigorous / Sketch / Conjecture**; demotions are migrations; withdrawn records are tombstones (never deleted) |
-| Authorization | Branch protection (required checks, no direct pushes) + machine-account PAT scopes (write, not admin; no `workflow` scope) + the four-tier merge-gate stack |
-| Service account | The machine account (repo variable `AUTONOMY_BOT`), asserted at runtime by an identity guard that refuses to act under any other login |
-| Policy engine | The gate stack: deterministic tier (tests, paper builds, citation existence) → semantic tier (LLM claim-support evaluator) → quorum tier (adversarial verdict markers, per-SHA) → constitutional tier (retired 2026-07-12 to a no-op; gate-workflow files remain structurally protected by PAT scope, other protected paths no longer require approval) |
+| Authorization | Branch protection (required checks, no direct pushes) + the merge-gate stack. Gate-workflow files (`.github/workflows/`) additionally require the calling PAT to lack the `workflow` scope — the one PAT-scope restriction still load-bearing after 2026-07-12 (see Identity and authority) |
+| Service account | **Changed 2026-07-12.** Originally the machine account (repo variable `AUTONOMY_BOT` = `will-physagent`, via `AUTONOMY_BOT_PAT`), asserted at runtime by an identity guard that refused to act under any other login. Copilot licenses are per-user and the machine account doesn't have one (confirmed by a live 403), so routine content is now created and authored under the experimenter's own account (`willregelmann`), via `COPILOT_TASK_API_PAT` — a deliberate, logged tradeoff, not a reversion to the 2026-06-05 failure mode (see Identity and authority for why those aren't the same thing). `AUTONOMY_BOT_PAT` still exists and is still used by `metrics.yml` and `autonomy-identity-probe.yml` |
+| Policy engine | The gate stack: deterministic tier (tests, paper builds, citation existence) → semantic tier (LLM claim-support evaluator) → quorum tier (adversarial verdict markers, per-SHA, honored from any commenter as of 2026-07-12 — no identity check left here either) → constitutional tier (retired 2026-07-12 to a no-op; gate-workflow files remain structurally protected by PAT scope, other protected paths no longer require approval). See the diagram below |
 | Feature flag / kill switch | Repo variable `AUTONOMY_ENABLED`; one flip stops the fleet. Full kill-switch runbook in `EXPERIMENT.md` |
-| Configuration | Repo variables (identity, switches) and secrets (PAT, model credentials, SMTP) |
-| Observability | [Metrics dashboard issue](https://github.com/willregelmann/self-consistency/issues/67) (weekly snapshots → `metrics/`), [Breakthrough digest issue](https://github.com/willregelmann/self-consistency/issues/87) (weekly plain-English digest), Tier-A alert emails, Actions logs as traces |
+| Configuration | Repo variables (cadence gate, model per role) and secrets: `COPILOT_TASK_API_PAT` (routine compute, willregelmann), `AUTONOMY_BOT_PAT` (metrics/identity-probe, will-physagent), `CLAUDE_CODE_OAUTH_TOKEN` (semantic-review's claim-support evaluator and the digest's significance pass — unrelated to routine compute since 2026-07-12), SMTP |
+| Observability | [Metrics dashboard issue](https://github.com/willregelmann/physagent/issues/67) (weekly snapshots → `metrics/`), [Breakthrough digest issue](https://github.com/willregelmann/physagent/issues/87) (weekly plain-English digest), Tier-A alert emails, Actions logs as traces |
 | Release process | Workflow and constitution changes are deploys: experimenter-authored PRs, admin-merged, each recorded in the `EXPERIMENT.md` log |
 | Incident log / postmortems | The same log — the 2026-06-05 identity halt, gate amendments, and instrumentation fixes are its entries |
 | Integration test | The pre-registered terminal audit: fresh agents with no project context re-verify a sample of merged Rigorous results and every citation added during the run |
+
+The gate stack, as it actually evaluates a PR today (post-2026-07-12):
+
+```mermaid
+flowchart TD
+    PR["PR opened / synchronized"] --> Det["Deterministic tier<br/>pytest, pdflatex, citation existence"]
+    Det -- fail --> Blocked1["blocked"]
+    Det -- pass --> Sem["Semantic tier<br/>claim-support LLM evaluator<br/>(diff-scoped)"]
+    Sem -- fail on touched citation --> Blocked2["blocked"]
+    Sem -- pre-existing defect --> Warn["warns, routes to a<br/>main-targeting issue"]
+    Sem -- pass --> Quorum["Quorum tier<br/>verdict marker for head SHA<br/>honored from ANY commenter"]
+    Quorum -- revise / reject --> Blocked3["blocked, responder dispatched"]
+    Quorum -- accept, promotion-rigorous --> Stress["+ independent stress-test marker required"]
+    Quorum -- accept, ordinary --> Const
+    Stress -- pass --> Const["Constitutional tier<br/>retired 2026-07-12 -- always passes"]
+    Const --> Merge["GitHub auto-merge"]
+```
+
+Two tiers no longer check identity at all (quorum's verdict trust, and the
+now-retired constitutional tier) — see **Identity and authority** below for
+what that trades away and what it doesn't.
 
 The deepest part of the mapping: **the research content is the application
 state, and the methodology is its schema.** A rigor label is a type
@@ -78,18 +99,56 @@ each step:
 
 ## Identity and authority
 
-Every agent operation authenticates as the machine account, whose PAT has
-write access but not admin and deliberately lacks the `workflow` scope —
-agents structurally cannot author changes to the gates that judge them. The
-runner asserts the effective login at startup and refuses to act on mismatch
-(the check whose absence caused the 2026-06-05 identity incident). The
-experimenter holds the complementary powers: kill switch, budget, PAT
-revocation, `needs-human` clearance, and the admin override that is the only
-deploy path for gate workflows (protected-path approval more broadly was
-retired 2026-07-12 — see `AUTONOMY.md` Amendment procedure). The event-dispatch
-fast path holds no authority at all —
-it presses, via the default workflow token, the same dispatch button the
-scheduler presses.
+This section describes two different eras honestly, because the mechanism
+changed and the reason it changed matters for reading the rest of this
+document correctly.
+
+**Through 2026-07-12:** every agent operation authenticated as the machine
+account (`will-physagent`), whose PAT had write access but not admin and
+deliberately lacked the `workflow` scope — agents structurally could not
+author changes to the gates that judge them. The runner asserted the
+effective login at startup and refused to act on mismatch — the check whose
+absence caused the 2026-06-05 identity incident (running under the
+experimenter's own admin login collapsed every authority boundary at once:
+self-approval, self-issued quorum verdicts, `gh pr merge --admin` past
+required checks).
+
+**From 2026-07-12:** routine compute moved to GitHub Copilot cloud agent
+tasks (see the mapping's Compute/runtime and Service account rows). Copilot
+licenses are per-user; the machine account doesn't have one — buying it a
+seat was considered and deferred as a cost decision. The accepted tradeoff:
+routine content is now created and authored under the experimenter's own
+account (`willregelmann`), and the runner logs that identity every run
+instead of guarding against it. **This is not the 2026-06-05 failure
+recurring** — that incident was an *unguarded accident* nobody chose; this is
+a *chosen, logged tradeoff*, made possible because the same day's
+constitutional amendments (`AUTONOMY.md` Amendment procedure) had already
+removed the two gates whose safety property depended specifically on
+machine-account-vs-experimenter separation: `constitution-guard`'s
+protected-path approval requirement (retired to a no-op) and `quorum-gate`'s
+machine-account-only verdict trust (now honors any commenter). Doing this
+compute migration *before* those amendments would have quietly reintroduced
+2026-06-05's failure mode; doing it after is a values decision about
+attribution honesty, not a security hole.
+
+```mermaid
+flowchart TD
+    subgraph RoutineCompute["Routine compute (2026-07-12+)"]
+        Routines["7 routines"] -->|COPILOT_TASK_API_PAT<br/>willregelmann| Tasks["Copilot cloud agent tasks"]
+    end
+    subgraph GateStack["Gate-stack workflows"]
+        Gates["quorum-gate, constitution-guard,<br/>semantic-review, verify-citations"] -->|default GITHUB_TOKEN| Checks["required status checks"]
+    end
+    subgraph StillMachineAccount["Still will-physagent"]
+        ABP["AUTONOMY_BOT_PAT"] --> MetricsProbe["metrics.yml,<br/>autonomy-identity-probe.yml"]
+    end
+    subgraph Experimenter["Experimenter-only (unaffected by any of this)"]
+        Exp["willregelmann, as experimenter"] -->|kill switch, PAT revocation,<br/>needs-human, gate-workflow admin-merge| GateStack
+    end
+```
+
+The event-dispatch fast path holds no authority at all — it presses, via the
+default workflow token, the same dispatch button the scheduler presses.
 
 ## Designed-for failure modes
 
@@ -100,9 +159,18 @@ actually fired at least once:
   double-fire, a responder watchdog that re-dispatches a missed review cycle,
   and the event-driven fast path, which removes the dependency on cron for
   the hot loop.
-- **Model-budget exhaustion** (session limits kill a routine mid-run): the
-  runner detects the limit message, sleeps through resets ≤90 minutes away
-  and retries once, otherwise fails loudly and defers to the next fire.
+- **Model-budget exhaustion / stuck runs** (through 2026-07-12): the
+  Claude-Code-CLI-based runner detected the session-limit message, slept
+  through resets ≤90 minutes away and retried once, otherwise failed loudly
+  and deferred to the next fire. **Since the 2026-07-12 compute migration**
+  this is unproven territory: the Agent Tasks API poll loop treats every
+  terminal state except `completed` (including `waiting_for_user`, observed
+  firsthand when a task paused for a plan-approval click nobody was present
+  to give) as a failure deferring to the next scheduled fire — a first cut,
+  flagged in the workflow's own comments as needing the same kind of
+  incremental refinement the old logic got from real 2026-06-11/06-20
+  incidents, once real Copilot-specific failure modes are observed in
+  production.
 - **Blind instrumentation** (metrics that "succeed" while reporting nothing):
   tripwire T5 halts the experiment if weekly metrics fail or go empty twice
   running; the 2026-06-12 label-count fix is the case study in why.
@@ -111,13 +179,18 @@ actually fired at least once:
   discipline is a logged open amendment.
 - **Runaway or compromised agents**: the gate stack is independent of agent
   cooperation (an unlabeled machine-account research PR *fails* rather than
-  skips quorum), protected paths require human approval, and `needs-human` is
-  a one-way halt only the experimenter clears.
+  skips quorum — though note this specific backstop keys on the PR author
+  being `will-physagent`, and post-2026-07-12 routine PRs are authored as
+  `willregelmann`, so this particular check no longer covers them; routine
+  discipline on self-labeling is what's actually carrying that weight now).
+  Gate-workflow files remain structurally unreachable regardless of PAT
+  identity (no `workflow` scope on either credential in use). `needs-human`
+  is a one-way halt only the experimenter clears.
 
 ## Watching it run
 
-- **Live queue:** [open `agent-pr` PRs](https://github.com/willregelmann/self-consistency/pulls?q=is%3Apr+is%3Aopen+label%3Aagent-pr) and [`agent-ready` issues](https://github.com/willregelmann/self-consistency/issues?q=is%3Aissue+is%3Aopen+label%3Aagent-ready)
-- **Vital signs:** [Metrics dashboard](https://github.com/willregelmann/self-consistency/issues/67) — demotion rate is the one to watch (a healthy adversarial system demotes)
-- **Plain English:** [Breakthrough digest](https://github.com/willregelmann/self-consistency/issues/87), weekly
-- **Traces:** the [Actions tab](https://github.com/willregelmann/self-consistency/actions) — every agent invocation is a public log
+- **Live queue:** [open `agent-pr` PRs](https://github.com/willregelmann/physagent/pulls?q=is%3Apr+is%3Aopen+label%3Aagent-pr) and [`agent-ready` issues](https://github.com/willregelmann/physagent/issues?q=is%3Aissue+is%3Aopen+label%3Aagent-ready)
+- **Vital signs:** [Metrics dashboard](https://github.com/willregelmann/physagent/issues/67) — demotion rate is the one to watch (a healthy adversarial system demotes)
+- **Plain English:** [Breakthrough digest](https://github.com/willregelmann/physagent/issues/87), weekly
+- **Traces:** the [Actions tab](https://github.com/willregelmann/physagent/actions) for the dispatch/poll wrapper around each run, and the repo's [Agents tab](https://github.com/willregelmann/physagent/agents) for the actual Copilot cloud agent task transcripts (2026-07-12+) — the reasoning now happens there, not in the Actions log
 - **Changelog & incidents:** the log table in [`EXPERIMENT.md`](../EXPERIMENT.md)


### PR DESCRIPTION
## Summary

`docs/ARCHITECTURE.md` and `automation/routines/README.md` still fully described the pre-2026-07-12 deployment (headless Claude Code CLI, machine-account-only identity, old model IDs, human-approval gates). Swept both files for every stale claim from today's changes (PRs #153, #155, #158) and updated them.

## What changed

**`docs/ARCHITECTURE.md`:**
- Compute/runtime, Service account, Policy engine, Authorization, Configuration mapping-table rows
- Identity and authority section rewritten to explain both eras honestly -- including *why* the compute migration is a deliberate, logged tradeoff and not a repeat of the 2026-06-05 incident (the two gates that made machine-account identity load-bearing were retired the same day, before the migration landed)
- The "runaway or compromised agents" bullet now correctly flags that the research-content backstop's author check no longer covers willregelmann-authored routine PRs
- The session-limit-retry bullet replaced with an honest accounting of the new (unproven, first-cut) Agent Tasks API failure handling
- Repo links updated from the old `self-consistency` name to `physagent`

**`automation/routines/README.md`:**
- Registration, Deployed instances, Kill switch, Enablement runbook, and Shared conventions sections all updated for the new compute path, credentials (`COPILOT_TASK_API_PAT` vs `AUTONOMY_BOT_PAT`), and model IDs (`claude-opus-4.6`, `claude-sonnet-5`)

**Both:** added Mermaid diagrams (gate stack flow, identity/credential map, dispatch flow) where prose was describing a graph of relationships that's genuinely easier to read as one.

## Self-checks

- Grepped both files for every stale reference (old compute description, old model IDs, old repo URL, stale identity claims) after editing -- clean
- Mermaid fence balance verified (no orphaned code blocks)
- Documentation only, no functional change -- not logged in `EXPERIMENT.md` (a doc sync isn't an amendment, incident, or design decision)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QY1ecJtHBGCq3JM9PNNtu3