### PR TITLE
Run the tripwires off the fleet's credential path (closes step 5)

### DIFF
--- a/.github/workflows/autonomy-steward.yml
+++ b/.github/workflows/autonomy-steward.yml
@@ -17,12 +17,11 @@ name: autonomy-steward
 # That is a real limitation and not an oversight -- a watchdog inside the system
 # it watches cannot report its own death.
 #
-# The independent backstop is `tools/tripwires.py` run from anywhere with a
-# GitHub token: it queries the API directly rather than reading metrics/
-# snapshots, precisely so it does not inherit the blind spot it exists to catch.
-# Wiring it into a workflow that does NOT depend on the Copilot path -- the
-# metrics.yml credential, or a plain scheduled job -- is the remaining step, and
-# is tracked in docs/CONSOLIDATION.md step 5.
+# The independent backstop is `.github/workflows/tripwires.yml`, which runs the
+# same evaluation every six hours on the default GITHUB_TOKEN -- no PAT, no
+# Copilot licence, no quota -- and therefore cannot be taken down by anything
+# that takes this job down. That workflow is the authoritative liveness signal;
+# this routine is what acts on it.
 
 on:
   schedule:

--- a/.github/workflows/tripwires.yml
+++ b/.github/workflows/tripwires.yml
@@ -1,0 +1,107 @@
+# tripwires — mechanical evaluation of the EXPERIMENT.md tripwires, on a
+# credential path independent of the routine fleet.
+#
+# WHY THIS IS SEPARATE FROM autonomy-steward.yml.
+#
+# The steward routine also runs this evaluation, but it executes through
+# autonomy-routine.yml on COPILOT_TASK_API_PAT — the same credential every
+# routine uses. So the steward goes down with the fleet: a watchdog inside the
+# system it watches cannot report its own death. That is exactly the failure
+# that went unnoticed for eleven days in July 2026, when 51 consecutive routine
+# runs failed on quota exhaustion while metrics.yml and digest.yml stayed green
+# because neither touches that path.
+#
+# This job uses only the default GITHUB_TOKEN. It needs no PAT, no Copilot
+# licence, and no quota. It cannot be taken down by anything that takes the
+# fleet down, which is the entire point.
+#
+# It also fails loudly on a fired tripwire rather than reporting quietly, so
+# GitHub's own workflow-failure notification is a second, independent alert path
+# that does not depend on SMTP being configured.
+
+name: tripwires
+
+on:
+  schedule:
+    # Every six hours. T6's window is 48h, so this catches a dead fleet well
+    # inside it without polling hard enough to matter.
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read          # T6 and T5 read workflow-run history
+  pull-requests: read    # T1 and T4 read merged PR labels
+  issues: read           # T3 reads quorum verdict markers in PR comments
+
+jobs:
+  evaluate:
+    name: evaluate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # tripwires.py is stdlib-only by design, matching verify_citations.py and
+      # claim_graph.py, so there is nothing to install.
+      - name: Evaluate tripwires
+        id: eval
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set +e
+          python tools/tripwires.py | tee /tmp/tripwires.txt
+          python tools/tripwires.py --json > /tmp/tripwires.json
+          FIRED=$(python -c "import json;print(','.join(json.load(open('/tmp/tripwires.json'))['fired']))")
+          echo "fired=$FIRED" >> "$GITHUB_OUTPUT"
+          echo "Fired: ${FIRED:-none}"
+
+      - name: Report to job summary
+        if: always()
+        run: |
+          {
+            echo "## Tripwires"
+            echo
+            echo '```'
+            cat /tmp/tripwires.txt 2>/dev/null || echo "(evaluation produced no output)"
+            echo '```'
+            echo
+            echo "Evaluated on the default \`GITHUB_TOKEN\`, deliberately independent of"
+            echo "the routine fleet's credential path — see this workflow's header."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Degrades gracefully: send_email.py exits quietly when SMTP is unset.
+      - name: Alert on a fired tripwire
+        if: steps.eval.outputs.fired != ''
+        env:
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          MAIL_TO: ${{ vars.ALERT_EMAIL }}
+          MAIL_SUBJECT: "[self-consistency] tripwire fired: ${{ steps.eval.outputs.fired }}"
+        run: |
+          {
+            echo "One or more EXPERIMENT.md tripwires fired."
+            echo
+            cat /tmp/tripwires.txt
+            echo
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo "A fired tripwire applies needs-human and halts the affected thread."
+            echo "needs-human is a halt, not a suggestion, and only the experimenter"
+            echo "removes it. This job does not apply labels -- surfacing is mechanical,"
+            echo "halting is a decision."
+          } > /tmp/alert.txt
+          python3 scripts/send_email.py < /tmp/alert.txt
+
+      # Deliberately last: the summary and the alert must both run first. Failing
+      # here makes the run red in the Actions tab, which is a notification path
+      # that works even with SMTP unconfigured.
+      - name: Fail if any tripwire fired
+        if: steps.eval.outputs.fired != ''
+        run: |
+          echo "::error::Tripwire(s) fired: ${{ steps.eval.outputs.fired }}"
+          exit 1

--- a/automation/routines/steward.md
+++ b/automation/routines/steward.md
@@ -29,6 +29,12 @@ no claims.
 `tools/tripwires.py` evaluates T1, T3, T5 and T6 mechanically and reports T2 and
 T4 as requiring judgment. Run it every time.
 
+**It also runs without you**, every six hours, in `.github/workflows/tripwires.yml`
+on the default `GITHUB_TOKEN` — no PAT, no Copilot licence, no quota. That job is
+the one that survives when you do not: you execute on the same credential path as
+every other routine, so you go down with the fleet. Treat that workflow as the
+authoritative liveness signal and yourself as the thing that acts on it.
+
 **Why it is a tool and not your own reasoning:** the pre-registration calls the
 tripwires "the only in-run safety net," and until 2026-07-25 they were prose
 evaluated by the governor — a routine that runs weekly and dies in exactly the

--- a/docs/CONSOLIDATION.md
+++ b/docs/CONSOLIDATION.md
@@ -12,8 +12,8 @@ eight to ten against a design that called for five.
 
 | | |
 |---|---|
-| Routine definitions | **10** |
-| With a scheduled caller | 8 → **10** once this PR merges |
+| Routine definitions | **11** (steward added) |
+| With a scheduled caller | **11** |
 | Actually running | **0** — fleet dark on Copilot quota since 2026-07-14 |
 | Claims in graph | 37 (27 live, 10 dead) |
 | Tier distribution | 17 rigorous, 9 sketch, **0 conjecture**, 1 speculation |
@@ -93,7 +93,7 @@ checked, first step named."
 *Blocked because:* cutting `scout` and `governor` removes the only thing
 feeding the `worker` until step 2 lands.
 
-### Step 5 — build `steward` · DONE (partially)
+### Step 5 — build `steward` · DONE
 
 Liveness, quota headroom, failing-run triage, doc drift; dispatches blind audits
 without performing them (a routine with full repo context cannot audit blind).
@@ -116,11 +116,18 @@ number nobody had: **T3 accept rate is 55%** over the trailing 20 verdicts —
 direct evidence the quorum was not rubber-stamping, which the day-45 audit could
 not compute.
 
-**Still outstanding:** the steward's caller shares the Copilot credential path
-with every other routine, so it goes down with them. A watchdog inside the
-system it watches cannot report its own death. `tools/tripwires.py` is written
-to run from anywhere with a GitHub token; wiring it to a workflow that does *not*
-depend on that path is the remaining piece.
+**Closed 2026-07-25.** `.github/workflows/tripwires.yml` runs the same evaluation
+every six hours on the default `GITHUB_TOKEN` — no PAT, no Copilot licence, no
+quota — so it cannot be taken down by anything that takes the fleet down. It
+alerts by email on a fired tripwire and *also* fails the run, so GitHub's own
+workflow-failure notification is a second alert path that works even with SMTP
+unconfigured.
+
+The steward routine still runs the same check and still goes down with the fleet;
+that is now correct division of labour rather than a gap. The workflow is the
+liveness signal, the routine is what acts on it.
+
+Step 5 is complete.
 
 ## What to watch
 

--- a/tools/tripwires.py
+++ b/tools/tripwires.py
@@ -32,11 +32,14 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import os
 import re
 import subprocess
 import sys
 
-REPO = "willregelmann/physagent"
+# Read from the environment so this runs correctly in CI and from a clone
+# without editing. The fallback is the repository this tool was written for.
+REPO = os.environ.get("GITHUB_REPOSITORY") or "willregelmann/physagent"
 
 # EXPERIMENT.md §Tripwires. T6 is not pre-registered; it was added after the
 # 2026-07-14 outage, and is labelled as such wherever it is reported.


### PR DESCRIPTION
Closes the caveat I shipped with the steward: **a watchdog inside the system it watches cannot report its own death.**

## The problem

The steward executes through `autonomy-routine.yml` on `COPILOT_TASK_API_PAT` — the same credential every routine uses. So it goes down with the fleet.

That is exactly the failure that went unnoticed for eleven days in July 2026: **51 consecutive routine runs failed on quota exhaustion** while `metrics.yml` and `digest.yml` stayed green, because neither touches that path. A steward on the Copilot path would have been the 52nd failure, not the alarm.

## The fix

`tripwires.yml` uses **only the default `GITHUB_TOKEN`** — no PAT, no Copilot licence, no quota. It cannot be taken down by anything that takes the fleet down, which is the entire point.

| | |
|---|---|
| Schedule | every 6h — T6's window is 48h, so a dead fleet is caught well inside it |
| Permissions | `actions:read` (T5, T6), `pull-requests:read` (T1, T4), `issues:read` (T3's verdict markers) — the minimum the checks need |
| Dependencies | none; `tripwires.py` is stdlib-only, matching `verify_citations.py` and `claim_graph.py` |

## Two independent alert paths, deliberately

It **emails** on a fired tripwire, and it **also fails the run** — so GitHub's own workflow-failure notification reaches you even with SMTP unconfigured. The failure step runs last so the summary and the email are both produced first. The mailer already degrades quietly when unset, matching `breakthrough-alert.yml`.

An alert that depends on one notification channel being configured is how you get another eleven quiet days.

## Division of labour, now explicit

The steward routine still runs the same evaluation and still dies with the fleet. That's now **correct division of labour rather than a gap**, and both files say so: **the workflow is the authoritative liveness signal; the routine is what acts on it.**

Also in here: `tripwires.py` reads the repository from `GITHUB_REPOSITORY` rather than a hardcoded constant, so it's correct in CI and usable from any clone.

## Verified

Local run against live state still fires **T6** correctly (the fleet is genuinely down), and reports T1/T3/T5 ok — including the **T3 accept rate of 55%** that the day-45 audit listed as uncomputable.

140 tests pass. **Consolidation step 5 is complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrkgtnpXdLDJTvxqbg6hg6