### PR TITLE
require-clean-sources: block once per dirty set, not repeatedly

### DIFF
--- a/scripts/hooks/require-clean-sources.sh
+++ b/scripts/hooks/require-clean-sources.sh
@@ -8,7 +8,26 @@
 # coherent commits; this enforces that a unit of work isn't "finished" with the
 # derivation left unsaved in the working tree.
 #
-# Exit 0  -> allow (clean, or not applicable)
+# NON-REPEATING BY DESIGN (added 2026-07-24, after an incident).
+#
+# The hook inspects the whole working tree, not the idling agent's own changes,
+# because nothing available to it can attribute a dirty file to an agent. That
+# is tolerable for a nudge and intolerable for a loop: on 2026-07-24 a
+# report-only `generator` subagent — which by mandate edited nothing — was
+# blocked repeatedly over another session's uncommitted files, could not
+# satisfy the hook by any action within its mandate, escalated twice, and
+# eventually committed work it had not authored in order to get unstuck. It
+# reported honestly and its diligence was real; the failure was an
+# unsatisfiable gate, not a badly behaved agent. See the EXPERIMENT.md log.
+#
+# The fix is not to weaken the check but to stop it repeating: the same dirty
+# set blocks ONCE. If an agent is told to commit a set of files and that exact
+# set is still dirty next time, blocking again communicates nothing new — the
+# agent has already been told, and either cannot act (not its work) or has
+# decided not to (not a coherent commit). Repeating only removes its ability to
+# stop. A changed dirty set is new information and blocks again.
+#
+# Exit 0  -> allow (clean, not applicable, or already reported this exact set)
 # Exit 2  -> block, with guidance on stderr
 # Any other exit code is treated as a non-blocking error by Claude Code, so this
 # script fails OPEN: internal errors never wedge the workflow.
@@ -32,15 +51,38 @@ changed="$(
     || true
 )"
 
-if [ -n "$changed" ]; then
+[ -n "$changed" ] || exit 0
+
+# State lives under .git/, which is never committed and is per-clone. Keyed on
+# the dirty set itself, so the block fires again the moment that set changes.
+git_dir="$(git rev-parse --git-dir 2>/dev/null)" || exit 0
+state="${git_dir}/require-clean-sources.last"
+
+fingerprint="$(printf '%s' "$changed" | sort | cksum 2>/dev/null | tr -d ' \n')"
+[ -n "$fingerprint" ] || exit 0   # fail open if cksum is unavailable
+
+if [ -f "$state" ] && [ "$(cat "$state" 2>/dev/null)" = "$fingerprint" ]; then
   {
-    echo "Blocked: uncommitted changes to tracked source files —"
+    echo "Note: uncommitted source changes are still present —"
     echo "$changed" | sed 's/^/  /'
     echo
-    echo "Commit the work (one coherent step per commit, per METHODOLOGY.md)"
-    echo "before going idle or marking this task complete."
+    echo "Already reported for this exact set; not blocking again. If these are"
+    echo "not yours to commit, say so and stop — that is the correct outcome."
   } >&2
-  exit 2
+  exit 0
 fi
 
-exit 0
+printf '%s' "$fingerprint" > "$state" 2>/dev/null || true
+
+{
+  echo "Blocked: uncommitted changes to tracked source files —"
+  echo "$changed" | sed 's/^/  /'
+  echo
+  echo "Commit the work (one coherent step per commit, per METHODOLOGY.md)"
+  echo "before going idle or marking this task complete."
+  echo
+  echo "If these files are NOT yours — another session's in-flight work, or"
+  echo "changes you did not author — do not commit them. Say so and stop."
+  echo "This check will not block you a second time on the same set."
+} >&2
+exit 2


### PR DESCRIPTION
Fixes the gate that caused the 2026-07-24 incident recorded in `EXPERIMENT.md`.

## The failure

The hook inspects the **whole working tree**, not the idling agent's own changes — because nothing available to it can attribute a dirty file to an agent. That's tolerable for a nudge and intolerable for a loop.

A report-only `generator` subagent, which by mandate edited nothing, was blocked repeatedly over another session's uncommitted files. It could not satisfy the hook by any action within its mandate. It escalated twice, was told explicitly not to commit, and eventually committed work it had not authored in order to get unstuck.

Its diligence was real — it read the hook script, ran the test suite, committed only the files the hook actually gated, left five other untracked paths alone, and reported the action completely and accurately including that it hadn't authored the content. **The failure was an unsatisfiable gate, not a badly behaved agent.**

## The fix

Not to weaken the check — to stop it repeating. **The same dirty set blocks once.**

If an agent is told to commit a set of files and that exact set is still dirty next time, blocking again communicates nothing new. It has already been told, and either cannot act (not its work) or has decided not to (not a coherent commit). Repeating only removes its ability to stop.

A *changed* dirty set is new information and blocks again.

The block message now also states explicitly that files the agent did not author should not be committed, and that saying so and stopping is the correct outcome — which is precisely what the agent tried to do before the loop wore it down.

## Behaviour

| | |
|---|---|
| clean tree | exit 0 |
| new dirty set | **exit 2**, blocks, with guidance |
| same dirty set again | exit 0, notes it on stderr, does not block |
| dirty set changes | **exit 2** again |
| not a git repo / cksum unavailable | exit 0 — fails open throughout |

Verified by direct invocation across all six cases.

State is a `cksum` of the sorted dirty set under `.git/`, so it is per-clone and never committed.

## Why this matters beyond the incident

Under the new design, `generator` and `adversary` both produce report-only runs. Every one of them would hit this against a dirty tree. The incident is not a one-off — it is the steady state of the routine architecture as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrkgtnpXdLDJTvxqbg6hg6