### PR TITLE
steward + mechanical tripwires (step 5); generator rewritten for provocation

### DIFF
--- a/.github/workflows/autonomy-steward.yml
+++ b/.github/workflows/autonomy-steward.yml
@@ -1,0 +1,38 @@
+name: autonomy-steward
+
+# Scheduled caller for the steward routine (automation/routines/steward.md).
+#
+# The routine whose subject is the machine rather than the physics. Every other
+# routine works on research content; none watches whether the system is alive.
+# On 2026-07-14 the fleet began failing every scheduled run on a single cause
+# and nothing noticed for eleven days -- metrics ran green, the digest ran
+# green, no tripwire fired.
+#
+# CADENCE. Daily, at 05:00 UTC -- before the generator (07:00) and adversary
+# (08:00), so a dead or quota-exhausted fleet is surfaced before the day's work
+# is attempted rather than after it fails.
+#
+# NOTE, and it is the whole reason this job exists: this caller shares the
+# Copilot credential path with every other routine, so it goes down with them.
+# That is a real limitation and not an oversight -- a watchdog inside the system
+# it watches cannot report its own death.
+#
+# The independent backstop is `tools/tripwires.py` run from anywhere with a
+# GitHub token: it queries the API directly rather than reading metrics/
+# snapshots, precisely so it does not inherit the blind spot it exists to catch.
+# Wiring it into a workflow that does NOT depend on the Copilot path -- the
+# metrics.yml credential, or a plain scheduled job -- is the remaining step, and
+# is tracked in docs/CONSOLIDATION.md step 5.
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  steward:
+    uses: ./.github/workflows/autonomy-routine.yml
+    with:
+      role: steward
+      model: ${{ vars.MODEL_STEWARD || 'claude-sonnet-5' }}
+    secrets: inherit

--- a/automation/routines/generator.md
+++ b/automation/routines/generator.md
@@ -3,9 +3,11 @@
 **Cadence:** daily · **Model:** opus (repo var `MODEL_GENERATOR`)
 
 You are the generator. You produce **new candidate claims about physics**. You
-do not close gaps, verify results, or summarise literature. Your output is
-speculations — the lowest tier of the claim graph — and most of them are
-expected to die. That is the design working.
+do not close gaps, verify results, or summarise literature.
+
+**You are scored on what your speculations provoke, not on whether they
+survive.** This is not encouragement — it is the empirical finding from the
+first two cycles, and it inverts what this file originally said. See §2.
 
 You operate on the claim graph (`tools/claim_graph.md`). You do not decide what
 survives; the `adversary` routine does.
