### PR TITLE
Correct two citation-attribution defects (GGD/co-emergence)

### DIFF
--- a/programs/co-emergence/index.tex
+++ b/programs/co-emergence/index.tex
@@ -1961,8 +1961,8 @@ foundations---the relationships between mass, signature, time, and
 Hilbert space---in a way that may point toward new physics at Planck-scale
 energies. Level~1 corrections (the smooth-structure sum beyond the
 single-metric approximation) are suppressed by powers of $\ell_P$ and
-invisible at any accessible scale. The companion
-paper~\cite{fixed_point} identifies specific predictions (gravitational
+invisible at any accessible scale. A companion
+paper~\cite{ggd} identifies specific predictions (gravitational
 decoherence timescales) that arise from the Level~2 fixed point; these
 are predictions of semiclassical gravity, not of the full hierarchy.
 
@@ -2044,6 +2044,12 @@ in differential geometry.
 \bibitem{fixed_point}
 W.~Regelmann and Claude (Anthropic),
 ``Fixed-point existence of self-consistent semiclassical gravity,''
+companion paper (2026).
+
+\bibitem{ggd}
+W.~Regelmann and Claude (Anthropic),
+``Gaussian temporal profile of gravitational decoherence from the
+Einstein-Langevin equation,''
 companion paper (2026).
 
 \bibitem{dewitt}

--- a/programs/gaussian-gravitational-decoherence/index.tex
+++ b/programs/gaussian-gravitational-decoherence/index.tex
@@ -854,9 +854,14 @@ dependence.
 
 \textbf{Companion paper.} The semiclassical Einstein equation underlying the
 Einstein-Langevin formalism is itself a fixed-point condition: geometry and quantum state
-must be mutually self-consistent. The existence of self-consistent solutions---established
-exactly for the Starobinsky inflation model and conditionally in general via the Schauder
-fixed-point theorem---is treated in a companion paper~\cite{fixed_point}.
+must be mutually self-consistent. The existence of self-consistent solutions is treated in a
+companion paper~\cite{fixed_point}, exactly for the Starobinsky inflation model and
+conditionally, via the Schauder fixed-point theorem, on backgrounds admitting a compact
+Cauchy surface. Neither of those results covers the asymptotically-flat, weak-field
+background this paper works on; the present calculation instead relies only on the
+unconditional classical existence of a Newtonian potential for a bounded mass distribution
+and on the well-posedness of the linear, flat-space wave equation, both independent of the
+companion paper's fixed-point program.
 
 %======================================================================
 \begin{thebibliography}{99}

--- a/tools/citation-allowlist.yml
+++ b/tools/citation-allowlist.yml
@@ -7,6 +7,7 @@
 # letting the API resolve a reference over adding an exception.
 
 fixed_point: Internal companion paper in this repository; not published, so no DOI/arXiv record exists.
+ggd: Internal companion paper in this repository (gaussian-gravitational-decoherence); not published, so no DOI/arXiv record exists.
 
 # Books -- no DOI; title-only search does not reliably resolve monographs.
 hawking_ellis: "Hawking & Ellis, The Large Scale Structure of Space-Time (CUP, 1973). Monograph, no DOI."


### PR DESCRIPTION
## Summary

Two citation-precision corrections found by `explorer/2026-07-19-ggd-m3-synthesis` (PR #173), independent of that exploration's main technical question.

1. **`gaussian-gravitational-decoherence/index.tex`** — the Discussion's "Companion paper" note credited `fixed-point-existence`'s Banach/Schauder theorems with treating existence for GGD's own regime. Both theorems explicitly require a compact Cauchy surface and explicitly state they don't cover Minkowski/asymptotically-flat backgrounds (`fixed-point-existence/index.tex` L766-771) — exactly GGD's regime. Reworded to disclose the scope mismatch and state precisely what GGD's derivation actually relies on instead (classical Newtonian-potential existence; linear wave-equation well-posedness — both independent of FPE's fixed-point program).
2. **`co-emergence/index.tex`** — cited `fixed_point` (the FPE companion paper) for "gravitational decoherence timescales," but FPE never derives a decoherence timescale anywhere in its text; that's GGD's own result. co-emergence had no bibliography entry for GGD at all. Added one (`ggd`, allowlisted the same way as `fixed_point` — internal companion paper, no DOI/arXiv record) and corrected the citation.

## Self-checks

- Both source passages independently re-read and verified directly (not taken on the exploration's characterization alone) before drafting either fix.
- Neither correction changes a numeric result, a coefficient, or a rigor label in either paper.
- New `ggd` bibitem added to `tools/citation-allowlist.yml` with the same justification pattern as the existing `fixed_point` entry.
- No open issue was found depending on either citation specifically (both defects were found fresh by the exploration, not from a pre-existing tracked pointer), so no additional issue comments are needed per METHODOLOGY's citation-failure-recovery protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)