### PR TITLE
Add autonomy-explorer.yml scheduled caller

### DIFF
--- a/.github/workflows/autonomy-explorer.yml
+++ b/.github/workflows/autonomy-explorer.yml
@@ -1,0 +1,41 @@
+name: autonomy-explorer
+
+# Scheduled caller for the explorer routine (automation/routines/explorer.md).
+# Cadence: biweekly (every two weeks). Cron has no native "every N weeks"
+# primitive, so this fires weekly (Mondays 04:00 UTC) and gates on ISO week
+# parity in a pre-step -- odd weeks are a no-op, even weeks call the reusable
+# runner exactly like every other role. workflow_dispatch always runs,
+# bypassing the parity gate, for manual testing of a single fire.
+#
+# The reusable runner gates on AUTONOMY_ENABLED and handles the Copilot Agent
+# Tasks API dispatch identically to every other role (see autonomy-routine.yml
+# and automation/routines/README.md's "Compute migration" note).
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  week-check:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.parity.outputs.run }}
+    steps:
+      - id: parity
+        run: |
+          WEEK=$(date -u +%V)
+          if [ $(( 10#$WEEK % 2 )) -eq 0 ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  explorer:
+    needs: week-check
+    if: needs.week-check.outputs.run == 'true'
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: explorer
+      model: ${{ vars.MODEL_EXPLORER || 'claude-opus-4.6' }}
+    secrets: inherit

--- a/automation/routines/README.md
+++ b/automation/routines/README.md
@@ -97,46 +97,16 @@ drifts from the workflow files, this file is wrong — fix it.
 | red-team | `autonomy-red-team.yml` | `0 8 */3 * *` | claude-opus-4.6 |
 | scout | `autonomy-scout.yml` | `0 3 * * 1` | claude-sonnet-5 |
 | librarian | `autonomy-librarian.yml` | `0 3 * * 2` | claude-sonnet-5 |
-| explorer | `autonomy-explorer.yml` (**drafted, not merged**) | `0 4 * * 1` + even-ISO-week gate (see draft) | claude-opus-4.6 |
+| explorer | `autonomy-explorer.yml` (**PR open, pending admin-merge**) | `0 4 * * 1` + even-ISO-week gate | claude-opus-4.6 |
 | governor | `autonomy-governor.yml` | `0 5 * * 0` | claude-opus-4.6 |
 
-`autonomy-explorer.yml` doesn't exist in `.github/workflows/` yet — cron has
-no native "every two weeks" primitive, so the draft fires weekly and gates on
-ISO week parity in a pre-step. Draft, for the experimenter to review and
-admin-merge:
-
-```yaml
-name: autonomy-explorer
-
-on:
-  schedule:
-    - cron: "0 4 * * 1"  # Mondays 04:00 UTC; see week-parity gate below
-  workflow_dispatch:
-
-jobs:
-  week-check:
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ steps.parity.outputs.run }}
-    steps:
-      - id: parity
-        run: |
-          WEEK=$(date -u +%V)
-          if [ $(( 10#$WEEK % 2 )) -eq 0 ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  run:
-    needs: week-check
-    if: needs.week-check.outputs.run == 'true'
-    uses: ./.github/workflows/autonomy-routine.yml
-    with:
-      role: explorer
-      model: ${{ vars.MODEL_EXPLORER || 'claude-opus-4.6' }}
-    secrets: inherit
-```
+`autonomy-explorer.yml` exists on a PR, not yet on `main` — cron has no
+native "every two weeks" primitive, so it fires weekly (Mondays 04:00 UTC)
+and gates on ISO week parity in a pre-step (odd weeks no-op;
+`workflow_dispatch` always runs). Gate-workflow files are the one exception
+to every other protected-path amendment in this experiment: they still need
+the experimenter's own admin-merge (`gh pr merge --admin`), recorded in the
+`EXPERIMENT.md` log like every other `.github/workflows/` change.
 
 Model IDs for the Agent Tasks API do not match the old Claude Code CLI's IDs
 (confirmed by direct testing: `claude-opus-4-8` 400s — "model not found";


### PR DESCRIPTION
## Summary

Wires the `explorer` routine (merged to `main` directly, per `EXPERIMENT.md`'s 2026-07-18 log entry) to an actual GitHub Actions cron, using the same `autonomy-routine.yml` reusable-runner pattern as every other role's caller (`autonomy-librarian.yml` used as the template).

- Cadence: biweekly. Cron has no native "every N weeks" primitive, so the workflow fires weekly (Mondays 04:00 UTC) and gates on ISO week parity in a `week-check` job -- odd weeks no-op, even weeks call the reusable runner. `workflow_dispatch` always runs, bypassing the parity gate, for manual single-fire testing.
- Model: `${{ vars.MODEL_EXPLORER || 'claude-opus-4.6' }}`, same per-role-variable pattern as every other caller.
- Updated `automation/routines/README.md`'s registry and deployed-instances tables to point at this PR instead of embedding a duplicate inline draft.

## Why this is a PR, not a direct commit

This is a `.github/workflows/` file. Per `AUTONOMY.md`, every other protected path in this repo no longer requires the experimenter's approving review to merge (the 2026-07-12 full-autonomy amendment) -- but gate-workflow files are the one explicit exception, "structurally unreachable by the machine account" and, for interactive-session changes, left for the experimenter's own admin-merge rather than committed directly. I'm opening this PR and stopping there; merging it (`gh pr merge --admin`, since it'll sit behind the same required-status-checks that a `.github/workflows/` diff triggers) is yours to do.

## Self-checks

- Structurally identical to the six existing `autonomy-<role>.yml` callers (checked `autonomy-librarian.yml` directly for the `uses:`/`with:`/`secrets: inherit` interface).
- No change to `autonomy-routine.yml` itself or any other existing workflow.
- The week-parity gate is a plain shell arithmetic check (`10#$WEEK % 2`), no external dependency; `workflow_dispatch` bypasses it entirely so a manual test doesn't have to wait for an even week.

## Once merged

Per `EXPERIMENT.md`'s log-entry convention, worth its own log line recording that the explorer routine went live and the date, same as every other gate-workflow merge in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)