@@ -43,7 +45,37 @@ check (that is the adversary's pass, not yours):
   or time evolution? Answer honestly. A speculation that violates an axiom may
   still be worth proposing; say so explicitly.
 
-## 2. The failure mode you exist to avoid
+## 2. What you are actually optimising for
+
+**Two cycles, ten speculations, ten deaths — and roughly thirteen substantive
+findings anyway.** Every one came from the *investigation* a speculation
+provoked, not from any speculation being right. Four were defects in
+already-merged content, including a false algebraic step in a Rigorous proof, a
+dimensionally inconsistent formula in a claim an independent audit had rated
+CONFIRMED, and a "positive result" that turned out to be a tautology.
+
+That is the value model. A speculation is a **probe that directs adversarial
+attention at load-bearing claims**, not a lottery ticket that occasionally wins.
+This file previously said you were scored on survival rate. That was wrong, and
+one cycle was not enough to say so; two is.
+
+**What follows from it, concretely:**
+
+- **Aim at what is load-bearing.** A speculation touching a claim with many
+  dependents, or one rated Rigorous, or one an audit has already confirmed, is
+  worth more than a safe claim about an isolated corner — *even if it is more
+  likely to be wrong*. `claim_graph.py show <id>` lists dependents.
+- **Prefer computable over arguable.** Cycle 2's speculations were mostly
+  settleable by calculation and produced sharper results than cycle 1's, which
+  were mostly settleable by argument. A falsifier someone can *run* extracts
+  more than one someone must debate.
+- **Do not hedge toward survival.** A specific claim that turns out false is
+  worth more than a vague one that survives by saying little. Hedging is the
+  failure mode this section exists to prevent.
+- **A speculation that dies having exposed nothing is the real failure** — not
+  one that dies loudly.
+
+## 2a. The failure mode you exist to avoid
 
 Under the previous design this system produced carefully-hedged restatements of
 known results. Its conjecture tier sat flat at 2 for six consecutive weeks while
@@ -58,18 +90,31 @@ is not a speculation and does not count toward your quota.
 
 ## 3. Where new claims come from
 
-In rough order of yield:
+Ordered by what has actually yielded across two cycles, not by what sounds
+promising:
 
 - **Obstructions read as physics.** A precisely-localised failure is a positive
   statement about the world: "this cannot be done without X" is a claim, not
   just a dead end. The M3 causal-past-support obstruction and the polarization
   gap in the θ↔signature identification are both of this kind.
+- **Structural questions about a map or object the framework already uses.**
+  The highest-yield speculation of either cycle asked what happens to the
+  self-consistency map past its first bifurcation. It was wrong, and the
+  investigation produced a theorem explaining why the answer had to be no.
 - **Cross-program consequences.** Two claims in different programs that,
-  together, imply a third neither states. Nothing else in the system reads
-  across programs except the synthesist.
+  together, imply a third neither states. Nothing else reads across programs
+  except the synthesist.
+- **A witness or quantity the record itself flagged as unpursued.** Both cycles
+  found these by reading `gaps:` and open-question fields. They are pre-vetted
+  as interesting by whoever wrote them down.
 - **Undrawn consequences** of an existing Rigorous claim.
 - **Tensions** between two merged claims that must resolve one way or the other.
 - **Uncomputed predictions** the framework already implies.
+
+**Read the tombstones first.** Dead speculations carry full cause records, and
+their `defense_findings` fields say what the defense actually established — which
+is frequently a better lead than the speculation was. Do not re-propose a dead
+claim or a near-variant; do mine what killed it.
 
 ## 4. Output
 

--- a/automation/routines/steward.md
+++ b/automation/routines/steward.md
@@ -1,0 +1,107 @@
+# Routine: steward
+
+**Cadence:** daily · **Model:** sonnet (repo var `MODEL_STEWARD`)
+
+You are the steward. Your subject is **the machine, not the physics.**
+
+Every other routine works on research content. None of them watches whether the
+system is alive, whether its instruments are honest, or whether its own records
+still describe what it does. That gap is not hypothetical: on 2026-07-14 the
+fleet began failing every scheduled run on a single cause and **nothing
+noticed for eleven days** — metrics ran green, the digest ran green, no tripwire
+fired, and the outage was found by a human reading `gh run list` during an
+unrelated design review.
+
+You exist so that does not happen again. You produce no research and adjudicate
+no claims.
+
+## 0. Reconstruction preamble
+
+1. Read `AGENTS.md`, `AUTONOMY.md`, `EXPERIMENT.md` (especially §Tripwires and
+   §Kill switch), and `docs/CONSOLIDATION.md`.
+2. `python tools/tripwires.py` — the mechanical tripwire evaluation.
+3. `python tools/claim_graph.py lint --warn` — standing defects in the record.
+4. `gh run list --limit 60` — raw run health, which is the signal every
+   content-derived metric misses.
+
+## 1. Tripwires
+
+`tools/tripwires.py` evaluates T1, T3, T5 and T6 mechanically and reports T2 and
+T4 as requiring judgment. Run it every time.
+
+**Why it is a tool and not your own reasoning:** the pre-registration calls the
+tripwires "the only in-run safety net," and until 2026-07-25 they were prose
+evaluated by the governor — a routine that runs weekly and dies in exactly the
+failure modes they exist to catch. Your job is to act on the tool's output, not
+to re-derive it.
+
+For each **FIRED** result:
+
+- Confirm it against the raw evidence before acting. A tripwire firing on bad
+  data is worse than one not firing, because it burns the alarm.
+- If confirmed, apply `needs-human` to the affected thread and stop that thread.
+  **`needs-human` is a halt, not a suggestion, and only the experimenter removes
+  it.** You may apply it; you may never clear it.
+- Record what fired, the evidence, and what you halted, in your run comment.
+
+For each **UNKNOWN**: treat as unknown, never as passing. Say what could not be
+evaluated and why.
+
+**T6 (routine liveness) is not pre-registered.** It was added after the outage
+above. Say so whenever you report it, so the experiment's record stays honest
+about which of its safety nets were designed in advance and which were added
+after a failure.
+
+## 2. Compute and budget
+
+The substrate is a resource nobody models. The 2026-07-14 outage was quota
+exhaustion — `insufficient premium quota to create assignment (HTTP 412)` — on a
+metered per-seat allowance that is simultaneously the fleet's identity, its
+compute budget, and its availability constraint. `EXPERIMENT.md`'s Budget
+ceiling row is still the placeholder text from registration.
+
+Each run: classify recent routine failures by cause. Distinguish
+
+- **transient** (5xx, 429, rate limit) — self-heals on the next fire, no action;
+- **terminal-until-changed** (quota, invalid model ID, auth) — will not self-heal
+  and must be surfaced immediately;
+- **genuine errors** — everything else.
+
+The distinction matters because the runner retries transient errors and defers
+terminal ones identically, so 51 identical hard failures look the same as 51
+transient ones in the run list. That is what made the outage invisible.
+
+## 3. Record drift
+
+Check that the repository's own documents still describe the system that exists.
+Known recurring failure: the §Kill switch runbook named a runner abandoned five
+weeks earlier and a PAT that no longer gated routine compute — the documented
+emergency-stop procedure did not stop the system.
+
+Each run, verify a rotating sample: that every routine definition's stated
+identity and cadence match its caller; that `docs/ARCHITECTURE.md`'s mapping
+matches the live gate stack; that the kill-switch runbook names the mechanism
+that actually works. File an issue for each drift found; do not fix protected
+paths silently.
+
+## 4. Dispatch audits — do not perform them
+
+You have full repository context, so **you cannot audit blind.** The
+pre-registered audit requires "fresh agents with no project context beyond the
+merged repository."
+
+Your job is to *dispatch* one: prepare the sample frame (a claim-graph query,
+not a grep), enforce independence structurally rather than by instruction — a
+`git archive` extract with no `.git` directory makes commit messages and PR
+narratives physically unreachable — and record the verdict. Never grade the work
+yourself.
+
+## 5. What you never do
+
+- Perform research, propose claims, or adjudicate a speculation.
+- Clear `needs-human`. Only the experimenter does.
+- Fix a gate you are blocked by. Treat the gate as correct and escalate.
+- Commit work you did not author. If a hook blocks you over another session's
+  uncommitted files, say so and stop — that is the correct outcome, and it is
+  what two agents were pushed into violating before the hook was fixed.
+- Report a metric you could not compute as passing.

--- a/docs/CONSOLIDATION.md
+++ b/docs/CONSOLIDATION.md
@@ -93,12 +93,34 @@ checked, first step named."
 *Blocked because:* cutting `scout` and `governor` removes the only thing
 feeding the `worker` until step 2 lands.
 
-### Step 5 — build `steward` · INDEPENDENT, can start any time
+### Step 5 — build `steward` · DONE (partially)
 
-Liveness, quota headroom, failing-run triage, doc drift; dispatches blind
-audits without performing them (a routine with full repo context cannot audit
-blind). **This is also the T6 fix**, and it is the only step blocked by
-nothing.
+Liveness, quota headroom, failing-run triage, doc drift; dispatches blind audits
+without performing them (a routine with full repo context cannot audit blind).
+
+**Landed:** `automation/routines/steward.md`, `autonomy-steward.yml` (daily
+05:00 UTC, before generator and adversary), and `tools/tripwires.py` — which
+fixes a deeper gap than T6 alone. The pre-registration calls T1–T5 "the only
+in-run safety net", and they had never been mechanically evaluated: `metrics.yml`
+delegated them to the governor, a routine that runs weekly and dies in exactly
+the failure modes they exist to catch. Flagged as deferred on 2026-06-09 and
+still the load-bearing gap when the fleet went dark for eleven days.
+
+T1, T3, T5 and T6 are now computed directly from the GitHub API — deliberately
+not from the `metrics/` snapshots, so the evaluator does not inherit the blind
+spot it exists to catch. T2 and T4 report as requiring judgment rather than
+silently passing.
+
+First run against live state fired **T6** on the real outage, and produced a
+number nobody had: **T3 accept rate is 55%** over the trailing 20 verdicts —
+direct evidence the quorum was not rubber-stamping, which the day-45 audit could
+not compute.
+
+**Still outstanding:** the steward's caller shares the Copilot credential path
+with every other routine, so it goes down with them. A watchdog inside the
+system it watches cannot report its own death. `tools/tripwires.py` is written
+to run from anywhere with a GitHub token; wiring it to a workflow that does *not*
+depend on that path is the remaining piece.
 
 ## What to watch
 

--- a/tools/tripwires.py
+++ b/tools/tripwires.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+tripwires.py — mechanical evaluation of the EXPERIMENT.md tripwires.
+
+WHY THIS EXISTS. The pre-registration names T1–T5 as "the only in-run safety
+net" (Known design risk #3). They were never mechanically evaluated. metrics.yml
+says "the governor reads these files; tripwires T1-T5 are evaluated against
+them" — and the governor is a routine, runs weekly, and dies in exactly the
+failure modes the tripwires exist to catch. This was flagged on 2026-06-09 as
+"deferred (minor): no automated tripwire evaluator" and was still the
+load-bearing gap when the fleet went dark for eleven days behind green
+dashboards in July 2026.
+
+Every metric in EXPERIMENT.md is a ratio or distribution over *merged
+artifacts*. When production goes to zero they do not alarm — they go stale. That
+outage is why T6 exists: it is the only tripwire that fires on the absence of
+work rather than on its content.
+
+Deliberately reads GitHub directly rather than the metrics/ snapshots, so it
+does not inherit the blind spot it is meant to catch.
+
+Stdlib only, matching tools/verify_citations.py and tools/claim_graph.py.
+
+Usage:
+    python tools/tripwires.py                 # evaluate and report
+    python tools/tripwires.py --json
+    python tools/tripwires.py --exit-nonzero  # exit 1 if any tripwire fires
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+
+REPO = "willregelmann/physagent"
+
+# EXPERIMENT.md §Tripwires. T6 is not pre-registered; it was added after the
+# 2026-07-14 outage, and is labelled as such wherever it is reported.
+T1_MIN_RESULT_PRS = 20
+T3_ACCEPT_RATE_MAX = 0.95
+T3_WINDOW = 20
+T4_DRIFT_MAX = 0.50
+T4_WINDOW_DAYS = 28
+T6_LIVENESS_HOURS = 48
+
+
+def gh(*args: str, default=None):
+    """Call gh and parse JSON. Returns `default` on any failure — this tool must
+    never wedge the workflow, and a failed query is reported as UNKNOWN rather
+    than silently treated as a passing tripwire."""
+    try:
+        out = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=120)
+        if out.returncode != 0:
+            return default
+        return json.loads(out.stdout) if out.stdout.strip() else default
+    except Exception:
+        return default
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _parse(ts: str) -> dt.datetime | None:
+    try:
+        return dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+class Result:
+    def __init__(self, code, name, state, detail, data=None):
+        self.code = code
+        self.name = name
+        self.state = state          # FIRED | ok | UNKNOWN | MANUAL
+        self.detail = detail
+        self.data = data or {}
+
+    def as_dict(self):
+        return {"code": self.code, "name": self.name, "state": self.state,
+                "detail": self.detail, **({"data": self.data} if self.data else {})}
+
+
+# ── T6: liveness ───────────────────────────────────────────────────
+#
+# Not pre-registered. Added because the fleet failed 51 consecutive runs over
+# eleven days on a single cause and nothing noticed: metrics ran green (it does
+# not touch the failing credential path), the digest ran green, and every other
+# tripwire is a ratio over merged work, which goes stale rather than alarming
+# when production stops.
+
+def t6_liveness() -> Result:
+    runs = gh("run", "list", "--repo", REPO, "--limit", "120",
+              "--json", "name,conclusion,createdAt")
+    if runs is None:
+        return Result("T6", "routine liveness", "UNKNOWN",
+                      "could not query workflow runs")
+    routine = [r for r in runs
+               if str(r.get("name", "")).startswith("autonomy-")
+               and r.get("name") != "autonomy-event-dispatch"]
+    if not routine:
+        return Result("T6", "routine liveness", "UNKNOWN",
+                      "no autonomy-* runs in the queried window")
+    cutoff = _now() - dt.timedelta(hours=T6_LIVENESS_HOURS)
+    recent = [r for r in routine if (_parse(r.get("createdAt", "")) or _now()) >= cutoff]
+    ok = [r for r in recent if r.get("conclusion") == "success"]
+    last_ok = next((r for r in routine if r.get("conclusion") == "success"), None)
+    since = None
+    if last_ok:
+        t = _parse(last_ok.get("createdAt", ""))
+        if t:
+            since = round((_now() - t).total_seconds() / 3600, 1)
+    if ok:
+        return Result("T6", "routine liveness", "ok",
+                      f"{len(ok)} successful routine run(s) in the last {T6_LIVENESS_HOURS}h",
+                      {"recent_runs": len(recent), "successes": len(ok)})
+    return Result(
+        "T6", "routine liveness", "FIRED",
+        f"no successful routine run in {T6_LIVENESS_HOURS}h"
+        + (f"; last success {since}h ago" if since is not None else "; none found in window")
+        + f"; {len(recent)} run(s) attempted and all failed",
+        {"recent_runs": len(recent), "successes": 0, "hours_since_last_success": since})
+
+
+# ── T1: red team collapsed into approval ───────────────────────────
+
+def t1_demotions() -> Result:
+    prs = gh("pr", "list", "--repo", REPO, "--state", "merged", "--limit", "400",
+             "--json", "number,labels")
+    if prs is None:
+        return Result("T1", "demotion machinery", "UNKNOWN", "could not query merged PRs")
+    def has(pr, label):
+        return any(l.get("name") == label for l in pr.get("labels", []))
+    agent = [p for p in prs if has(p, "agent-pr")]
+    corrections = [p for p in agent if has(p, "demotion") or has(p, "withdrawn")]
+    if len(agent) < T1_MIN_RESULT_PRS:
+        return Result("T1", "demotion machinery", "ok",
+                      f"{len(agent)} merged agent PRs — below the {T1_MIN_RESULT_PRS} "
+                      "threshold at which this tripwire becomes evaluable",
+                      {"agent_prs": len(agent), "corrections": len(corrections)})
+    if corrections:
+        return Result("T1", "demotion machinery", "ok",
+                      f"{len(corrections)} demotion/withdrawal PR(s) across "
+                      f"{len(agent)} merged agent PRs",
+                      {"agent_prs": len(agent), "corrections": len(corrections)})
+    return Result("T1", "demotion machinery", "FIRED",
+                  f"zero demotions or withdrawals across {len(agent)} merged agent PRs — "
+                  "the red team has likely collapsed into approval",
+                  {"agent_prs": len(agent), "corrections": 0})
+
+
+# ── T3: sycophancy / rubber-stamp drift ────────────────────────────
+
+VERDICT_RE = re.compile(r"<!--\s*quorum:verdict\s+(accept|revise|reject)\b")
+
+
+def t3_accept_rate() -> Result:
+    prs = gh("pr", "list", "--repo", REPO, "--state", "all", "--limit", "40",
+             "--json", "number,labels")
+    if prs is None:
+        return Result("T3", "quorum accept rate", "UNKNOWN", "could not query PRs")
+    agent = [p for p in prs
+             if any(l.get("name") == "agent-pr" for l in p.get("labels", []))]
+    verdicts: list[str] = []
+    for pr in agent:
+        if len(verdicts) >= T3_WINDOW:
+            break
+        comments = gh("api", f"repos/{REPO}/issues/{pr['number']}/comments",
+                      "--jq", "[.[].body]", default=[])
+        for body in comments or []:
+            m = VERDICT_RE.search(str(body))
+            if m:
+                verdicts.append(m.group(1))
+    if len(verdicts) < T3_WINDOW:
+        return Result("T3", "quorum accept rate", "ok",
+                      f"only {len(verdicts)} verdict(s) found — below the "
+                      f"{T3_WINDOW}-verdict window at which this becomes evaluable",
+                      {"verdicts": len(verdicts)})
+    window = verdicts[:T3_WINDOW]
+    rate = window.count("accept") / len(window)
+    state = "FIRED" if rate > T3_ACCEPT_RATE_MAX else "ok"
+    return Result("T3", "quorum accept rate", state,
+                  f"accept rate {rate:.0%} over the trailing {len(window)} verdicts"
+                  + (" — above the 95% sycophancy threshold" if state == "FIRED" else ""),
+                  {"accept_rate": round(rate, 3), "window": len(window)})
+
+
+# ── T5: instrumentation blindness ──────────────────────────────────
+
+def t5_metrics() -> Result:
+    runs = gh("run", "list", "--repo", REPO, "--workflow", "metrics.yml",
+              "--limit", "6", "--json", "conclusion,createdAt")
+    if runs is None:
+        return Result("T5", "metrics instrumentation", "UNKNOWN",
+                      "could not query metrics runs")
+    if len(runs) < 2:
+        return Result("T5", "metrics instrumentation", "ok",
+                      f"only {len(runs)} metrics run(s) on record")
+    last_two = [r.get("conclusion") for r in runs[:2]]
+    if all(c != "success" for c in last_two):
+        return Result("T5", "metrics instrumentation", "FIRED",
+                      f"two consecutive metrics runs did not succeed: {last_two} — "
+                      "the experiment must not run uninstrumented",
+                      {"last_two": last_two})
+    return Result("T5", "metrics instrumentation", "ok",
+                  f"most recent metrics runs: {last_two}", {"last_two": last_two})
+
+
+# ── T2, T4: not mechanically decidable here ────────────────────────
+
+def t2_citations() -> Result:
+    return Result(
+        "T2", "citation integrity", "MANUAL",
+        "Not mechanically decidable. verify-citations checks existence only, and "
+        "claim-support is diff-scoped, so neither detects a real paper attached to "
+        "a claim it does not support — the defect class that put `geroch` and "
+        "`thm:exotic` on main from March to July 2026. Requires an adversarial "
+        "content pass. Track via the claim graph's L6 lint, which flags "
+        "load-bearing citations verified by abstract only, expired, or unrecorded.")
+
+
+def t4_drift() -> Result:
+    prs = gh("pr", "list", "--repo", REPO, "--state", "merged", "--limit", "200",
+             "--json", "number,labels,mergedAt")
+    if prs is None:
+        return Result("T4", "topic drift", "UNKNOWN", "could not query merged PRs")
+    cutoff = _now() - dt.timedelta(days=T4_WINDOW_DAYS)
+    recent = [p for p in prs
+              if (_parse(p.get("mergedAt") or "") or dt.datetime.min.replace(
+                  tzinfo=dt.timezone.utc)) >= cutoff
+              and any(l.get("name") == "agent-pr" for l in p.get("labels", []))]
+    return Result(
+        "T4", "topic drift", "MANUAL",
+        f"{len(recent)} agent PRs merged in the trailing {T4_WINDOW_DAYS} days. "
+        "Attributing each to an OBJECTIVES milestone requires reading PR bodies "
+        "against milestone IDs and is not mechanised here. Note the redesign "
+        "replaces OBJECTIVES-as-closure-conditions (see docs/CONSOLIDATION.md "
+        "step 4), which will change what this tripwire should measure.",
+        {"agent_prs_in_window": len(recent)})
+
+
+ALL = [t6_liveness, t1_demotions, t3_accept_rate, t5_metrics, t2_citations, t4_drift]
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Evaluate the EXPERIMENT.md tripwires.")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--exit-nonzero", action="store_true",
+                    help="exit 1 if any tripwire FIRED (for use as a gate)")
+    args = ap.parse_args(argv)
+
+    results = [fn() for fn in ALL]
+    fired = [r for r in results if r.state == "FIRED"]
+    unknown = [r for r in results if r.state == "UNKNOWN"]
+
+    if args.json:
+        print(json.dumps({"fired": [r.code for r in fired],
+                          "results": [r.as_dict() for r in results]}, indent=2))
+    else:
+        for r in results:
+            mark = {"FIRED": "FIRED ", "ok": "ok    ", "UNKNOWN": "UNKNOWN", "MANUAL": "manual"}[r.state]
+            print(f"{mark} {r.code}  {r.name}")
+            for line in (r.detail or "").split(". "):
+                if line.strip():
+                    print(f"         {line.strip().rstrip('.')}.")
+        print()
+        if fired:
+            print(f"{len(fired)} tripwire(s) FIRED: {', '.join(r.code for r in fired)}")
+            print("Per EXPERIMENT.md, a fired tripwire applies `needs-human` and halts the")
+            print("affected thread. `needs-human` is a halt, not a suggestion, and only the")
+            print("experimenter removes it. This tool does not apply labels — surfacing is")
+            print("mechanical, halting is a decision.")
+        else:
+            print("No tripwires fired.")
+        if unknown:
+            print(f"{len(unknown)} could not be evaluated: {', '.join(r.code for r in unknown)}"
+                  " — treat as unknown, not as passing.")
+
+    return 1 if (args.exit_nonzero and fired) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Consolidation **step 5**, plus the `generator.md` rewrite two cycles now justify. Contains a workflow file, so it needs an admin merge.

