### PR TITLE
Metrics snapshot 2026-W29

### DIFF
--- a/metrics/2026-W29.json
+++ b/metrics/2026-W29.json
@@ -1,0 +1,30 @@
+{
+  "week": "2026-W29",
+  "date": "2026-07-13",
+  "throughput": {
+    "merged_agent_total": 27,
+    "merged_agent_week": 4,
+    "open_awaiting_quorum": 1
+  },
+  "corrections": {
+    "demotions_merged": 5,
+    "withdrawals_merged": 0,
+    "promotions_merged": 1,
+    "demotion_rate": 0.18518518518518517
+  },
+  "queue": {
+    "agent_ready": 1,
+    "stuck": 0,
+    "needs_human": 1
+  },
+  "proposals": {
+    "open": 3,
+    "filed_week": 0,
+    "closed_week": 0
+  },
+  "rigor_distribution": {
+    "rigorous": 6,
+    "sketch": 15,
+    "conjecture": 2
+  }
+}


### PR DESCRIPTION
Automated weekly metrics snapshot (metrics.yml). Not an agent research PR; quorum-exempt by design.