### PR TITLE
Correct melo_dissipative citation attribution (GGD dDP discrimination section)

### DIFF
--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -635,9 +635,11 @@ toward a finite asymptotic value associated with a noise ``temperature''
 $T$~\cite{ddp_model}. In the zero-friction limit ($T\to\infty$) the dDP master equation
 reduces to standard DP, recovering the exponential coherence decay
 $|\rho_{LR}^{\text{exp}}| = e^{-t/\tau_{DP}}$ of eq.~\eqref{eq:corr_diosi}. The
-discrimination question raised by~\cite{melo_dissipative} is whether the friction deforms
+discrimination question this section asks is whether the friction deforms
 that exponential enough to mimic---or be confused with---the Gaussian profile of
-eq.~\eqref{eq:tau_coh} at the sensitivities of \S\ref{sec:predictions}.
+eq.~\eqref{eq:tau_coh} at the sensitivities of \S\ref{sec:predictions}, assessed below
+against the dDP model's own non-Gaussian phase-space signature, characterized
+by~\cite{melo_dissipative}.
 
 It does not, at currently proposed platforms. The distinctive dDP signatures are
 phase-space effects, not coherence-profile effects: the friction drives the reduced state


### PR DESCRIPTION
## Summary

Fixes a real citation misattribution in `programs/gaussian-gravitational-decoherence/index.tex` §"Discrimination from the dissipative Diósi–Penrose model", found by the new `melo_dissipative` claim-support assertion added while hardening this program's citation-gate coverage (previously untested — see PR #170).

**The defect:** the paper stated "the discrimination question raised by [melo_dissipative] is whether the friction deforms that exponential enough to mimic ... the Gaussian profile of eq. (tau_coh)" -- attributing the comparison-against-this-paper's-own-Gaussian-result question to the cited source. Verified independently by direct fetch of the abstract (arXiv:2606.06259, "Non-equilibrium thermodynamics of collapse models in the strongly non-Gaussian regime"): the paper's scope is the dDP model's own non-equilibrium steady-state thermodynamics. It doesn't compare against a Gaussian decoherence profile from a separate framework -- and couldn't, since that profile is this GGD paper's own result, not something the cited source could reference.

**What's NOT wrong:** the section's other two citations of this source (characterizing the dDP model's non-Gaussian phase-space/momentum-sector signature, in this same section and in §"Material-dependent profile transition") are accurate and unchanged. This is an attribution error about *who poses the question*, not a technical error about *what the source establishes*.

## Fix

Reworded the one sentence: the discrimination question is now attributed to this section's own analysis; `melo_dissipative` is credited only for the phase-space characterization it actually supplies (used to assess the question, not to have raised it). No equation, coefficient, or numeric result changes. The section's existing **(Sketch)** label is unaffected -- this was never a rigor-level claim, just a misattributed framing sentence.

## Self-checks

- **Citation verification:** independently re-fetched the source's abstract directly (not relying solely on the claim-support evaluator's judgment) before drafting the correction.
- **Consistency:** checked whether any other result in the paper used this specific attribution as a lemma -- none does; the section's "Consequence" paragraph (the three-way-collapses-to-two-way discrimination conclusion) depends only on the correctly-cited technical characterization, not on who posed the question.
- **Scope:** single sentence, no other content touched. `git log -S` confirms the sentence was introduced by PR #105 (GGD-2, merged 2026-06-15) and never previously reviewed for claim-support (this program had zero claim-support coverage until PR #170).

## Per METHODOLOGY's citation-failure-recovery protocol

1. This correction PR.
2. Commented on issue #92 (the `informs-issue` pointer this citation originated from) -- see the issue for the full writeup.
3. Checked for other results depending on this citation as a lemma (none, per Self-checks above).

## Note

`programs/gaussian-gravitational-decoherence/index.tex` also has an open, unmerged PR (#141, GGD-1) touching a different subsection of the same file (§"Material-dependent profile transition"). This PR only touches §"Discrimination from the dissipative Diósi–Penrose model" (lines 635-641) -- no expected overlap, but flagging in case of a rebase conflict when #141 eventually lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)