## The tripwires were never actually evaluated

`EXPERIMENT.md` calls T1–T5 *"the only in-run safety net"* (Known design risk #3). They were prose. `metrics.yml` said "the governor reads these files; tripwires T1–T5 are evaluated against them" — and **the governor is a routine that runs weekly and dies in exactly the failure modes they exist to catch.** Flagged as `deferred (minor)` on 2026-06-09; still the load-bearing gap when the fleet went dark for eleven days behind green dashboards.

`tools/tripwires.py` computes **T1, T3, T5 and T6** directly from the GitHub API — deliberately *not* from the `metrics/` snapshots, so the evaluator doesn't inherit the blind spot it exists to catch. T2 and T4 report as requiring judgment. An unevaluable tripwire reports `UNKNOWN`, never `ok`.

**First run against live state:**

```
FIRED  T6  routine liveness    no successful routine run in 48h; 9 attempted, all failed
ok     T1  demotion machinery  5 demotion/withdrawal PRs across 28 merged agent PRs
ok     T3  quorum accept rate  55% over the trailing 20 verdicts
ok     T5  metrics             ['success', 'success']
manual T2  citation integrity  not mechanically decidable — see below
manual T4  topic drift         8 agent PRs in window; milestone attribution not mechanised
```

Two things there are worth more than the tool:

**T6 fires correctly on the real outage.** It is also the *only* tripwire that fires on the absence of work rather than on its content — which is precisely why every other one stayed silent for eleven days. Every pre-registered metric is a ratio over merged artifacts, and ratios go stale rather than alarming when production stops.

**T3 = 55% is a number nobody had.** The day-45 audit flagged quorum accept rate as uncomputable. It's direct evidence the quorum was *not* rubber-stamping — a real datapoint on the experiment's own null hypothesis.

**T6 is not pre-registered**, and the tool says so wherever it reports it, so the record stays honest about which safety nets were designed in advance and which followed a failure.

## steward

The routine whose subject is **the machine, not the physics**. It dispatches blind audits without performing them (a routine with full repo context structurally cannot audit blind), and classifies failures as **transient / terminal-until-changed / genuine** — because the runner defers both identically, which is exactly why 51 identical hard failures looked no different from 51 transient ones in the run list.

**Honest limitation, recorded in the workflow file itself:** this caller shares the Copilot credential path with every other routine, so it goes down with them. *A watchdog inside the system it watches cannot report its own death.* `tools/tripwires.py` is written to run from anywhere with a GitHub token; wiring it to a workflow off that path is the remaining piece, and it's tracked.

## generator.md rewritten

It said **"scored on survival rate, never volume."** That was wrong.

Two cycles: **10 speculations, 10 deaths, ~13 substantive findings anyway** — every one from the *investigation* a speculation provoked, four of them defects in already-merged content (a false algebraic step in a Rigorous proof, a dimensionally inconsistent formula in an audit-CONFIRMED claim, a "positive result" that was a tautology).

So a speculation is a **probe that directs adversarial attention at load-bearing claims**, not a lottery ticket. What follows concretely, and is now in the file:

- Aim at what is load-bearing — many dependents, Rigorous, or audit-confirmed — **even when more likely to be wrong**
- Prefer **computable** falsifiers over arguable ones; cycle 2's were mostly calculable and produced sharper results than cycle 1's
- Don't hedge toward survival; a specific false claim beats a vague surviving one
- **A speculation that dies having exposed nothing is the real failure** — not one that dies loudly
- Read the tombstones first: `defense_findings` is frequently a better lead than the speculation was

One cycle wasn't enough to justify this. Two is.

140 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrkgtnpXdLDJTvxqbg6hg6