### PR TITLE
steward: read tripwire state from an issue instead of a sandbox it can't reach

### DIFF
--- a/.github/workflows/tripwires.yml
+++ b/.github/workflows/tripwires.yml
@@ -18,6 +18,15 @@
 # It also fails loudly on a fired tripwire rather than reporting quietly, so
 # GitHub's own workflow-failure notification is a second, independent alert path
 # that does not depend on SMTP being configured.
+#
+# It also posts every run's result to the "Tripwire monitor" issue (below),
+# specifically so `steward` can read it. Found 2026-08-02: the steward routine
+# runs inside a Copilot cloud-agent sandbox whose GitHub credential 403s on
+# `actions/runs` (it has issues/PRs/contents access, not Actions-API access),
+# so it cannot run this same evaluation itself and, correctly, reported every
+# tripwire as UNKNOWN rather than guessing. Posting the JSON to an issue
+# steward can read with the access it already has closes that gap without
+# granting the sandbox any new credential.
 
 name: tripwires
 
@@ -32,7 +41,7 @@ permissions:
   contents: read
   actions: read          # T6 and T5 read workflow-run history
   pull-requests: read    # T1 and T4 read merged PR labels
-  issues: read           # T3 reads quorum verdict markers in PR comments
+  issues: write          # T3 reads quorum verdict markers; also posts the snapshot below
 
 jobs:
   evaluate:
@@ -73,6 +82,26 @@ jobs:
             echo "Evaluated on the default \`GITHUB_TOKEN\`, deliberately independent of"
             echo "the routine fleet's credential path — see this workflow's header."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish snapshot to the Tripwire monitor issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          NUM=$(gh issue list --repo "$REPO" --state open --search 'in:title "Tripwire monitor"' --json number,title \
+            | jq -r '[ .[] | select(.title == "Tripwire monitor") ][0].number // empty')
+          if [ -z "$NUM" ]; then
+            NUM=$(gh issue create --repo "$REPO" --title "Tripwire monitor" --label governance \
+              --body "Mechanical T1/T3/T5/T6 evaluation (T2/T4 report \`manual\`), posted every 6h by \`tripwires.yml\` on the default \`GITHUB_TOKEN\` — independent of the routine fleet's credential path. One comment per run. This is what \`steward\` reads instead of running \`tools/tripwires.py\` itself: its own Copilot cloud-agent sandbox 403s on the Actions API, so it cannot query \`gh run list\` directly (see automation/routines/steward.md). Treat a comment older than ~14h (more than two missed fires) as stale, not as passing." \
+              | grep -oE '[0-9]+$')
+          fi
+          FIRED=$(jq -r '.fired | join(", ")' /tmp/tripwires.json)
+          gh issue comment "$NUM" --repo "$REPO" --body "**$(jq -r .generated_at /tmp/tripwires.json)** — fired: ${FIRED:-none}
+          \`\`\`json
+          $(cat /tmp/tripwires.json)
+          \`\`\`"
 
       # Degrades gracefully: send_email.py exits quietly when SMTP is unset.
       - name: Alert on a fired tripwire

--- a/automation/routines/steward.md
+++ b/automation/routines/steward.md
@@ -19,44 +19,69 @@ no claims.
 
 1. Read `AGENTS.md`, `AUTONOMY.md`, `EXPERIMENT.md` (especially §Tripwires and
    §Kill switch), and `docs/CONSOLIDATION.md`.
-2. `python tools/tripwires.py` — the mechanical tripwire evaluation.
+2. Read the latest comment on the **"Tripwire monitor"** issue (opened by
+   `tripwires.yml`) — the mechanical tripwire evaluation. Do not run
+   `python tools/tripwires.py` yourself; see §1 for why.
 3. `python tools/claim_graph.py lint --warn` — standing defects in the record.
-4. `gh run list --limit 60` — raw run health, which is the signal every
-   content-derived metric misses.
+4. `gh run list --limit 60`, on the chance this session's sandbox has working
+   Actions-API access — it has not, on either checked date (see §1), so expect
+   this to 403 and do not block on it.
 
 ## 1. Tripwires
 
-`tools/tripwires.py` evaluates T1, T3, T5 and T6 mechanically and reports T2 and
-T4 as requiring judgment. Run it every time.
+**Do not run `python tools/tripwires.py` from inside this routine.** Found on
+both 2026-08-01 and 2026-08-02 (issues #196, #197): this routine executes
+inside a Copilot cloud-agent sandbox whose GitHub credential 403s on
+`actions/runs` (it has issues/PRs/contents access, not Actions-API access), so
+the tool's `gh run list`/`gh pr list` calls fail and every mechanically
+evaluable tripwire reports `UNKNOWN` — both runs correctly said so rather than
+guessing, but that means running the tool here can *only* ever produce
+`UNKNOWN`, never real signal. Confirm this is still true on any environment
+change before trusting it again; do not just assume the old finding still
+holds forever.
 
-**It also runs without you**, every six hours, in `.github/workflows/tripwires.yml`
-on the default `GITHUB_TOKEN` — no PAT, no Copilot licence, no quota. That job is
-the one that survives when you do not: you execute on the same credential path as
-every other routine, so you go down with the fleet. Treat that workflow as the
-authoritative liveness signal and yourself as the thing that acts on it.
+**Read the "Tripwire monitor" issue instead.** `tripwires.yml` evaluates T1,
+T3, T5 and T6 (T2 and T4 report `manual`) every six hours on the default
+`GITHUB_TOKEN` — no PAT, no Copilot licence, no quota, so it cannot be taken
+down by anything that takes the fleet down — and posts the JSON result as a
+comment on that issue specifically so you can read it with the access your
+sandbox does have. Read the **latest comment only**. If its `generated_at` is
+more than ~14h old (more than two missed six-hourly fires), treat it as
+**stale** — report `UNKNOWN` due to staleness, the same discipline as an
+unreachable query, never as passing.
 
-**Why it is a tool and not your own reasoning:** the pre-registration calls the
-tripwires "the only in-run safety net," and until 2026-07-25 they were prose
-evaluated by the governor — a routine that runs weekly and dies in exactly the
-failure modes they exist to catch. Your job is to act on the tool's output, not
-to re-derive it.
+**Why it is a tool's output and not your own reasoning:** the pre-registration
+calls the tripwires "the only in-run safety net," and until 2026-07-25 they
+were prose evaluated by the governor — a routine that runs weekly and dies in
+exactly the failure modes they exist to catch. Your job is to act on the
+mechanical result, not to re-derive it, and not to let your own sandbox's
+narrower access silently downgrade what you act on.
 
-For each **FIRED** result:
+For each **FIRED** code in the latest comment:
 
-- Confirm it against the raw evidence before acting. A tripwire firing on bad
-  data is worse than one not firing, because it burns the alarm.
-- If confirmed, apply `needs-human` to the affected thread and stop that thread.
-  **`needs-human` is a halt, not a suggestion, and only the experimenter removes
-  it.** You may apply it; you may never clear it.
+- Confirm it against whatever raw evidence you *can* reach before acting — the
+  per-role data already embedded in the comment's JSON (which roles, which
+  window, how many attempts/successes), plus anything corroborating you can
+  read directly (recent PRs/issues/commits touching the named role's files).
+  You cannot re-run `gh run list` yourself (see above); "confirm before
+  acting" means corroborate from what you have, not repeat the same query. A
+  tripwire firing on bad data is worse than one not firing, because it burns
+  the alarm — but an unconfirmable FIRED is still not the same as a
+  disconfirmed one; when you cannot corroborate either way, say so explicitly
+  and apply `needs-human` anyway rather than silently trusting the comment.
+- If confirmed (or unconfirmable but not disconfirmed), apply `needs-human` to
+  the affected thread and stop that thread. **`needs-human` is a halt, not a
+  suggestion, and only the experimenter removes it.** You may apply it; you
+  may never clear it.
 - Record what fired, the evidence, and what you halted, in your run comment.
 
 For each **UNKNOWN**: treat as unknown, never as passing. Say what could not be
 evaluated and why.
 
-**T6 (routine liveness) is not pre-registered.** It was added after the outage
-above. Say so whenever you report it, so the experiment's record stays honest
-about which of its safety nets were designed in advance and which were added
-after a failure.
+**T6 (routine liveness) is not pre-registered.** It was added after the 2026-07
+outage below. Say so whenever you report it, so the experiment's record stays
+honest about which of its safety nets were designed in advance and which were
+added after a failure.
 
 ## 2. Compute and budget
 
@@ -64,18 +89,27 @@ The substrate is a resource nobody models. The 2026-07-14 outage was quota
 exhaustion — `insufficient premium quota to create assignment (HTTP 412)` — on a
 metered per-seat allowance that is simultaneously the fleet's identity, its
 compute budget, and its availability constraint. `EXPERIMENT.md`'s Budget
-ceiling row is still the placeholder text from registration.
+ceiling row is still the placeholder text from registration. The 2026-08-02
+outage (six of ten roles dead for a week on a bad `MODEL_<ROLE>` variable) was
+a second, distinct terminal-until-changed cause on the same substrate.
 
-Each run: classify recent routine failures by cause. Distinguish
+Each run: classify recent routine failures by cause where you can. Distinguish
 
 - **transient** (5xx, 429, rate limit) — self-heals on the next fire, no action;
 - **terminal-until-changed** (quota, invalid model ID, auth) — will not self-heal
   and must be surfaced immediately;
 - **genuine errors** — everything else.
 
-The distinction matters because the runner retries transient errors and defers
-terminal ones identically, so 51 identical hard failures look the same as 51
-transient ones in the run list. That is what made the outage invisible.
+**This classification needs the actual failure message from a run's log**,
+which — unlike T6's fired/ok state — is not carried in the Tripwire monitor
+issue and is not reachable from this sandbox at all (§1). When T6 fires, you
+can and must act on liveness alone (zero successes in a role's own window is
+sufficient grounds for `needs-human` regardless of cause); you cannot, from
+here, additionally say *which* of the three causes above it was. Say so
+plainly rather than guessing a cause you have no evidence for. The distinction
+still matters for whoever picks up the resulting `needs-human` thread with
+real log access — record what you could and could not determine, don't fill
+the gap with a plausible-sounding guess.
 
 ## 3. Record drift
 

--- a/docs/CONSOLIDATION.md
+++ b/docs/CONSOLIDATION.md
@@ -139,6 +139,26 @@ The steward routine still runs the same check and still goes down with the fleet
 that is now correct division of labour rather than a gap. The workflow is the
 liveness signal, the routine is what acts on it.
 
+**Correction, 2026-08-02:** the paragraph above is half right. The workflow
+*is* the liveness signal, but "the routine is what acts on it" assumed the
+routine could still read that signal by running the same check itself — and
+it cannot. Steward's Copilot cloud-agent sandbox 403s on the Actions API
+(issues/PRs/contents access only), confirmed on both 2026-08-01 and
+2026-08-02 (issues #196, #197): every attempt to run `tools/tripwires.py`
+inside the routine reports T1/T3/T5/T6 as `UNKNOWN`, correctly rather than
+guessing, but that meant the routine had *no working path* to the mechanical
+result at all, not degraded access to it. Compounding this, T6 itself was
+fleet-wide (fired only if *zero* `autonomy-*` runs succeeded anywhere), so a
+six-of-ten-role outage on 2026-08-02 (bad `MODEL_<ROLE>` variable) sat
+undetected by both the routine (couldn't read the signal) and the tripwire
+(wasn't scoped to notice a partial outage) for a week. Fixed same day: T6 is
+now per-role (`tools/tripwires.py`), and `tripwires.yml` posts its JSON result
+to a "Tripwire monitor" issue every six hours specifically so steward can read
+it with the issues-scope access its sandbox does have, instead of re-running a
+query it cannot make. `automation/routines/steward.md` §1 updated accordingly.
+Division of labour is now: the workflow computes *and* publishes; the routine
+reads the publication and decides whether to halt.
+
 Step 5 is complete.
 
 ## What to watch


### PR DESCRIPTION
## Summary

Second half of the 2026-08-02 fix (see #198 for the incident writeup, #199 for T6 going per-role). This closes the detection gap found alongside that incident: `steward` — built specifically to watch for exactly this class of outage — ran clean on both 2026-08-01 and 2026-08-02 (issues #196, #197) but reported every mechanically-evaluable tripwire as `UNKNOWN` both times, because its Copilot cloud-agent sandbox 403s on the Actions API (`gh run list`/`gh pr list`). It has issues/PRs/contents access, not Actions-API access — this isn't a degraded signal, it's no signal at all.

- `tripwires.yml` already runs the full T1/T3/T5/T6 evaluation standalone, every 6h, on the default `GITHUB_TOKEN` — independent of the routine fleet's credential path, so it can't be taken down by anything that takes the fleet down. It now also posts that JSON result as a comment on a new **"Tripwire monitor"** issue (bumping its `issues` permission from `read` to `write`; no PAT needed).
- `steward` can read that issue with the issues-scope access its sandbox already has (it successfully filed issues #194–197 with that same access). `automation/routines/steward.md` §1 and §2 are rewritten to read the issue instead of trying to re-run a query it structurally cannot make, with a staleness rule (a comment older than ~14h, i.e. more than two missed fires, is `UNKNOWN` due to staleness, never treated as passing).
- Honest about what this does *not* fix: root-cause classification of *why* a role is dead (transient vs. terminal-until-changed vs. genuine error) needs the actual failure log, which still isn't reachable from steward's sandbox. Liveness alone (T6) is sufficient to act on (`needs-human`), but steward now says explicitly when it can't determine cause rather than guessing one.
- `docs/CONSOLIDATION.md`'s step-5 log is corrected: it had called "the routine goes down with the fleet, the workflow is the signal" a *closed*, correct division of labour. It wasn't — the routine had no substitute path to the signal at all. Appended a dated correction rather than rewriting the historical entry.

## Dependency

Pairs with #199, which adds the `generated_at` field this change's staleness check reads. Functions either way (a missing field just prints `null` in the issue comment), but ideally merges together with or after #199.

## Why this needs your merge specifically

This touches `.github/workflows/tripwires.yml`. Per `AUTONOMY.md`, gate-workflow files are structurally outside what any routine or interactive session merges through the normal gate stack (the machine account's PAT lacks the `workflow` scope, and — separately — this is the one category of protected-path change the full-autonomy amendment deliberately left as experimenter-authored, admin-merged). I can draft and push it, as I have, but not merge it.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tripwires.yml'))"` — parses without error
- [x] Bash pattern for the issue-comment step (find-or-create issue, embed JSON via `$(cat ...)` in a `--body` string) mirrors `metrics.yml`'s existing, already-working "Metrics dashboard" pattern verbatim
- Not run live (would require an actual Actions run) — recommend a `workflow_dispatch` test run after merge to confirm the "Tripwire monitor" issue is created and populated as expected