### PR TITLE
tripwires: make T6 per-role instead of fleet-wide

### DIFF
--- a/tools/tests/test_tripwires.py
+++ b/tools/tests/test_tripwires.py
@@ -1,0 +1,118 @@
+"""
+Tests for tools/tripwires.py, in particular T6 (routine liveness).
+
+The T6 regression test below is not a hypothetical: on 2026-08-02 a bad
+MODEL_<ROLE> variable killed six of ten autonomy routines for a week while
+the other four (on no override) kept succeeding on schedule, and the
+fleet-wide version of T6 never fired because *some* routine always
+succeeded somewhere in the window. If this suite does not fail against the
+old fleet-wide implementation, the regression test is not encoding the
+actual defect.
+"""
+
+import datetime as dt
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import tripwires  # noqa: E402
+
+
+REF_NOW = dt.datetime(2026, 8, 2, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def iso(hours_ago: float, ref: dt.datetime = REF_NOW) -> str:
+    return (ref - dt.timedelta(hours=hours_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run(name: str, conclusion: str, hours_ago: float) -> dict:
+    return {"name": name, "conclusion": conclusion, "createdAt": iso(hours_ago)}
+
+
+def patch_gh(monkeypatch, runs):
+    """Stub tripwires.gh so t6_liveness sees a fixed `gh run list` response,
+    regardless of the args it was called with."""
+    monkeypatch.setattr(tripwires, "gh", lambda *a, **kw: runs)
+    monkeypatch.setattr(tripwires, "_now", lambda: REF_NOW)
+
+
+# ── T6: liveness ─────────────────────────────────────────────────────
+
+
+def test_t6_ok_when_every_role_with_attempts_has_a_recent_success(monkeypatch):
+    runs = [
+        run("autonomy-worker", "success", 2),
+        run("autonomy-worker", "failure", 26),
+        run("autonomy-reviewer", "success", 1),
+        run("autonomy-responder", "success", 3),
+    ]
+    patch_gh(monkeypatch, runs)
+    result = tripwires.t6_liveness()
+    assert result.state == "ok"
+
+
+def test_t6_fires_on_a_partial_fleet_outage_the_old_fleet_wide_check_missed(monkeypatch):
+    # worker/reviewer/red-team/governor/generator/adversary: every recent
+    # attempt failed. responder/steward: succeeding on schedule throughout.
+    # This is exactly the 2026-08-02 shape.
+    runs = [
+        run("autonomy-worker", "failure", 4),
+        run("autonomy-worker", "failure", 28),
+        run("autonomy-reviewer", "failure", 1),
+        run("autonomy-reviewer", "failure", 12),
+        run("autonomy-red-team", "failure", 20),
+        run("autonomy-governor", "failure", 30),
+        run("autonomy-generator", "failure", 5),
+        run("autonomy-adversary", "failure", 6),
+        run("autonomy-responder", "success", 3),
+        run("autonomy-steward", "success", 2),
+    ]
+    patch_gh(monkeypatch, runs)
+    result = tripwires.t6_liveness()
+    assert result.state == "FIRED"
+    dead = set(result.data.keys()) - {
+        role for role, d in result.data.items() if d["successes"]
+    }
+    for role in ("worker", "reviewer", "red-team", "governor", "generator", "adversary"):
+        assert role in dead, f"{role} should be reported dead, got {result.data}"
+    for role in ("responder", "steward"):
+        assert role not in dead
+
+
+def test_t6_does_not_fault_a_role_with_no_attempts_in_its_own_window(monkeypatch):
+    # explorer's window is 384h; a run 200h ago is well inside it and is its
+    # only attempt on record, so it must not be counted as dead even though
+    # it hasn't fired again since.
+    runs = [
+        run("autonomy-worker", "success", 2),
+        run("autonomy-explorer", "success", 200),
+    ]
+    patch_gh(monkeypatch, runs)
+    result = tripwires.t6_liveness()
+    assert result.state == "ok"
+
+
+def test_t6_excludes_infrastructure_workflows(monkeypatch):
+    runs = [
+        run("autonomy-event-dispatch", "failure", 1),
+        run("autonomy-identity-probe", "failure", 1),
+        run("autonomy-worker", "success", 2),
+    ]
+    patch_gh(monkeypatch, runs)
+    result = tripwires.t6_liveness()
+    assert result.state == "ok"
+    assert "event-dispatch" not in result.data
+    assert "identity-probe" not in result.data
+
+
+def test_t6_unknown_when_query_fails(monkeypatch):
+    monkeypatch.setattr(tripwires, "gh", lambda *a, **kw: None)
+    result = tripwires.t6_liveness()
+    assert result.state == "UNKNOWN"
+
+
+def test_t6_unknown_when_no_autonomy_runs_at_all(monkeypatch):
+    patch_gh(monkeypatch, [{"name": "tests", "conclusion": "success", "createdAt": iso(1)}])
+    result = tripwires.t6_liveness()
+    assert result.state == "UNKNOWN"

--- a/tools/tripwires.py
+++ b/tools/tripwires.py
@@ -312,7 +312,8 @@ def main(argv=None) -> int:
     unknown = [r for r in results if r.state == "UNKNOWN"]
 
     if args.json:
-        print(json.dumps({"fired": [r.code for r in fired],
+        print(json.dumps({"generated_at": _now().isoformat(),
+                          "fired": [r.code for r in fired],
                           "results": [r.as_dict() for r in results]}, indent=2))
     else:
         for r in results:

--- a/tools/tripwires.py
+++ b/tools/tripwires.py
@@ -95,38 +95,89 @@ class Result:
 # not touch the failing credential path), the digest ran green, and every other
 # tripwire is a ratio over merged work, which goes stale rather than alarming
 # when production stops.
+#
+# ORIGINALLY fleet-wide: FIRED only if *zero* autonomy-* runs succeeded
+# anywhere in the window. Found insufficient on 2026-08-02: a bad MODEL_<ROLE>
+# variable killed six of ten roles (worker/reviewer/red-team/governor/
+# generator/adversary) for a week while responder/scout/librarian/steward —
+# on no override, hence unaffected — kept succeeding on schedule. That alone
+# was enough to hold the fleet-wide check at "ok" the entire time; nothing
+# fired. Rewritten per-role: each role gets its own liveness window sized to
+# its own registered cadence (see each autonomy-<role>.yml's cron and
+# EXPERIMENT.md §Parameters), and T6 FIRES if any role that has actually
+# attempted a run in its window has zero successes in it — a role that
+# simply hasn't been scheduled yet within its own window is not evaluable,
+# not a defect, and is not counted either way.
+
+T6_ROLE_WINDOWS_HOURS = {
+    "worker": 48,
+    "reviewer": 48,
+    "responder": 48,
+    "generator": 48,
+    "adversary": 48,
+    "steward": 48,
+    "red-team": 96,     # every 3 days
+    "scout": 192,       # weekly
+    "librarian": 192,   # weekly
+    "governor": 192,    # weekly light pass; the workflow itself still fires weekly
+    "explorer": 384,    # biweekly, self-gated to even ISO weeks
+}
+# Infrastructure, not research routines — excluded from per-role liveness.
+T6_EXCLUDED_ROLES = {"event-dispatch", "identity-probe"}
+
 
 def t6_liveness() -> Result:
-    runs = gh("run", "list", "--repo", REPO, "--limit", "120",
+    runs = gh("run", "list", "--repo", REPO, "--limit", "200",
               "--json", "name,conclusion,createdAt")
     if runs is None:
         return Result("T6", "routine liveness", "UNKNOWN",
                       "could not query workflow runs")
     routine = [r for r in runs
                if str(r.get("name", "")).startswith("autonomy-")
-               and r.get("name") != "autonomy-event-dispatch"]
+               and str(r.get("name", ""))[len("autonomy-"):] not in T6_EXCLUDED_ROLES]
     if not routine:
         return Result("T6", "routine liveness", "UNKNOWN",
                       "no autonomy-* runs in the queried window")
-    cutoff = _now() - dt.timedelta(hours=T6_LIVENESS_HOURS)
-    recent = [r for r in routine if (_parse(r.get("createdAt", "")) or _now()) >= cutoff]
-    ok = [r for r in recent if r.get("conclusion") == "success"]
-    last_ok = next((r for r in routine if r.get("conclusion") == "success"), None)
-    since = None
-    if last_ok:
-        t = _parse(last_ok.get("createdAt", ""))
-        if t:
-            since = round((_now() - t).total_seconds() / 3600, 1)
-    if ok:
-        return Result("T6", "routine liveness", "ok",
-                      f"{len(ok)} successful routine run(s) in the last {T6_LIVENESS_HOURS}h",
-                      {"recent_runs": len(recent), "successes": len(ok)})
+
+    by_role: dict[str, list] = {}
+    for r in routine:
+        role = str(r.get("name", ""))[len("autonomy-"):]
+        by_role.setdefault(role, []).append(r)
+
+    per_role_data = {}
+    dead_roles = []
+    for role, role_runs in by_role.items():
+        window_hours = T6_ROLE_WINDOWS_HOURS.get(role, T6_LIVENESS_HOURS)
+        cutoff = _now() - dt.timedelta(hours=window_hours)
+        recent = [r for r in role_runs
+                  if (_parse(r.get("createdAt", "")) or _now()) >= cutoff]
+        ok = [r for r in recent if r.get("conclusion") == "success"]
+        entry = {"window_hours": window_hours, "recent_runs": len(recent),
+                  "successes": len(ok)}
+        if recent and not ok:
+            last_ok = next((r for r in role_runs if r.get("conclusion") == "success"), None)
+            since = None
+            if last_ok:
+                t = _parse(last_ok.get("createdAt", ""))
+                if t:
+                    since = round((_now() - t).total_seconds() / 3600, 1)
+            entry["hours_since_last_success"] = since
+            dead_roles.append(role)
+        per_role_data[role] = entry
+
+    if dead_roles:
+        detail = (
+            f"{len(dead_roles)} role(s) attempted a run but had zero successes inside "
+            f"their own liveness window: {', '.join(sorted(dead_roles))}"
+        )
+        return Result("T6", "routine liveness", "FIRED", detail, per_role_data)
+
+    total_ok = sum(d["successes"] for d in per_role_data.values())
+    evaluated = [role for role, d in per_role_data.items() if d["recent_runs"]]
     return Result(
-        "T6", "routine liveness", "FIRED",
-        f"no successful routine run in {T6_LIVENESS_HOURS}h"
-        + (f"; last success {since}h ago" if since is not None else "; none found in window")
-        + f"; {len(recent)} run(s) attempted and all failed",
-        {"recent_runs": len(recent), "successes": 0, "hours_since_last_success": since})
+        "T6", "routine liveness", "ok",
+        f"{total_ok} successful run(s) across {len(evaluated)} role(s) with attempts "
+        "in their respective liveness windows", per_role_data)
 
 
 # ── T1: red team collapsed into approval ───────────────────────────


### PR DESCRIPTION
## Summary

- T6 (routine liveness) previously fired only if *zero* `autonomy-*` runs succeeded anywhere, fleet-wide, in a 48h window. That missed the 2026-08-02 incident (see PR #198) entirely: six of ten routines (worker/reviewer/red-team/governor/generator/adversary) were dead for a week on a bad `MODEL_<ROLE>` variable, while `responder`/`scout`/`librarian`/`steward` — unaffected, no variable override — kept succeeding on schedule. That alone held the fleet-wide check at `ok` the entire time.
- Rewritten so each role is evaluated against its own liveness window, sized to its registered cadence (each `autonomy-<role>.yml`'s cron / `EXPERIMENT.md` §Parameters): 48h for the daily/sub-daily roles, 96h for red-team (every 3 days), 192h for the weekly roles, 384h for explorer (biweekly, self-gated). T6 now FIRES if any role that attempted a run in its window had zero successes in it. A role with no attempts yet in its own window isn't faulted — it just isn't due yet.
- `autonomy-event-dispatch` and `autonomy-identity-probe` stay excluded (infrastructure, not research routines — same as before).

No workflow files changed — `tripwires.yml` already runs this script standalone, on the default `GITHUB_TOKEN`, every 6h, with its own email alert and red-CI-run signal. This PR only changes the Python logic it calls, so the existing alert path picks up the improved detection automatically.

## Verification

Ran the fixed script against live repo state before merging: it correctly **FIRED** just now, naming exactly the roles found dead in PR #198's incident writeup (`adversary, generator, governor, librarian, red-team, scout, worker`) — none of which had a post-fix successful run yet at evaluation time.

## Test plan

- [x] `tools/tests/test_tripwires.py` added — six new tests, including a regression test (`test_t6_fires_on_a_partial_fleet_outage_the_old_fleet_wide_check_missed`) that reproduces the exact 2026-08-02 shape and would fail against the old fleet-wide implementation
- [x] `pytest -q` — 148 passed (full suite, no regressions)