### PR TITLE
Write the Lean build result back into the claim graph

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -34,7 +34,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write        # the scheduled run writes the build result back
+  pull-requests: write   # ... via a branch and PR, matching metrics.yml
 
 jobs:
   build:
@@ -150,3 +151,51 @@ jobs:
             echo "updated to today with \`result: pass\`. Until that write-back is"
             echo "wired, lint L10 continues to fire and mechanical coverage reads 0."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # WRITE-BACK, scheduled runs only.
+      #
+      # Without this the graph never learns the build happened: L10 keeps firing
+      # and mechanical coverage keeps reading zero while CI is green. The check
+      # runs, the record does not know -- the same shape of gap as a machine
+      # check nobody re-runs, one level up.
+      #
+      # Not on pull requests: a PR should not mutate the graph as a side effect
+      # of being tested.
+      #
+      # Branch -> PR -> auto-merge, matching metrics.yml. `record-build` is
+      # idempotent and reports what it changed, so an unchanged value opens no
+      # pull request and the weekly run is silent when there is nothing to say.
+      - name: Record the build result in the claim graph
+        if: github.event_name == 'schedule' && success()
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          CHANGED=$(python tools/claim_graph.py record-build \
+            --program co-emergence --result pass \
+            | python -c "import json,sys; print(len(json.load(sys.stdin)['changed']))")
+          if [ "$CHANGED" = "0" ]; then
+            echo "Build record already current; nothing to write."
+            exit 0
+          fi
+
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="lean-build-record-$DATE"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add programs/*/claims/
+          git commit -m "Record lean build result ($DATE)
+
+          Written by lean.yml after a green build: lake build succeeded, no
+          'sorry' in the output, and every declaration named by a formal node
+          verified against Mathlib's standard axioms. Updates formal.last_built
+          so the graph records a machine check rather than an assertion."
+          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$BRANCH"
+          PR_URL=$(gh pr create --repo "$REPO" --head "$BRANCH" \
+            --title "Record lean build result ($DATE)" \
+            --body "Automated write-back from lean.yml. Not an agent research PR; quorum-exempt by design. Updates \`formal.last_built\` on formal claim nodes after a verified build." \
+            2>/dev/null || gh pr view "$BRANCH" --repo "$REPO" --json url --jq .url)
+          gh pr merge --repo "$REPO" --auto --squash "$PR_URL" || true
+          echo "Opened $PR_URL"

--- a/programs/co-emergence/claims/lean-purity-decrease.md
+++ b/programs/co-emergence/claims/lean-purity-decrease.md
@@ -42,13 +42,16 @@ provenance: {born: 2026-07-05, born_by: worker}
 Part (a) of the entropy excess, formalized in full: purity decrease for all
 ranks, via Fact 3 and the entrywise modulus bound.
 
-**`last_built` is deliberately absent.** No CI job in this repository runs
-`lake build`, and none ever has - `grep -rln 'lean\|lake' .github/workflows/`
-returns nothing. The `#print axioms` audit recorded in the paper's
-`rem:lean_entropy_excess` is a prose assertion about a machine check that no
-machine has re-run since it was written. Lint L10 fires on this node and should
-keep firing until the CI job exists. That is the correct state of the record,
-not a bookkeeping oversight.
+**`last_built` is absent until CI writes it.** When this node was created there
+was no job running `lake build` at all: the `#print axioms` audit recorded in the
+paper's `rem:lean_entropy_excess` was a prose assertion about a machine check no
+machine had re-run since it was written.
+
+`lean.yml` now exists, builds against a pinned toolchain, asserts no `sorry`, and
+verifies the axiom set against declarations generated from this graph. Its
+scheduled run writes the result back here via `claim_graph.py record-build`, so
+this field records something a machine actually did rather than something a
+human asserted. Until that run lands, L10 fires on this node - correctly.
 
 `bridge.reviewed` is likewise null: the formal-to-informal correspondence has
 never been adversarially reviewed as such.

--- a/programs/co-emergence/claims/lean-rank2-entropy-excess.md
+++ b/programs/co-emergence/claims/lean-rank2-entropy-excess.md
@@ -60,3 +60,10 @@ Recorded for the record: the general-rank entropy excess is **not** formalized
 because it is **false**, and was retracted. That retraction came out of an
 attempted formalization - the highest-value thing Lean has done in this
 repository, and it was a killing, not a verification.
+
+**`last_built` is absent until CI writes it.** `lean.yml`'s scheduled run
+populates this field via `claim_graph.py record-build`, so it records a build a
+machine performed rather than an assertion a human made. L10 fires until then,
+correctly. Note that a passing build would not change this node's accounting
+anyway: `discharges` is empty, so its mechanical coverage contribution is zero
+whether or not the build is green.

--- a/tools/claim_graph.py
+++ b/tools/claim_graph.py
@@ -847,6 +847,50 @@ def mechanical_coverage(g: Graph, claim_id: str) -> dict:
     }
 
 
+def record_build(program: str, result: str, date: str,
+                 root: str = REPO_ROOT) -> list[str]:
+    """Write a build result into each formal node's `formal.last_built`.
+
+    CI verifies the Lean development; this is how the graph learns that it did.
+    Without it L10 fires and mechanical coverage reads zero even while the build
+    is green — the check runs but the record does not know, which is the same
+    class of gap as a machine check nobody re-runs.
+
+    Edits the frontmatter line-wise rather than round-tripping the parser, which
+    would reflow every file it touched. Idempotent: returns the ids actually
+    changed, so a caller can skip opening a no-op pull request.
+    """
+    changed = []
+    entry = f"  last_built: {{at: {date}, by: ci, result: {result}}}"
+    pattern = os.path.join(root, "programs", program, "claims", "*.md")
+    for path in sorted(glob.glob(pattern)):
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().split("\n")
+        try:
+            start = next(i for i, L in enumerate(lines) if L.rstrip() == "formal:")
+        except StopIteration:
+            continue                                   # not a formal node
+        end = start + 1
+        while end < len(lines) and (lines[end].startswith("  ") or not lines[end].strip()):
+            end += 1
+        block = lines[start + 1:end]
+        existing = next((i for i, L in enumerate(block)
+                         if L.startswith("  last_built:")), None)
+        if existing is not None:
+            if block[existing].rstrip() == entry:
+                continue                               # already current
+            block[existing] = entry
+        else:
+            while block and not block[-1].strip():      # keep trailing blanks last
+                block.pop()
+            block.append(entry)
+        lines[start + 1:end] = block
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+        changed.append(os.path.splitext(os.path.basename(path))[0])
+    return changed
+
+
 def stats(g: Graph) -> dict:
     live = [c for c in g.claims if c.status == "live"]
     dist = {t: sum(1 for c in live if c.tier == t) for t in TIERS}
@@ -959,6 +1003,14 @@ def _cmd_formal(args) -> int:
     return 0
 
 
+def _cmd_record_build(args) -> int:
+    date = args.date or _dt.date.today().isoformat()
+    changed = record_build(args.program, args.result, date)
+    print(json.dumps({"program": args.program, "result": args.result,
+                      "date": date, "changed": changed}, indent=2))
+    return 0
+
+
 def _cmd_stats(args) -> int:
     g, _ = Graph.load()
     print(json.dumps(stats(g), indent=2))
@@ -997,6 +1049,13 @@ def main(argv=None) -> int:
     p = sub.add_parser("formal", help="emit formal (Lean) nodes as JSON for CI")
     p.add_argument("--program", help="restrict to one program")
     p.set_defaults(fn=_cmd_formal)
+
+    p = sub.add_parser("record-build",
+                       help="write a CI build result into formal nodes' last_built")
+    p.add_argument("--program", required=True)
+    p.add_argument("--result", required=True, choices=["pass", "fail"])
+    p.add_argument("--date", help="ISO date; defaults to today")
+    p.set_defaults(fn=_cmd_record_build)
 
     p = sub.add_parser("stats", help="graph-level counts")
     p.set_defaults(fn=_cmd_stats)

--- a/tools/tests/test_claim_graph.py
+++ b/tools/tests/test_claim_graph.py
@@ -617,6 +617,65 @@ novelty: {status: novel}
     assert "E016" in codes(validate_schema(Graph([claim(src, "c")])))
 
 
+# ── record-build ───────────────────────────────────────────────────
+
+
+def test_record_build_writes_inserts_and_is_idempotent(tmp_path):
+    """CI verifies the Lean development; this is how the graph learns it did.
+    Without the write-back, L10 fires and mechanical coverage reads zero while
+    the build is green -- the check runs but the record does not know."""
+    import claim_graph
+    d = tmp_path / "programs" / "p" / "claims"
+    d.mkdir(parents=True)
+    (d / "lean-thing.md").write_text(
+        "---\n"
+        "id: lean-thing\n"
+        "program: p\n"
+        "kind: formal\n"
+        "tier: rigorous\n"
+        "status: live\n"
+        "statement: s\n"
+        "formal:\n"
+        "  decl: Foo.bar\n"
+        "  sorry_free: true\n"
+        "discharges: []\n"
+        "---\n\nbody\n")
+
+    # inserts when absent
+    changed = claim_graph.record_build("p", "pass", "2026-07-25", root=str(tmp_path))
+    assert changed == ["lean-thing"]
+    text = (d / "lean-thing.md").read_text()
+    assert "  last_built: {at: 2026-07-25, by: ci, result: pass}" in text
+    # inserted INSIDE the formal block, not after it
+    assert text.index("last_built") < text.index("discharges:")
+
+    # idempotent -- no second PR for an unchanged value
+    assert claim_graph.record_build("p", "pass", "2026-07-25", root=str(tmp_path)) == []
+
+    # updates in place rather than duplicating
+    assert claim_graph.record_build("p", "fail", "2026-07-26", root=str(tmp_path)) == ["lean-thing"]
+    text = (d / "lean-thing.md").read_text()
+    assert text.count("last_built") == 1
+    assert "result: fail" in text
+
+    # still parses, and the round trip preserves the rest of the node
+    data, _ = claim_graph.parse_frontmatter(text)
+    assert data["formal"]["last_built"]["result"] == "fail"
+    assert data["formal"]["decl"] == "Foo.bar"
+    assert data["discharges"] == []
+
+
+def test_record_build_ignores_informal_nodes(tmp_path):
+    import claim_graph
+    d = tmp_path / "programs" / "p" / "claims"
+    d.mkdir(parents=True)
+    (d / "ordinary.md").write_text(
+        "---\nid: ordinary\nprogram: p\ntier: sketch\nstatus: live\n"
+        "statement: s\n---\n\nbody\n")
+    assert claim_graph.record_build("p", "pass", "2026-07-25", root=str(tmp_path)) == []
+    assert "last_built" not in (d / "ordinary.md").read_text()
+
+
 # ── The real graph ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes the gap left when `lean.yml` landed: **the check runs, and the record doesn't know.**

Until now L10 fired and mechanical coverage read 0.0 even with CI green — the same shape of gap as a machine check nobody re-runs, one level up.

## What's new

`claim_graph.py record-build` writes `formal.last_built` into each formal node. Implemented as a **line-wise frontmatter edit** rather than a parser round trip, which would reflow every file it touched.

**Idempotent, and it says what it changed** — so an unchanged value opens no PR and the weekly run is silent when there's nothing to say.

Wired into `lean.yml` on **scheduled runs only** (a PR shouldn't mutate the graph as a side effect of being tested), via branch → PR → auto-merge, matching the pattern `metrics.yml` already uses.

## Verified

With a build recorded: **L10 → 0 errors**, and mechanical coverage of `ce-entropy-excess` goes **0.0 → 1.0**.

## And then I reverted that local run

It would have written `by: ci` into the record while a human produced it — and the entire point of the field is that it records something a *machine* actually did. That's the same provenance sloppiness that produced an unauthorised commit and a commit message describing work it didn't contain, earlier in this session.

**The first real value comes from CI.** L10 fires until then, correctly.

## Also

Both Lean nodes' prose said *"No CI job in this repository runs `lake build`, and none ever has."* True when written, false now. Updated.

## Tests

Six behaviours: insertion when absent; in-place update without duplication; idempotency; placement **inside** the `formal:` block rather than after it; that the round trip preserves the rest of the node; and that informal nodes are left untouched.

142 tests pass.

## Note

Contains a workflow file, so it needs an admin merge. After it lands, a manual `workflow_dispatch` on `lean` won't populate the field — the write-back is gated to `schedule` — so the first real record arrives on the next Monday run. If you'd rather it populate immediately, the gate is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrkgtnpXdLDJTvxqbg6hg6